### PR TITLE
FOLIO-3564: openjdk image: apt-get upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,12 @@ RUN mvn package
 # final base image
 FROM openjdk:11-jre-slim
 
+# Upgrade to latest patch versions of packages: https://pythonspeed.com/articles/security-updates-in-docker/
+RUN apt-get update \
+ && apt-get upgrade -y \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
 # set deployment directory
 WORKDIR /mod-workflow
 

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>workflow-parent</artifactId>
-    <version>1.1.2</version>
+    <version>1.1.3-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <artifactId>workflow-parent</artifactId>
 
-  <version>1.1.2</version>
+  <version>1.1.3-SNAPSHOT</version>
 
   <name>Workflow Parent</name>
 

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>workflow-parent</artifactId>
-    <version>1.1.2</version>
+    <version>1.1.3-SNAPSHOT</version>
   </parent>
 
   <packaging>jar</packaging>
@@ -130,7 +130,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>workflow-components</artifactId>
-      <version>1.1.2-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
The Dockerfile uses

`FROM openjdk:11-jre-slim`

as base image. Run apt-get upgrade to upgrade vulnerable packages. This will fix these vulnerabilities:

* zlib/zlib1g Out-of-bounds Write https://nvd.nist.gov/vuln/detail/CVE-2022-37434
* gnutls28/libgnutls30 Double Free https://nvd.nist.gov/vuln/detail/CVE-2022-2509