### PR TITLE
Bump version of master branch from 1.1.4 to 1.1.5-SNAPSHOT

### DIFF
--- a/components/pom.xml
+++ b/components/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>workflow-parent</artifactId>
-    <version>1.1.4</version>
+    <version>1.1.5-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <artifactId>workflow-parent</artifactId>
 
-  <version>1.1.4</version>
+  <version>1.1.5-SNAPSHOT</version>
 
   <name>Workflow Parent</name>
 

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>workflow-parent</artifactId>
-    <version>1.1.4</version>
+    <version>1.1.5-SNAPSHOT</version>
   </parent>
 
   <packaging>jar</packaging>


### PR DESCRIPTION
After the release of 1.1.4 master must be a SNAPSHOT version.