### PR TITLE
FOLIO-3646: Upgrade to spring-module-core 1.1.2 fixing vulns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>spring-module-core</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
   </parent>
 
   <modules>


### PR DESCRIPTION
Upgrade org.folio:spring-module-core from 1.1.1 to 1.1.2.

The spring-module-core upgrade indirectly upgrades jackson-databind from 2.13.2.1 to 2.14.0 fixing Denial of Service (DoS):
https://nvd.nist.gov/vuln/detail/CVE-2022-42004
https://nvd.nist.gov/vuln/detail/CVE-2022-42003

The spring-module-core upgrade indirectly upgrades org.postgresql:postgresql from 42.3.3 to 42.5.0 fixing SQL Injection:
https://nvd.nist.gov/vuln/detail/CVE-2022-31197

The spring-module-core upgrade indirectly upgrades spring-beans from 5.3.19 to 5.3.23 fixing Denial of Service (DoS):
https://nvd.nist.gov/vuln/detail/CVE-2022-22970

The spring-module-core upgrade indirectly upgrades spring-data-rest-webmvc from 3.6.4 to 3.7.5 fixing Information Exposure:
https://nvd.nist.gov/vuln/detail/CVE-2022-31679

The spring-module-core upgrade indirectly upgrades snakeyaml from1.29 to 1.33 fixing Denial of Service (DoS) and Stack-based Buffer Overflow:
https://nvd.nist.gov/vuln/detail/CVE-2022-25857
https://nvd.nist.gov/vuln/detail/CVE-2022-38749
https://nvd.nist.gov/vuln/detail/CVE-2022-38750
https://nvd.nist.gov/vuln/detail/CVE-2022-38751
https://nvd.nist.gov/vuln/detail/CVE-2022-38752
https://nvd.nist.gov/vuln/detail/CVE-2022-41854

The spring-module-core upgrade indirectly upgrades spring-messaging from 5.3.19 to 5.3.23 fixing Denial of Service (DoS):
https://nvd.nist.gov/vuln/detail/CVE-2022-22971

The spring-module-core upgrade indirectly upgrades kotlin-stdlib from 1.3.50 to 1.6.21 fixing Improper Locking and Information Exposure:
https://nvd.nist.gov/vuln/detail/CVE-2022-24329
https://nvd.nist.gov/vuln/detail/CVE-2020-29582

The spring-module-core upgrade indirectly upgrades tomcat-embed-core from 9.0.62 to 9.0.68 fixing HTTP Request Smuggling:
https://nvd.nist.gov/vuln/detail/CVE-2022-42252