### PR TITLE
MODWRKFLOW-2: Create DTO/Entity implementations of a the workflow interface.

### DIFF
--- a/components/pom.xml
+++ b/components/pom.xml
@@ -33,6 +33,12 @@
       <artifactId>spring-boot-starter-activemq</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/components/src/main/java/org/folio/rest/workflow/dto/WorkflowDto.java
+++ b/components/src/main/java/org/folio/rest/workflow/dto/WorkflowDto.java
@@ -1,0 +1,16 @@
+package org.folio.rest.workflow.dto;
+
+import org.folio.rest.workflow.model.has.HasDeploymentId;
+import org.folio.rest.workflow.model.has.HasId;
+import org.folio.rest.workflow.model.has.HasInformational;
+import org.folio.rest.workflow.model.has.HasName;
+import org.folio.rest.workflow.model.has.HasNodes;
+import org.folio.rest.workflow.model.has.HasVersionTag;
+import org.folio.rest.workflow.model.has.common.HasWorkflowCommon;
+
+/**
+ * This is a DTO design for providing the entire {@link org.folio.rest.workflow.model.Workflow Workflow} model.
+ */
+public interface WorkflowDto extends HasDeploymentId, HasId, HasInformational, HasName, HasNodes, HasVersionTag, HasWorkflowCommon {
+
+}

--- a/components/src/main/java/org/folio/rest/workflow/dto/WorkflowOperationalDto.java
+++ b/components/src/main/java/org/folio/rest/workflow/dto/WorkflowOperationalDto.java
@@ -1,0 +1,13 @@
+package org.folio.rest.workflow.dto;
+
+import org.folio.rest.workflow.model.has.HasDeploymentId;
+import org.folio.rest.workflow.model.has.HasVersionTag;
+
+/**
+ * This is a DTO designed for operational purposes.
+ *
+ * Examples are starting a {@link org.folio.rest.workflow.model.Workflow Workflow} or getting the {@link org.folio.rest.workflow.model.Workflow Workflow} history.
+ */
+public interface WorkflowOperationalDto extends HasDeploymentId, HasVersionTag {
+
+}

--- a/components/src/main/java/org/folio/rest/workflow/enums/CompressFileContainer.java
+++ b/components/src/main/java/org/folio/rest/workflow/enums/CompressFileContainer.java
@@ -1,4 +1,4 @@
-package org.folio.rest.workflow.model;
+package org.folio.rest.workflow.enums;
 
 public enum CompressFileContainer {
   NONE, TAR

--- a/components/src/main/java/org/folio/rest/workflow/enums/CompressFileFormat.java
+++ b/components/src/main/java/org/folio/rest/workflow/enums/CompressFileFormat.java
@@ -1,4 +1,4 @@
-package org.folio.rest.workflow.model;
+package org.folio.rest.workflow.enums;
 
 public enum CompressFileFormat {
   BZIP2, GZIP, ZIP

--- a/components/src/main/java/org/folio/rest/workflow/enums/DatabaseResultType.java
+++ b/components/src/main/java/org/folio/rest/workflow/enums/DatabaseResultType.java
@@ -1,4 +1,4 @@
-package org.folio.rest.workflow.model;
+package org.folio.rest.workflow.enums;
 
 public enum DatabaseResultType {
   CSV, TSV, JSON

--- a/components/src/main/java/org/folio/rest/workflow/enums/Direction.java
+++ b/components/src/main/java/org/folio/rest/workflow/enums/Direction.java
@@ -1,4 +1,4 @@
-package org.folio.rest.workflow.model;
+package org.folio.rest.workflow.enums;
 
 public enum Direction {
   UNSPECIFIED("Unspecified"),

--- a/components/src/main/java/org/folio/rest/workflow/enums/DirectoryAction.java
+++ b/components/src/main/java/org/folio/rest/workflow/enums/DirectoryAction.java
@@ -1,4 +1,4 @@
-package org.folio.rest.workflow.model;
+package org.folio.rest.workflow.enums;
 
 public enum DirectoryAction {
   READ_NEXT, DELETE_NEXT, LIST, WRITE

--- a/components/src/main/java/org/folio/rest/workflow/enums/FileOp.java
+++ b/components/src/main/java/org/folio/rest/workflow/enums/FileOp.java
@@ -1,4 +1,4 @@
-package org.folio.rest.workflow.model;
+package org.folio.rest.workflow.enums;
 
 public enum FileOp {
   LIST, READ, WRITE, COPY, MOVE, DELETE, LINE_COUNT, READ_LINE, PUSH, POP

--- a/components/src/main/java/org/folio/rest/workflow/enums/ScriptType.java
+++ b/components/src/main/java/org/folio/rest/workflow/enums/ScriptType.java
@@ -1,4 +1,4 @@
-package org.folio.rest.workflow.model;
+package org.folio.rest.workflow.enums;
 
 public enum ScriptType {
   GROOVY("groovy"),

--- a/components/src/main/java/org/folio/rest/workflow/enums/SftpOp.java
+++ b/components/src/main/java/org/folio/rest/workflow/enums/SftpOp.java
@@ -1,0 +1,5 @@
+package org.folio.rest.workflow.enums;
+
+public enum SftpOp {
+  GET, PUT
+}

--- a/components/src/main/java/org/folio/rest/workflow/enums/StartEventType.java
+++ b/components/src/main/java/org/folio/rest/workflow/enums/StartEventType.java
@@ -1,4 +1,4 @@
-package org.folio.rest.workflow.model;
+package org.folio.rest.workflow.enums;
 
 public enum StartEventType {
   MESSAGE_CORRELATION, SCHEDULED, SIGNAL, NONE

--- a/components/src/main/java/org/folio/rest/workflow/enums/SubprocessType.java
+++ b/components/src/main/java/org/folio/rest/workflow/enums/SubprocessType.java
@@ -1,4 +1,4 @@
-package org.folio.rest.workflow.model;
+package org.folio.rest.workflow.enums;
 
 public enum SubprocessType {
   EMBEDDED, TRANSACTION

--- a/components/src/main/java/org/folio/rest/workflow/enums/VariableType.java
+++ b/components/src/main/java/org/folio/rest/workflow/enums/VariableType.java
@@ -1,4 +1,4 @@
-package org.folio.rest.workflow.model;
+package org.folio.rest.workflow.enums;
 
 public enum VariableType {
   PROCESS, LOCAL

--- a/components/src/main/java/org/folio/rest/workflow/model/AbstractGateway.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/AbstractGateway.java
@@ -2,47 +2,38 @@ package org.folio.rest.workflow.model;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.persistence.Column;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.MappedSuperclass;
 import javax.persistence.OneToMany;
 import javax.persistence.OrderColumn;
+import lombok.Getter;
+import lombok.Setter;
 import org.folio.rest.workflow.enums.Direction;
 import org.folio.rest.workflow.model.components.Gateway;
+import org.folio.rest.workflow.model.has.HasNodes;
 
 @MappedSuperclass
-public abstract class AbstractGateway extends Node implements Gateway {
+public abstract class AbstractGateway extends Node implements Gateway, HasNodes {
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   @Enumerated(EnumType.STRING)
   private Direction direction;
 
+  @Getter
+  @Setter
   @OneToMany
   @OrderColumn
   private List<Node> nodes;
 
   AbstractGateway() {
     super();
+
     direction = Direction.UNSPECIFIED;
     nodes = new ArrayList<Node>();
-  }
-
-  public Direction getDirection() {
-    return direction;
-  }
-
-  public void setDirection(Direction direction) {
-    this.direction = direction;
-  }
-
-  public List<Node> getNodes() {
-    return nodes;
-  }
-
-  public void setNodes(List<Node> nodes) {
-    this.nodes = nodes;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/AbstractGateway.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/AbstractGateway.java
@@ -9,7 +9,7 @@ import javax.persistence.Enumerated;
 import javax.persistence.MappedSuperclass;
 import javax.persistence.OneToMany;
 import javax.persistence.OrderColumn;
-
+import org.folio.rest.workflow.enums.Direction;
 import org.folio.rest.workflow.model.components.Gateway;
 
 @MappedSuperclass

--- a/components/src/main/java/org/folio/rest/workflow/model/CompressFileTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/CompressFileTask.java
@@ -9,7 +9,8 @@ import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
-
+import org.folio.rest.workflow.enums.CompressFileContainer;
+import org.folio.rest.workflow.enums.CompressFileFormat;
 import org.folio.rest.workflow.model.components.DelegateTask;
 
 @Entity

--- a/components/src/main/java/org/folio/rest/workflow/model/CompressFileTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/CompressFileTask.java
@@ -2,115 +2,72 @@ package org.folio.rest.workflow.model;
 
 import java.util.HashSet;
 import java.util.Set;
-
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import lombok.Getter;
+import lombok.Setter;
 import org.folio.rest.workflow.enums.CompressFileContainer;
 import org.folio.rest.workflow.enums.CompressFileFormat;
 import org.folio.rest.workflow.model.components.DelegateTask;
+import org.folio.rest.workflow.model.has.HasAsync;
+import org.folio.rest.workflow.model.has.HasInputOutput;
+import org.folio.rest.workflow.model.has.common.HasCompressFileTaskCommon;
 
 @Entity
-public class CompressFileTask extends Node implements DelegateTask {
+public class CompressFileTask extends Node implements DelegateTask, HasAsync, HasCompressFileTaskCommon, HasInputOutput {
 
+  @Getter
+  @Setter
   @ElementCollection
   private Set<EmbeddedVariable> inputVariables;
 
+  @Getter
+  @Setter
   @Embedded
   private EmbeddedVariable outputVariable;
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   private boolean asyncBefore;
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   private boolean asyncAfter;
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   private String source;
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   private String destination;
 
+  @Getter
+  @Setter
   @Enumerated(EnumType.STRING)
   @Column(nullable = false)
   private CompressFileFormat format;
 
+  @Getter
+  @Setter
   @Enumerated(EnumType.STRING)
   @Column(nullable = false)
   private CompressFileContainer container;
 
   public CompressFileTask() {
     super();
+
     inputVariables = new HashSet<EmbeddedVariable>();
     asyncBefore = false;
     asyncAfter = false;
-  }
-
-  public Set<EmbeddedVariable> getInputVariables() {
-    return inputVariables;
-  }
-
-  public void setInputVariables(Set<EmbeddedVariable> inputVariables) {
-    this.inputVariables = inputVariables;
-  }
-
-  public EmbeddedVariable getOutputVariable() {
-    return outputVariable;
-  }
-
-  public void setOutputVariable(EmbeddedVariable outputVariable) {
-    this.outputVariable = outputVariable;
-  }
-
-  public boolean isAsyncBefore() {
-    return asyncBefore;
-  }
-
-  public void setAsyncBefore(boolean asyncBefore) {
-    this.asyncBefore = asyncBefore;
-  }
-
-  public boolean isAsyncAfter() {
-    return asyncAfter;
-  }
-
-  public void setAsyncAfter(boolean asyncAfter) {
-    this.asyncAfter = asyncAfter;
-  }
-
-  public String getSource() {
-    return source;
-  }
-
-  public void setSource(String source) {
-    this.source = source;
-  }
-
-  public String getDestination() {
-    return destination;
-  }
-
-  public void setDestination(String destination) {
-    this.destination = destination;
-  }
-
-  public CompressFileFormat getFormat() {
-    return format;
-  }
-
-  public void setFormat(CompressFileFormat format) {
-    this.format = format;
-  }
-
-  public CompressFileContainer getContainer() {
-    return container;
-  }
-
-  public void setContainer(CompressFileContainer container) {
-    this.container = container;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/Condition.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/Condition.java
@@ -4,17 +4,22 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
-
+import lombok.Getter;
+import lombok.Setter;
 import org.folio.rest.workflow.model.components.Conditional;
 
 @Entity
 public class Condition extends Node implements Conditional {
 
+  @Getter
+  @Setter
   @NotNull
   @Size(min = 4, max = 128)
   @Column(nullable = false)
   private String expression;
 
+  @Getter
+  @Setter
   @NotNull
   @Size(min = 2, max = 64)
   @Column(nullable = false)
@@ -22,22 +27,6 @@ public class Condition extends Node implements Conditional {
 
   public Condition() {
     super();
-  }
-
-  public String getExpression() {
-    return expression;
-  }
-
-  public void setExpression(String expression) {
-    this.expression = expression;
-  }
-
-  public String getAnswer() {
-    return answer;
-  }
-
-  public void setAnswer(String answer) {
-    this.answer = answer;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/ConnectTo.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/ConnectTo.java
@@ -3,26 +3,21 @@ package org.folio.rest.workflow.model;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.validation.constraints.NotNull;
-
+import lombok.Getter;
+import lombok.Setter;
 import org.folio.rest.workflow.model.components.Navigation;
 
 @Entity
 public class ConnectTo extends Node implements Navigation {
 
+  @Getter
+  @Setter
   @NotNull
   @Column(nullable = false)
   private String nodeId;
 
   public ConnectTo() {
     super();
-  }
-
-  public String getNodeId() {
-    return nodeId;
-  }
-
-  public void setNodeId(String nodeId) {
-    this.nodeId = nodeId;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/DatabaseConnectionTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/DatabaseConnectionTask.java
@@ -1,109 +1,66 @@
 package org.folio.rest.workflow.model;
 
 import java.util.Set;
-
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
-
+import lombok.Getter;
+import lombok.Setter;
 import org.folio.rest.workflow.model.components.DelegateTask;
+import org.folio.rest.workflow.model.has.HasDesignation;
+import org.folio.rest.workflow.model.has.HasPassword;
+import org.folio.rest.workflow.model.has.HasUrl;
+import org.folio.rest.workflow.model.has.HasUsername;
 
 @Entity
-public class DatabaseConnectionTask extends Node implements DelegateTask {
+public class DatabaseConnectionTask extends Node implements DelegateTask, HasDesignation, HasPassword, HasUrl, HasUsername {
 
+  @Getter
+  @Setter
   @ElementCollection
   private Set<EmbeddedVariable> inputVariables;
 
+  @Getter
+  @Setter
   @Embedded
   private EmbeddedVariable outputVariable;
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   private boolean asyncBefore;
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   private boolean asyncAfter;
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   private String designation;
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   private String url;
 
+  @Getter
+  @Setter
   @Column(nullable = true)
   private String username;
 
+  @Getter
+  @Setter
   @Column(nullable = true)
   private String password;
 
   public DatabaseConnectionTask() {
     super();
+
     asyncBefore = false;
     asyncAfter = false;
-  }
-
-  public Set<EmbeddedVariable> getInputVariables() {
-    return inputVariables;
-  }
-
-  public void setInputVariables(Set<EmbeddedVariable> inputVariables) {
-    this.inputVariables = inputVariables;
-  }
-
-  public EmbeddedVariable getOutputVariable() {
-    return outputVariable;
-  }
-
-  public void setOutputVariable(EmbeddedVariable outputVariable) {
-    this.outputVariable = outputVariable;
-  }
-
-  public boolean isAsyncBefore() {
-    return asyncBefore;
-  }
-
-  public void setAsyncBefore(boolean asyncBefore) {
-    this.asyncBefore = asyncBefore;
-  }
-
-  public boolean isAsyncAfter() {
-    return asyncAfter;
-  }
-
-  public void setAsyncAfter(boolean asyncAfter) {
-    this.asyncAfter = asyncAfter;
-  }
-
-  public String getDesignation() {
-    return designation;
-  }
-
-  public void setDesignation(String designation) {
-    this.designation = designation;
-  }
-
-  public String getUrl() {
-    return url;
-  }
-
-  public void setUrl(String url) {
-    this.url = url;
-  }
-
-  public String getUsername() {
-    return username;
-  }
-
-  public void setUsername(String username) {
-    this.username = username;
-  }
-
-  public String getPassword() {
-    return password;
-  }
-
-  public void setPassword(String password) {
-    this.password = password;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/DatabaseDisconnectTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/DatabaseDisconnectTask.java
@@ -1,76 +1,48 @@
 package org.folio.rest.workflow.model;
 
 import java.util.Set;
-
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
-
+import lombok.Getter;
+import lombok.Setter;
 import org.folio.rest.workflow.model.components.DelegateTask;
+import org.folio.rest.workflow.model.has.HasDesignation;
 
 @Entity
-public class DatabaseDisconnectTask extends Node implements DelegateTask {
+public class DatabaseDisconnectTask extends Node implements DelegateTask, HasDesignation {
 
+  @Getter
+  @Setter
   @ElementCollection
   private Set<EmbeddedVariable> inputVariables;
 
+  @Getter
+  @Setter
   @Embedded
   private EmbeddedVariable outputVariable;
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   private boolean asyncBefore;
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   private boolean asyncAfter;
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   private String designation;
 
   public DatabaseDisconnectTask() {
     super();
+
     asyncBefore = false;
     asyncAfter = false;
-  }
-
-  public Set<EmbeddedVariable> getInputVariables() {
-    return inputVariables;
-  }
-
-  public void setInputVariables(Set<EmbeddedVariable> inputVariables) {
-    this.inputVariables = inputVariables;
-  }
-
-  public EmbeddedVariable getOutputVariable() {
-    return outputVariable;
-  }
-
-  public void setOutputVariable(EmbeddedVariable outputVariable) {
-    this.outputVariable = outputVariable;
-  }
-
-  public boolean isAsyncBefore() {
-    return asyncBefore;
-  }
-
-  public void setAsyncBefore(boolean asyncBefore) {
-    this.asyncBefore = asyncBefore;
-  }
-
-  public boolean isAsyncAfter() {
-    return asyncAfter;
-  }
-
-  public void setAsyncAfter(boolean asyncAfter) {
-    this.asyncAfter = asyncAfter;
-  }
-
-  public String getDesignation() {
-    return designation;
-  }
-
-  public void setDesignation(String designation) {
-    this.designation = designation;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/DatabaseQueryTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/DatabaseQueryTask.java
@@ -8,7 +8,7 @@ import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
-
+import org.folio.rest.workflow.enums.DatabaseResultType;
 import org.folio.rest.workflow.model.components.DelegateTask;
 
 @Entity

--- a/components/src/main/java/org/folio/rest/workflow/model/DatabaseQueryTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/DatabaseQueryTask.java
@@ -1,125 +1,75 @@
 package org.folio.rest.workflow.model;
 
 import java.util.Set;
-
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import lombok.Getter;
+import lombok.Setter;
 import org.folio.rest.workflow.enums.DatabaseResultType;
 import org.folio.rest.workflow.model.components.DelegateTask;
+import org.folio.rest.workflow.model.has.HasDesignation;
+import org.folio.rest.workflow.model.has.common.HasDatabaseQueryTaskCommon;
 
 @Entity
-public class DatabaseQueryTask extends Node implements DelegateTask {
+public class DatabaseQueryTask extends Node implements DelegateTask, HasDatabaseQueryTaskCommon, HasDesignation {
 
+  @Getter
+  @Setter
   @ElementCollection
   private Set<EmbeddedVariable> inputVariables;
 
+  @Getter
+  @Setter
   @Embedded
   private EmbeddedVariable outputVariable;
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   private boolean asyncBefore;
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   private boolean asyncAfter;
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   private String designation;
 
+  @Getter
+  @Setter
   @Column(columnDefinition = "TEXT", nullable = false)
   private String query;
 
+  @Getter
+  @Setter
   @Column(nullable = true)
   private String outputPath;
 
+  @Getter
+  @Setter
   @Enumerated(EnumType.STRING)
   @Column(nullable = true)
   private DatabaseResultType resultType;
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   private Boolean includeHeader;
 
   public DatabaseQueryTask() {
     super();
+
     asyncBefore = false;
     asyncAfter = false;
     resultType = DatabaseResultType.TSV;
     includeHeader = false;
-  }
-
-  public Set<EmbeddedVariable> getInputVariables() {
-    return inputVariables;
-  }
-
-  public void setInputVariables(Set<EmbeddedVariable> inputVariables) {
-    this.inputVariables = inputVariables;
-  }
-
-  public EmbeddedVariable getOutputVariable() {
-    return outputVariable;
-  }
-
-  public void setOutputVariable(EmbeddedVariable outputVariable) {
-    this.outputVariable = outputVariable;
-  }
-
-  public boolean isAsyncBefore() {
-    return asyncBefore;
-  }
-
-  public void setAsyncBefore(boolean asyncBefore) {
-    this.asyncBefore = asyncBefore;
-  }
-
-  public boolean isAsyncAfter() {
-    return asyncAfter;
-  }
-
-  public void setAsyncAfter(boolean asyncAfter) {
-    this.asyncAfter = asyncAfter;
-  }
-
-  public String getDesignation() {
-    return designation;
-  }
-
-  public void setDesignation(String designation) {
-    this.designation = designation;
-  }
-
-  public String getQuery() {
-    return query;
-  }
-
-  public void setQuery(String query) {
-    this.query = query;
-  }
-
-  public String getOutputPath() {
-    return outputPath;
-  }
-
-  public void setOutputPath(String outputPath) {
-    this.outputPath = outputPath;
-  }
-
-  public DatabaseResultType getResultType() {
-    return resultType;
-  }
-
-  public void setResultType(DatabaseResultType resultType) {
-    this.resultType = resultType;
-  }
-
-  public Boolean getIncludeHeader() {
-    return includeHeader;
-  }
-
-  public void setIncludeHeader(Boolean includeHeader) {
-    this.includeHeader = includeHeader;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/DirectoryTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/DirectoryTask.java
@@ -2,7 +2,6 @@ package org.folio.rest.workflow.model;
 
 import java.util.HashSet;
 import java.util.Set;
-
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Embedded;
@@ -10,98 +9,60 @@ import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
 import org.folio.rest.workflow.enums.DirectoryAction;
 import org.folio.rest.workflow.model.components.DelegateTask;
+import org.folio.rest.workflow.model.has.common.HasDirectoryTaskCommon;
 
 @Entity
-public class DirectoryTask extends Node implements DelegateTask {
+public class DirectoryTask extends Node implements DelegateTask, HasDirectoryTaskCommon {
 
+  @Getter
+  @Setter
+  @ElementCollection
+  private Set<EmbeddedVariable> inputVariables;
+
+  @Getter
+  @Setter
+  @Embedded
+  private EmbeddedVariable outputVariable;
+
+  @Getter
+  @Setter
+  @Column(nullable = false)
+  private boolean asyncBefore;
+
+  @Getter
+  @Setter
+  @Column(nullable = false)
+  private boolean asyncAfter;
+
+  @Getter
+  @Setter
   @NotNull
   @Column(nullable = false)
   private String path;
 
+  @Getter
+  @Setter
   @NotNull
   @Column(nullable = false)
   private String workflow;
 
+  @Getter
+  @Setter
   @NotNull
   @Column(nullable = false)
   @Enumerated(EnumType.STRING)
   private DirectoryAction action;
 
-  @ElementCollection
-  private Set<EmbeddedVariable> inputVariables;
-
-  @Embedded
-  private EmbeddedVariable outputVariable;
-
-  @Column(nullable = false)
-  private boolean asyncBefore;
-
-  @Column(nullable = false)
-  private boolean asyncAfter;
-
   public DirectoryTask() {
     super();
+
     inputVariables = new HashSet<EmbeddedVariable>();
     asyncBefore = false;
     asyncAfter = false;
-  }
-
-  public String getPath() {
-    return path;
-  }
-
-  public void setPath(String path) {
-    this.path = path;
-  }
-
-  public String getWorkflow() {
-    return workflow;
-  }
-
-  public void setWorkflow(String workflow) {
-    this.workflow = workflow;
-  }
-
-  public DirectoryAction getAction() {
-    return action;
-  }
-
-  public void setAction(DirectoryAction action) {
-    this.action = action;
-  }
-
-  public Set<EmbeddedVariable> getInputVariables() {
-    return inputVariables;
-  }
-
-  public void setInputVariables(Set<EmbeddedVariable> inputVariables) {
-    this.inputVariables = inputVariables;
-  }
-
-  public EmbeddedVariable getOutputVariable() {
-    return outputVariable;
-  }
-
-  public void setOutputVariable(EmbeddedVariable outputVariable) {
-    this.outputVariable = outputVariable;
-  }
-
-  public boolean isAsyncBefore() {
-    return asyncBefore;
-  }
-
-  public void setAsyncBefore(boolean asyncBefore) {
-    this.asyncBefore = asyncBefore;
-  }
-
-  public boolean isAsyncAfter() {
-    return asyncAfter;
-  }
-
-  public void setAsyncAfter(boolean asyncAfter) {
-    this.asyncAfter = asyncAfter;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/DirectoryTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/DirectoryTask.java
@@ -10,7 +10,7 @@ import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.validation.constraints.NotNull;
-
+import org.folio.rest.workflow.enums.DirectoryAction;
 import org.folio.rest.workflow.model.components.DelegateTask;
 
 @Entity

--- a/components/src/main/java/org/folio/rest/workflow/model/EmailTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/EmailTask.java
@@ -2,68 +2,96 @@ package org.folio.rest.workflow.model;
 
 import java.util.HashSet;
 import java.util.Set;
-
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.validation.constraints.Size;
-
+import lombok.Getter;
+import lombok.Setter;
 import org.folio.rest.workflow.model.components.DelegateTask;
+import org.folio.rest.workflow.model.has.common.HasEmailTaskCommon;
 import org.springframework.lang.NonNull;
 
 @Entity
-public class EmailTask extends Node implements DelegateTask {
+public class EmailTask extends Node implements DelegateTask, HasEmailTaskCommon {
 
+  @Getter
+  @Setter
   @ElementCollection
   private Set<EmbeddedVariable> inputVariables;
 
+  @Getter
+  @Setter
   @Embedded
   private EmbeddedVariable outputVariable;
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   private boolean asyncBefore;
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   private boolean asyncAfter;
 
+  @Getter
+  @Setter
   @NonNull
   @Size(min = 3, max = 256)
   @Column(nullable = false)
   private String mailTo;
 
+  @Getter
+  @Setter
   @Column(nullable = true)
   private String mailCc;
 
+  @Getter
+  @Setter
   @Column(nullable = true)
   private String mailBcc;
 
+  @Getter
+  @Setter
   @NonNull
   @Size(min = 3, max = 256)
   @Column(nullable = false)
   private String mailFrom;
 
+  @Getter
+  @Setter
   @NonNull
   @Size(min = 2, max = 256)
   @Column(nullable = false)
   private String mailSubject;
 
+  @Getter
+  @Setter
   @NonNull
   @Size(min = 2)
   @Column(columnDefinition = "TEXT", nullable = false)
   private String mailText;
 
+  @Getter
+  @Setter
   @Column(columnDefinition = "TEXT", nullable = true)
   private String mailMarkup;
 
+  @Getter
+  @Setter
   @Column(nullable = true)
   private String attachmentPath;
 
+  @Getter
+  @Setter
   @Column(nullable = true)
   private String includeAttachment;
 
   public EmailTask() {
     super();
+
     inputVariables = new HashSet<EmbeddedVariable>();
     asyncBefore = false;
     asyncAfter = false;
@@ -71,110 +99,6 @@ public class EmailTask extends Node implements DelegateTask {
     mailFrom = "";
     mailSubject = "";
     mailText = "";
-  }
-
-  public Set<EmbeddedVariable> getInputVariables() {
-    return inputVariables;
-  }
-
-  public void setInputVariables(Set<EmbeddedVariable> inputVariables) {
-    this.inputVariables = inputVariables;
-  }
-
-  public EmbeddedVariable getOutputVariable() {
-    return outputVariable;
-  }
-
-  public void setOutputVariable(EmbeddedVariable outputVariable) {
-    this.outputVariable = outputVariable;
-  }
-
-  public boolean isAsyncBefore() {
-    return asyncBefore;
-  }
-
-  public void setAsyncBefore(boolean asyncBefore) {
-    this.asyncBefore = asyncBefore;
-  }
-
-  public boolean isAsyncAfter() {
-    return asyncAfter;
-  }
-
-  public void setAsyncAfter(boolean asyncAfter) {
-    this.asyncAfter = asyncAfter;
-  }
-
-  public String getMailTo() {
-    return mailTo;
-  }
-
-  public void setMailTo(String mailTo) {
-    this.mailTo = mailTo;
-  }
-
-  public String getMailCc() {
-    return mailCc;
-  }
-
-  public void setMailCc(String mailCc) {
-    this.mailCc = mailCc;
-  }
-
-  public String getMailBcc() {
-    return mailBcc;
-  }
-
-  public void setMailBcc(String mailBcc) {
-    this.mailBcc = mailBcc;
-  }
-
-  public String getMailFrom() {
-    return mailFrom;
-  }
-
-  public void setMailFrom(String mailFrom) {
-    this.mailFrom = mailFrom;
-  }
-
-  public String getMailSubject() {
-    return mailSubject;
-  }
-
-  public void setMailSubject(String mailSubject) {
-    this.mailSubject = mailSubject;
-  }
-
-  public String getMailText() {
-    return mailText;
-  }
-
-  public void setMailText(String mailText) {
-    this.mailText = mailText;
-  }
-
-  public String getMailMarkup() {
-    return mailMarkup;
-  }
-
-  public void setMailMarkup(String mailMarkup) {
-    this.mailMarkup = mailMarkup;
-  }
-
-  public String getAttachmentPath() {
-    return attachmentPath;
-  }
-
-  public void setAttachmentPath(String attachmentPath) {
-    this.attachmentPath = attachmentPath;
-  }
-
-  public String getIncludeAttachment() {
-    return includeAttachment;
-  }
-
-  public void setIncludeAttachment(String includeAttachment) {
-    this.includeAttachment = includeAttachment;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/EmbeddedLoopReference.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/EmbeddedLoopReference.java
@@ -3,81 +3,58 @@ package org.folio.rest.workflow.model;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import org.folio.rest.workflow.model.has.common.HasEmbeddedLoopReferenceCommon;
 
 @Embeddable
-public class EmbeddedLoopReference {
+public class EmbeddedLoopReference implements HasEmbeddedLoopReferenceCommon {
 
+  @Getter
+  @Setter
   @Column(nullable = true)
   private String cardinalityExpression;
 
+  @Getter
+  @Setter
   @Column(nullable = true)
   private String dataInputRefExpression;
 
+  @Getter
+  @Setter
   @Column(nullable = true)
   private String inputDataName;
 
+  @Getter
+  @Setter
   @Column(nullable = true)
   private String completeConditionExpression;
 
+  @Getter
+  @Setter
   @NotNull
   @Column(nullable = true)
   private boolean parallel;
 
   public EmbeddedLoopReference() {
     super();
+
     parallel = false;
   }
 
-  public String getCardinalityExpression() {
-    return cardinalityExpression;
-  }
-
-  public void setCardinalityExpression(String cardinalityExpression) {
-    this.cardinalityExpression = cardinalityExpression;
-  }
-
+  @Override
   public boolean hasCardinalityExpression() {
     return cardinalityExpression != null;
   }
 
-  public String getDataInputRefExpression() {
-    return dataInputRefExpression;
-  }
-
-  public void setDataInputRefExpression(String dataInputRefExpression) {
-    this.dataInputRefExpression = dataInputRefExpression;
-  }
-
-  public String getInputDataName() {
-    return inputDataName;
-  }
-
-  public void setInputDataName(String inputDataName) {
-    this.inputDataName = inputDataName;
-  }
-
-  public boolean hasDataInput() {
-    return dataInputRefExpression != null && inputDataName != null;
-  }
-
-  public String getCompleteConditionExpression() {
-    return completeConditionExpression;
-  }
-
-  public void setCompleteConditionExpression(String completeConditionExpression) {
-    this.completeConditionExpression = completeConditionExpression;
-  }
-
+  @Override
   public boolean hasCompleteConditionExpression() {
     return completeConditionExpression != null;
   }
 
-  public boolean isParallel() {
-    return parallel;
-  }
-
-  public void setParallel(boolean parallel) {
-    this.parallel = parallel;
+  @Override
+  public boolean hasDataInput() {
+    return dataInputRefExpression != null && inputDataName != null;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/EmbeddedProcessor.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/EmbeddedProcessor.java
@@ -6,75 +6,49 @@ import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
 import org.folio.rest.workflow.enums.ScriptType;
+import org.folio.rest.workflow.model.has.common.HasEmbeddedProcessorCommon;
 
 @Embeddable
-public class EmbeddedProcessor {
+public class EmbeddedProcessor implements HasEmbeddedProcessorCommon {
 
+  @Getter
+  @Setter
   @NotNull
   @Column(nullable = false)
   @Enumerated(EnumType.STRING)
   private ScriptType scriptType;
 
+  @Getter
+  @Setter
   @NotNull
   @Size(min = 4, max = 128)
   @Column(nullable = false)
   private String functionName;
 
+  @Getter
+  @Setter
   @NotNull
   @Column(columnDefinition = "TEXT", nullable = false)
   private String code;
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   private int buffer;
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   private int delay;
 
   public EmbeddedProcessor() {
     super();
+
     buffer = 0;
     delay = 0;
-  }
-
-  public ScriptType getScriptType() {
-    return scriptType;
-  }
-
-  public void setScriptType(ScriptType scriptType) {
-    this.scriptType = scriptType;
-  }
-
-  public String getFunctionName() {
-    return functionName;
-  }
-
-  public void setFunctionName(String functionName) {
-    this.functionName = functionName;
-  }
-
-  public String getCode() {
-    return code;
-  }
-
-  public void setCode(String code) {
-    this.code = code;
-  }
-
-  public int getBuffer() {
-    return buffer;
-  }
-
-  public void setBuffer(int buffer) {
-    this.buffer = buffer;
-  }
-
-  public int getDelay() {
-    return delay;
-  }
-
-  public void setDelay(int delay) {
-    this.delay = delay;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/EmbeddedProcessor.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/EmbeddedProcessor.java
@@ -6,6 +6,7 @@ import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
+import org.folio.rest.workflow.enums.ScriptType;
 
 @Embeddable
 public class EmbeddedProcessor {

--- a/components/src/main/java/org/folio/rest/workflow/model/EmbeddedRequest.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/EmbeddedRequest.java
@@ -5,109 +5,64 @@ import javax.persistence.Embeddable;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.validation.constraints.NotNull;
-
+import lombok.Getter;
+import lombok.Setter;
+import org.folio.rest.workflow.model.has.common.HasEmbeddedRequestCommon;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 
 @Embeddable
-public class EmbeddedRequest {
+public class EmbeddedRequest implements HasEmbeddedRequestCommon {
 
+  @Getter
+  @Setter
   @NotNull
   @Column(nullable = false)
   private String url;
 
+  @Getter
+  @Setter
   @NotNull
   @Column(nullable = false)
   @Enumerated(EnumType.STRING)
   private HttpMethod method;
 
+  @Getter
+  @Setter
   @NotNull
   @Column(nullable = false)
   private String contentType;
 
+  @Getter
+  @Setter
   @NotNull
   @Column(nullable = false)
   private String accept;
 
+  @Getter
+  @Setter
   @Column(columnDefinition = "TEXT", nullable = false)
   private String bodyTemplate;
 
+  @Getter
+  @Setter
   private boolean iterable;
 
+  @Getter
+  @Setter
   private String iterableKey;
 
+  @Getter
+  @Setter
   private String responseKey;
 
   public EmbeddedRequest() {
     super();
+
     contentType = MediaType.APPLICATION_JSON_VALUE;
     accept = MediaType.APPLICATION_JSON_VALUE;
     bodyTemplate = "{}";
     iterable = false;
-  }
-
-  public String getUrl() {
-    return url;
-  }
-
-  public void setUrl(String url) {
-    this.url = url;
-  }
-
-  public HttpMethod getMethod() {
-    return method;
-  }
-
-  public void setMethod(HttpMethod method) {
-    this.method = method;
-  }
-
-  public String getContentType() {
-    return contentType;
-  }
-
-  public void setContentType(String contentType) {
-    this.contentType = contentType;
-  }
-
-  public String getAccept() {
-    return accept;
-  }
-
-  public void setAccept(String accept) {
-    this.accept = accept;
-  }
-
-  public String getBodyTemplate() {
-    return bodyTemplate;
-  }
-
-  public void setBodyTemplate(String bodyTemplate) {
-    this.bodyTemplate = bodyTemplate;
-  }
-
-  public boolean isIterable() {
-    return iterable;
-  }
-
-  public void setIterable(boolean iterable) {
-    this.iterable = iterable;
-  }
-
-  public String getIterableKey() {
-    return iterableKey;
-  }
-
-  public void setIterableKey(String iterableKey) {
-    this.iterableKey = iterableKey;
-  }
-
-  public String getResponseKey() {
-    return responseKey;
-  }
-
-  public void setResponseKey(String responseKey) {
-    this.responseKey = responseKey;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/EmbeddedVariable.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/EmbeddedVariable.java
@@ -8,6 +8,7 @@ import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
+import org.folio.rest.workflow.enums.VariableType;
 
 @Embeddable
 public class EmbeddedVariable {

--- a/components/src/main/java/org/folio/rest/workflow/model/EmbeddedVariable.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/EmbeddedVariable.java
@@ -1,33 +1,44 @@
 package org.folio.rest.workflow.model;
 
-import java.util.Optional;
-
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
 import org.folio.rest.workflow.enums.VariableType;
+import org.folio.rest.workflow.model.has.common.HasEmbeddedVariableCommon;
 
 @Embeddable
-public class EmbeddedVariable {
+public class EmbeddedVariable implements HasEmbeddedVariableCommon {
 
+  @Getter
+  @Setter
   @NotNull
   @Size(min = 4, max = 64)
   @Column(nullable = true)
   private String key;
 
+  @Getter
+  @Setter
   @Column(nullable = true)
   @Enumerated(EnumType.STRING)
   private VariableType type;
 
+  @Getter
+  @Setter
   @Column(nullable = true)
   private boolean spin;
 
+  @Getter
+  @Setter
   @Column(nullable = true)
   private Boolean asJson;
 
+  @Getter
+  @Setter
   @Column(nullable = true)
   private Boolean asTransient;
 
@@ -36,46 +47,6 @@ public class EmbeddedVariable {
     spin = false;
     asJson = false;
     asTransient = false;
-  }
-
-  public Optional<String> getKey() {
-    return Optional.ofNullable(key);
-  }
-
-  public void setKey(String key) {
-    this.key = key;
-  }
-
-  public Optional<VariableType> getType() {
-    return Optional.ofNullable(type);
-  }
-
-  public void setType(VariableType type) {
-    this.type = type;
-  }
-
-  public boolean isSpin() {
-    return spin;
-  }
-
-  public void setSpin(boolean spin) {
-    this.spin = spin;
-  }
-
-  public Boolean getAsJson() {
-    return asJson;
-  }
-
-  public void setAsJson(Boolean asJson) {
-    this.asJson = asJson;
-  }
-
-  public Boolean getAsTransient() {
-    return asTransient;
-  }
-
-  public void setAsTransient(Boolean asTransient) {
-    this.asTransient = asTransient;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/EndEvent.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/EndEvent.java
@@ -1,7 +1,6 @@
 package org.folio.rest.workflow.model;
 
 import javax.persistence.Entity;
-
 import org.folio.rest.workflow.model.components.Event;
 
 @Entity

--- a/components/src/main/java/org/folio/rest/workflow/model/EventSubprocess.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/EventSubprocess.java
@@ -2,36 +2,38 @@ package org.folio.rest.workflow.model;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.OneToMany;
 import javax.persistence.OrderColumn;
+import lombok.Getter;
+import lombok.Setter;
+import org.folio.rest.workflow.model.has.HasAsync;
+import org.folio.rest.workflow.model.has.HasNodes;
 
 @Entity
-public class EventSubprocess extends Node {
+public class EventSubprocess extends Node implements HasAsync, HasNodes {
 
+  @Getter
+  @Setter
+  @Column(nullable = false)
+  private boolean asyncBefore;
+
+  @Getter
+  @Setter
+  @Column(nullable = false)
+  private boolean asyncAfter;
+
+  @Getter
+  @Setter
   @OneToMany
   @OrderColumn
   private List<Node> nodes;
 
-  @Column(nullable = false)
-  private boolean asyncBefore;
-
-  @Column(nullable = false)
-  private boolean asyncAfter;
-
   public EventSubprocess() {
     super();
+
     nodes = new ArrayList<Node>();
-  }
-
-  public List<Node> getNodes() {
-    return nodes;
-  }
-
-  public void setNodes(List<Node> nodes) {
-    this.nodes = nodes;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/FileTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/FileTask.java
@@ -2,113 +2,68 @@ package org.folio.rest.workflow.model;
 
 import java.util.HashSet;
 import java.util.Set;
-
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import lombok.Getter;
+import lombok.Setter;
 import org.folio.rest.workflow.enums.FileOp;
 import org.folio.rest.workflow.model.components.DelegateTask;
+import org.folio.rest.workflow.model.has.common.HasFileTaskCommon;
 
 @Entity
-public class FileTask extends Node implements DelegateTask {
+public class FileTask extends Node implements DelegateTask, HasFileTaskCommon {
 
+  @Getter
+  @Setter
   @ElementCollection
   private Set<EmbeddedVariable> inputVariables;
 
+  @Getter
+  @Setter
   @Embedded
   private EmbeddedVariable outputVariable;
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   private boolean asyncBefore;
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   private boolean asyncAfter;
 
+  @Getter
+  @Setter
   @Enumerated(EnumType.STRING)
   @Column(nullable = false)
   private FileOp op;
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   private String path;
 
+  @Getter
+  @Setter
   @Column(nullable = true)
   private String target;
 
+  @Getter
+  @Setter
   @Column(nullable = true)
   private String line;
 
   public FileTask() {
     super();
+
     inputVariables = new HashSet<EmbeddedVariable>();
     asyncBefore = false;
     asyncAfter = false;
-  }
-
-  public Set<EmbeddedVariable> getInputVariables() {
-    return inputVariables;
-  }
-
-  public void setInputVariables(Set<EmbeddedVariable> inputVariables) {
-    this.inputVariables = inputVariables;
-  }
-
-  public EmbeddedVariable getOutputVariable() {
-    return outputVariable;
-  }
-
-  public void setOutputVariable(EmbeddedVariable outputVariable) {
-    this.outputVariable = outputVariable;
-  }
-
-  public boolean isAsyncBefore() {
-    return asyncBefore;
-  }
-
-  public void setAsyncBefore(boolean asyncBefore) {
-    this.asyncBefore = asyncBefore;
-  }
-
-  public boolean isAsyncAfter() {
-    return asyncAfter;
-  }
-
-  public void setAsyncAfter(boolean asyncAfter) {
-    this.asyncAfter = asyncAfter;
-  }
-
-  public FileOp getOp() {
-    return op;
-  }
-
-  public void setOp(FileOp op) {
-    this.op = op;
-  }
-
-  public String getPath() {
-    return path;
-  }
-
-  public void setPath(String path) {
-    this.path = path;
-  }
-
-  public String getTarget() {
-    return target;
-  }
-
-  public void setTarget(String target) {
-    this.target = target;
-  }
-
-  public String getLine() {
-    return line;
-  }
-
-  public void setLine(String line) {
-    this.line = line;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/FileTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/FileTask.java
@@ -9,7 +9,7 @@ import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
-
+import org.folio.rest.workflow.enums.FileOp;
 import org.folio.rest.workflow.model.components.DelegateTask;
 
 @Entity

--- a/components/src/main/java/org/folio/rest/workflow/model/FtpTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/FtpTask.java
@@ -2,157 +2,102 @@ package org.folio.rest.workflow.model;
 
 import java.util.HashSet;
 import java.util.Set;
-
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import lombok.Getter;
+import lombok.Setter;
 import org.folio.rest.workflow.enums.SftpOp;
 import org.folio.rest.workflow.model.components.DelegateTask;
+import org.folio.rest.workflow.model.has.HasPassword;
+import org.folio.rest.workflow.model.has.HasService;
+import org.folio.rest.workflow.model.has.HasUsername;
+import org.folio.rest.workflow.model.has.common.HasFtpTaskCommon;
 
 @Entity
-public class FtpTask extends Node implements DelegateTask {
+public class FtpTask extends Node implements DelegateTask, HasFtpTaskCommon, HasPassword, HasService, HasUsername {
 
+  @Getter
+  @Setter
   @ElementCollection
   private Set<EmbeddedVariable> inputVariables;
 
+  @Getter
+  @Setter
   @Embedded
   private EmbeddedVariable outputVariable;
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   private boolean asyncBefore;
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   private boolean asyncAfter;
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   private String originPath;
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   private String destinationPath;
 
+  @Getter
+  @Setter
   @Enumerated(EnumType.STRING)
   @Column(nullable = false)
   private SftpOp op;
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   private String scheme;
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   private String host;
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   private int port;
 
+  @Getter
+  @Setter
   @Column(nullable = true)
   private String username;
 
+  @Getter
+  @Setter
   @Column(nullable = true)
   private String password;
 
   public FtpTask() {
     super();
+
     inputVariables = new HashSet<EmbeddedVariable>();
     asyncBefore = false;
     asyncAfter = false;
   }
 
-  public Set<EmbeddedVariable> getInputVariables() {
-    return inputVariables;
+  @Override
+  public String getBasePath() {
+    // This is currently not used.
+    return "";
   }
 
-  public void setInputVariables(Set<EmbeddedVariable> inputVariables) {
-    this.inputVariables = inputVariables;
-  }
-
-  public EmbeddedVariable getOutputVariable() {
-    return outputVariable;
-  }
-
-  public void setOutputVariable(EmbeddedVariable outputVariable) {
-    this.outputVariable = outputVariable;
-  }
-
-  public boolean isAsyncBefore() {
-    return asyncBefore;
-  }
-
-  public void setAsyncBefore(boolean asyncBefore) {
-    this.asyncBefore = asyncBefore;
-  }
-
-  public boolean isAsyncAfter() {
-    return asyncAfter;
-  }
-
-  public void setAsyncAfter(boolean asyncAfter) {
-    this.asyncAfter = asyncAfter;
-  }
-
-  public String getOriginPath() {
-    return originPath;
-  }
-
-  public void setOriginPath(String originPath) {
-    this.originPath = originPath;
-  }
-
-  public String getDestinationPath() {
-    return destinationPath;
-  }
-
-  public void setDestinationPath(String destinationPath) {
-    this.destinationPath = destinationPath;
-  }
-
-  public SftpOp getOp() {
-    return op;
-  }
-
-  public void setOp(SftpOp op) {
-    this.op = op;
-  }
-
-  public String getScheme() {
-    return scheme;
-  }
-
-  public void setScheme(String scheme) {
-    this.scheme = scheme;
-  }
-
-  public String getHost() {
-    return host;
-  }
-
-  public void setHost(String host) {
-    this.host = host;
-  }
-
-  public int getPort() {
-    return port;
-  }
-
-  public void setPort(int port) {
-    this.port = port;
-  }
-
-  public String getUsername() {
-    return username;
-  }
-
-  public void setUsername(String username) {
-    this.username = username;
-  }
-
-  public String getPassword() {
-    return password;
-  }
-
-  public void setPassword(String password) {
-    this.password = password;
+  @Override
+  public void setBasePath(String basePath) {
+    // This is currently not used.
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/FtpTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/FtpTask.java
@@ -9,7 +9,7 @@ import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
-
+import org.folio.rest.workflow.enums.SftpOp;
 import org.folio.rest.workflow.model.components.DelegateTask;
 
 @Entity

--- a/components/src/main/java/org/folio/rest/workflow/model/MoveToNode.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/MoveToNode.java
@@ -2,45 +2,35 @@ package org.folio.rest.workflow.model;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.OneToMany;
 import javax.persistence.OrderColumn;
 import javax.validation.constraints.NotNull;
-
+import lombok.Getter;
+import lombok.Setter;
 import org.folio.rest.workflow.model.components.Branch;
+import org.folio.rest.workflow.model.has.common.HasMoveToNodeCommon;
 
 @Entity
-public class MoveToNode extends Node implements Branch {
+public class MoveToNode extends Node implements Branch, HasMoveToNodeCommon {
 
+  @Getter
+  @Setter
   @NotNull
   @Column(nullable = false)
   private String gatewayId;
 
+  @Getter
+  @Setter
   @OneToMany
   @OrderColumn
   private List<Node> nodes;
 
   public MoveToNode() {
     super();
+
     nodes = new ArrayList<Node>();
-  }
-
-  public String getGatewayId() {
-    return gatewayId;
-  }
-
-  public void setGatewayId(String gatewayId) {
-    this.gatewayId = gatewayId;
-  }
-
-  public List<Node> getNodes() {
-    return nodes;
-  }
-
-  public void setNodes(List<Node> nodes) {
-    this.nodes = nodes;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/Node.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/Node.java
@@ -1,16 +1,20 @@
 package org.folio.rest.workflow.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Inheritance;
 import javax.persistence.InheritanceType;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-
+import lombok.Getter;
+import lombok.Setter;
+import org.folio.rest.workflow.model.has.HasId;
+import org.folio.rest.workflow.model.has.HasInformational;
+import org.folio.rest.workflow.model.has.HasName;
+import org.folio.rest.workflow.model.has.common.HasNodeCommon;
 import org.folio.spring.domain.model.AbstractBaseEntity;
 
 @Entity
@@ -65,46 +69,28 @@ import org.folio.spring.domain.model.AbstractBaseEntity;
     @JsonSubTypes.Type(value = ScriptTask.class, name = "ScriptTask")
 
 })
-public abstract class Node extends AbstractBaseEntity {
+public abstract class Node extends AbstractBaseEntity implements HasId, HasInformational, HasName, HasNodeCommon {
 
+  @Getter
+  @Setter
   @NotNull
   @Size(min = 3, max = 64)
   @Column(nullable = false)
   private String name;
 
+  @Getter
+  @Setter
   @Size(min = 0, max = 512)
   @Column(nullable = true)
   private String description;
 
+  @Getter
+  @Setter
   @JsonProperty(access = JsonProperty.Access.READ_ONLY)
   private String deserializeAs = this.getClass().getSimpleName();
 
   public Node() {
     super();
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  public String getDeserializeAs() {
-    return deserializeAs;
-  }
-
-  public void setDeserializeAs(String deserializeAs) {
-    this.deserializeAs = deserializeAs;
   }
 
   public String getIdentifier() {

--- a/components/src/main/java/org/folio/rest/workflow/model/ProcessorTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/ProcessorTask.java
@@ -2,77 +2,49 @@ package org.folio.rest.workflow.model;
 
 import java.util.HashSet;
 import java.util.Set;
-
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
-
+import lombok.Getter;
+import lombok.Setter;
 import org.folio.rest.workflow.model.components.DelegateTask;
+import org.folio.rest.workflow.model.has.common.HasProcessorTaskCommon;
 
 @Entity
-public class ProcessorTask extends Node implements DelegateTask {
+public class ProcessorTask extends Node implements DelegateTask, HasProcessorTaskCommon {
 
-  @Embedded
-  private EmbeddedProcessor processor;
-
+  @Getter
+  @Setter
   @ElementCollection
   private Set<EmbeddedVariable> inputVariables;
 
+  @Getter
+  @Setter
   @Embedded
   private EmbeddedVariable outputVariable;
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   private boolean asyncBefore;
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   private boolean asyncAfter;
 
+  @Getter
+  @Setter
+  @Embedded
+  private EmbeddedProcessor processor;
+
   public ProcessorTask() {
     super();
+
     inputVariables = new HashSet<EmbeddedVariable>();
     asyncBefore = false;
     asyncAfter = false;
-  }
-
-  public EmbeddedProcessor getProcessor() {
-    return processor;
-  }
-
-  public void setProcessor(EmbeddedProcessor processor) {
-    this.processor = processor;
-  }
-
-  public Set<EmbeddedVariable> getInputVariables() {
-    return inputVariables;
-  }
-
-  public void setInputVariables(Set<EmbeddedVariable> inputVariables) {
-    this.inputVariables = inputVariables;
-  }
-
-  public EmbeddedVariable getOutputVariable() {
-    return outputVariable;
-  }
-
-  public void setOutputVariable(EmbeddedVariable outputVariable) {
-    this.outputVariable = outputVariable;
-  }
-
-  public boolean isAsyncBefore() {
-    return asyncBefore;
-  }
-
-  public void setAsyncBefore(boolean asyncBefore) {
-    this.asyncBefore = asyncBefore;
-  }
-
-  public boolean isAsyncAfter() {
-    return asyncAfter;
-  }
-
-  public void setAsyncAfter(boolean asyncAfter) {
-    this.asyncAfter = asyncAfter;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/ReceiveTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/ReceiveTask.java
@@ -4,51 +4,36 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
-
+import lombok.Getter;
+import lombok.Setter;
 import org.folio.rest.workflow.model.components.Wait;
+import org.folio.rest.workflow.model.has.HasAsync;
 
 @Entity
-public class ReceiveTask extends Node implements Wait {
+public class ReceiveTask extends Node implements HasAsync, Wait {
 
+  @Getter
+  @Setter
   @NotNull
   @Size(min = 4, max = 256)
   @Column(nullable = false)
   private String message;
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   private boolean asyncBefore;
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   private boolean asyncAfter;
 
   public ReceiveTask() {
     super();
+
     asyncBefore = false;
     asyncAfter = false;
-  }
-
-  public String getMessage() {
-    return message;
-  }
-
-  public void setMessage(String message) {
-    this.message = message;
-  }
-
-  public boolean isAsyncBefore() {
-    return asyncBefore;
-  }
-
-  public void setAsyncBefore(boolean asyncBefore) {
-    this.asyncBefore = asyncBefore;
-  }
-
-  public boolean isAsyncAfter() {
-    return asyncAfter;
-  }
-
-  public void setAsyncAfter(boolean asyncAfter) {
-    this.asyncAfter = asyncAfter;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/RequestTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/RequestTask.java
@@ -2,89 +2,55 @@ package org.folio.rest.workflow.model;
 
 import java.util.HashSet;
 import java.util.Set;
-
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
-
+import lombok.Getter;
+import lombok.Setter;
 import org.folio.rest.workflow.model.components.DelegateTask;
+import org.folio.rest.workflow.model.has.common.HasRequestTaskCommon;
 
 @Entity
-public class RequestTask extends Node implements DelegateTask {
+public class RequestTask extends Node implements DelegateTask, HasRequestTaskCommon {
 
-  @Embedded
-  private EmbeddedRequest request;
-
+  @Getter
+  @Setter
   @ElementCollection
   private Set<EmbeddedVariable> inputVariables;
 
+  @Getter
+  @Setter
   @ElementCollection
   private Set<EmbeddedVariable> headerOutputVariables;
 
+  @Getter
+  @Setter
   @Embedded
   private EmbeddedVariable outputVariable;
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   private boolean asyncBefore;
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   private boolean asyncAfter;
 
+  @Getter
+  @Setter
+  @Embedded
+  private EmbeddedRequest request;
+
   public RequestTask() {
     super();
+
     inputVariables = new HashSet<EmbeddedVariable>();
     headerOutputVariables = new HashSet<EmbeddedVariable>();
     asyncBefore = false;
     asyncAfter = false;
-  }
-
-  public EmbeddedRequest getRequest() {
-    return request;
-  }
-
-  public void setRequest(EmbeddedRequest request) {
-    this.request = request;
-  }
-
-  public Set<EmbeddedVariable> getInputVariables() {
-    return inputVariables;
-  }
-
-  public void setInputVariables(Set<EmbeddedVariable> inputVariables) {
-    this.inputVariables = inputVariables;
-  }
-
-  public Set<EmbeddedVariable> getHeaderOutputVariables() {
-    return headerOutputVariables;
-  }
-
-  public void setHeaderOutputVariables(Set<EmbeddedVariable> headerOutputVariables) {
-    this.headerOutputVariables = headerOutputVariables;
-  }
-
-  public EmbeddedVariable getOutputVariable() {
-    return outputVariable;
-  }
-
-  public void setOutputVariable(EmbeddedVariable outputVariable) {
-    this.outputVariable = outputVariable;
-  }
-
-  public boolean isAsyncBefore() {
-    return asyncBefore;
-  }
-
-  public void setAsyncBefore(boolean asyncBefore) {
-    this.asyncBefore = asyncBefore;
-  }
-
-  public boolean isAsyncAfter() {
-    return asyncAfter;
-  }
-
-  public void setAsyncAfter(boolean asyncAfter) {
-    this.asyncAfter = asyncAfter;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/ScriptTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/ScriptTask.java
@@ -3,77 +3,51 @@ package org.folio.rest.workflow.model;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.validation.constraints.NotNull;
-
+import lombok.Getter;
+import lombok.Setter;
 import org.folio.rest.workflow.model.components.Task;
+import org.folio.rest.workflow.model.has.HasCode;
+import org.folio.rest.workflow.model.has.common.HasScriptTaskCommon;
 
 @Entity
-public class ScriptTask extends Node implements Task {
+public class ScriptTask extends Node implements HasCode, HasScriptTaskCommon, Task {
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   private String scriptFormat;
 
+  @Getter
+  @Setter
   @NotNull
   @Column(columnDefinition = "TEXT", nullable = false)
   private String code;
 
+  @Getter
+  @Setter
   @Column(nullable = true)
   private String resultVariable;
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   private boolean asyncBefore;
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   private boolean asyncAfter;
 
   public ScriptTask() {
     super();
+
     scriptFormat = "javaScript";
     asyncBefore = false;
     asyncAfter = false;
   }
 
-  public String getScriptFormat() {
-    return scriptFormat;
-  }
-
-  public void setScriptFormat(String scriptFormat) {
-    this.scriptFormat = scriptFormat;
-  }
-
-  public String getCode() {
-    return code;
-  }
-
-  public void setCode(String code) {
-    this.code = code;
-  }
-
-  public String getResultVariable() {
-    return resultVariable;
-  }
-
-  public void setResultVariable(String resultVariable) {
-    this.resultVariable = resultVariable;
-  }
-
   public boolean hasResultVariable() {
     return resultVariable != null;
-  }
-
-  public boolean isAsyncBefore() {
-    return asyncBefore;
-  }
-
-  public void setAsyncBefore(boolean asyncBefore) {
-    this.asyncBefore = asyncBefore;
-  }
-
-  public boolean isAsyncAfter() {
-    return asyncAfter;
-  }
-
-  public void setAsyncAfter(boolean asyncAfter) {
-    this.asyncAfter = asyncAfter;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/Setup.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/Setup.java
@@ -2,36 +2,28 @@ package org.folio.rest.workflow.model;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
+import lombok.Getter;
+import lombok.Setter;
+import org.folio.rest.workflow.model.has.HasAsync;
 
 @Embeddable
-public class Setup {
+public class Setup implements HasAsync {
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   private boolean asyncBefore;
 
+  @Getter
+  @Setter
   @Column(nullable = false)
   private boolean asyncAfter;
 
   public Setup() {
     super();
+
     asyncBefore = false;
     asyncAfter = false;
-  }
-
-  public boolean isAsyncBefore() {
-    return asyncBefore;
-  }
-
-  public void setAsyncBefore(boolean asyncBefore) {
-    this.asyncBefore = asyncBefore;
-  }
-
-  public boolean isAsyncAfter() {
-    return asyncAfter;
-  }
-
-  public void setAsyncAfter(boolean asyncAfter) {
-    this.asyncAfter = asyncAfter;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/SftpOp.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/SftpOp.java
@@ -1,5 +1,0 @@
-package org.folio.rest.workflow.model;
-
-public enum SftpOp {
-  GET, PUT
-}

--- a/components/src/main/java/org/folio/rest/workflow/model/StartEvent.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/StartEvent.java
@@ -6,7 +6,7 @@ import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
-
+import org.folio.rest.workflow.enums.StartEventType;
 import org.folio.rest.workflow.model.components.Event;
 
 @Entity

--- a/components/src/main/java/org/folio/rest/workflow/model/Subprocess.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/Subprocess.java
@@ -11,7 +11,7 @@ import javax.persistence.Enumerated;
 import javax.persistence.OneToMany;
 import javax.persistence.OrderColumn;
 import javax.validation.constraints.NotNull;
-
+import org.folio.rest.workflow.enums.SubprocessType;
 import org.folio.rest.workflow.model.components.Branch;
 import org.folio.rest.workflow.model.components.MultiInstance;
 

--- a/components/src/main/java/org/folio/rest/workflow/model/Subprocess.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/Subprocess.java
@@ -2,7 +2,6 @@ package org.folio.rest.workflow.model;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;

--- a/components/src/main/java/org/folio/rest/workflow/model/Workflow.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/Workflow.java
@@ -22,6 +22,7 @@ import javax.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 import org.folio.rest.workflow.model.converter.JsonNodeConverter;
+import org.folio.rest.workflow.model.has.HasDeploymentId;
 import org.folio.rest.workflow.model.has.HasId;
 import org.folio.rest.workflow.model.has.HasInformational;
 import org.folio.rest.workflow.model.has.HasName;
@@ -32,7 +33,7 @@ import org.folio.spring.domain.model.AbstractBaseEntity;
 
 @Entity
 @JsonIgnoreProperties({ "hibernateLazyInitializer", "handler" })
-public class Workflow extends AbstractBaseEntity implements HasId, HasInformational, HasName, HasNodes, HasVersionTag, HasWorkflowCommon {
+public class Workflow extends AbstractBaseEntity implements HasDeploymentId, HasId, HasInformational, HasName, HasNodes, HasVersionTag, HasWorkflowCommon {
 
   @Getter
   @Setter

--- a/components/src/main/java/org/folio/rest/workflow/model/Workflow.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/Workflow.java
@@ -1,10 +1,11 @@
 package org.folio.rest.workflow.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.JsonNode;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
 import javax.persistence.Convert;
@@ -18,48 +19,70 @@ import javax.persistence.OrderColumn;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
-
+import lombok.Getter;
+import lombok.Setter;
 import org.folio.rest.workflow.model.converter.JsonNodeConverter;
+import org.folio.rest.workflow.model.has.HasId;
+import org.folio.rest.workflow.model.has.HasInformational;
+import org.folio.rest.workflow.model.has.HasName;
+import org.folio.rest.workflow.model.has.HasNodes;
+import org.folio.rest.workflow.model.has.HasVersionTag;
+import org.folio.rest.workflow.model.has.common.HasWorkflowCommon;
 import org.folio.spring.domain.model.AbstractBaseEntity;
-
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.JsonNode;
 
 @Entity
 @JsonIgnoreProperties({ "hibernateLazyInitializer", "handler" })
-public class Workflow extends AbstractBaseEntity {
+public class Workflow extends AbstractBaseEntity implements HasId, HasInformational, HasName, HasNodes, HasVersionTag, HasWorkflowCommon {
 
+  @Getter
+  @Setter
   @NotNull
   @Size(min = 4, max = 64)
   @Column(unique = true)
   private String name;
 
+  @Getter
+  @Setter
+  @Size(min = 0, max = 512)
+  @Column(nullable = true)
+  private String description;
+
+  @Getter
+  @Setter
   @NotNull
   @Size(min = 1, max = 64)
   @Column(nullable = false)
   private String versionTag;
 
+  @Getter
+  @Setter
   @Min(0)
   @Column(nullable = false)
   private Integer historyTimeToLive;
 
-  @Size(min = 0, max = 512)
-  @Column(nullable = true)
-  private String description;
-
+  @Getter
+  @Setter
   @Column(nullable = false)
   private boolean active;
 
+  @Getter
+  @Setter
   @Column(unique = true)
   private String deploymentId;
 
+  @Getter
+  @Setter
   @Embedded
   private Setup setup;
 
+  @Getter
+  @Setter
   @OneToMany
   @OrderColumn
   private List<Node> nodes;
 
+  @Getter
+  @Setter
   @ElementCollection
   @CollectionTable(name = "workflow_initial_context", joinColumns = @JoinColumn(name = "workflow_id"))
   @MapKeyColumn(name = "context_key")
@@ -69,82 +92,11 @@ public class Workflow extends AbstractBaseEntity {
 
   public Workflow() {
     super();
+
     active = false;
     nodes = new ArrayList<Node>();
     initialContext = new HashMap<String, JsonNode>();
     historyTimeToLive = 0;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public String getVersionTag() {
-    return versionTag;
-  }
-
-  public void setVersionTag(String versionTag) {
-    this.versionTag = versionTag;
-  }
-
-  public Integer getHistoryTimeToLive() {
-    return historyTimeToLive;
-  }
-
-  public void setHistoryTimeToLive(Integer historyTimeToLive) {
-    this.historyTimeToLive = historyTimeToLive;
-  }
-
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  public boolean isActive() {
-    return active;
-  }
-
-  public void setActive(boolean active) {
-    this.active = active;
-  }
-
-  public String getDeploymentId() {
-    return deploymentId;
-  }
-
-  public void setDeploymentId(String deploymentId) {
-    this.deploymentId = deploymentId;
-  }
-
-  public Setup getSetup() {
-    return setup;
-  }
-
-  public void setSetup(Setup setup) {
-    this.setup = setup;
-  }
-
-  public List<Node> getNodes() {
-    return nodes;
-  }
-
-  public void setNodes(List<Node> nodes) {
-    this.nodes = nodes;
-  }
-
-  public Map<String, JsonNode> getInitialContext() {
-    return initialContext;
-  }
-
-  public void setInitialContext(Map<String, JsonNode> initialContext) {
-    this.initialContext = initialContext;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/components/Branch.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/components/Branch.java
@@ -1,13 +1,7 @@
 package org.folio.rest.workflow.model.components;
 
-import java.util.List;
+import org.folio.rest.workflow.model.has.HasNodes;
 
-import org.folio.rest.workflow.model.Node;
-
-public interface Branch {
-
-  public List<Node> getNodes();
-
-  public void setNodes(List<Node> nodes);
+public interface Branch extends HasNodes {
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/components/Conditional.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/components/Conditional.java
@@ -1,13 +1,8 @@
 package org.folio.rest.workflow.model.components;
 
-public interface Conditional {
+import org.folio.rest.workflow.model.has.HasAnswer;
+import org.folio.rest.workflow.model.has.HasExpression;
 
-  public String getExpression();
-
-  public void setExpression(String expression);
-
-  public String getAnswer();
-
-  public void setAnswer(String answer);
+public interface Conditional extends HasAnswer, HasExpression {
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/components/DelegateTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/components/DelegateTask.java
@@ -1,17 +1,7 @@
 package org.folio.rest.workflow.model.components;
 
-import java.util.Set;
+import org.folio.rest.workflow.model.has.HasInputOutput;
 
-import org.folio.rest.workflow.model.EmbeddedVariable;
-
-public interface DelegateTask extends Task {
-
-  public Set<EmbeddedVariable> getInputVariables();
-
-  public void setInputVariables(Set<EmbeddedVariable> inputVariables);
-
-  public EmbeddedVariable getOutputVariable();
-
-  public void setOutputVariable(EmbeddedVariable outputVariable);
+public interface DelegateTask extends HasInputOutput, Task {
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/components/Gateway.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/components/Gateway.java
@@ -1,6 +1,6 @@
 package org.folio.rest.workflow.model.components;
 
-import org.folio.rest.workflow.model.Direction;
+import org.folio.rest.workflow.enums.Direction;
 
 public interface Gateway extends Branch {
 

--- a/components/src/main/java/org/folio/rest/workflow/model/components/Gateway.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/components/Gateway.java
@@ -1,11 +1,7 @@
 package org.folio.rest.workflow.model.components;
 
-import org.folio.rest.workflow.enums.Direction;
+import org.folio.rest.workflow.model.has.HasDirection;
 
-public interface Gateway extends Branch {
-
-  public Direction getDirection();
-
-  public void setDirection(Direction direction);
+public interface Gateway extends Branch, HasDirection {
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/components/MultiInstance.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/components/MultiInstance.java
@@ -11,5 +11,4 @@ public interface MultiInstance {
   public default boolean isMultiInstance() {
     return getLoopRef() != null && (getLoopRef().hasCardinalityExpression() || getLoopRef().hasDataInput());
   }
-
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/components/Navigation.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/components/Navigation.java
@@ -1,5 +1,7 @@
 package org.folio.rest.workflow.model.components;
 
-public interface Navigation {
+import org.folio.rest.workflow.model.has.HasNodeId;
+
+public interface Navigation extends HasNodeId {
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/components/Task.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/components/Task.java
@@ -1,13 +1,7 @@
 package org.folio.rest.workflow.model.components;
 
-public interface Task {
+import org.folio.rest.workflow.model.has.HasAsync;
 
-  public boolean isAsyncBefore();
-
-  public void setAsyncBefore(boolean asyncBefore);
-
-  public boolean isAsyncAfter();
-
-  public void setAsyncAfter(boolean asyncAfter);
+public interface Task extends HasAsync {
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/components/Wait.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/components/Wait.java
@@ -1,9 +1,7 @@
 package org.folio.rest.workflow.model.components;
 
-public interface Wait extends Task {
+import org.folio.rest.workflow.model.has.HasMessage;
 
-  public String getMessage();
-
-  public void setMessage(String mesasge);
+public interface Wait extends HasMessage, Task {
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/has/HasAnswer.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/HasAnswer.java
@@ -1,0 +1,11 @@
+package org.folio.rest.workflow.model.has;
+
+/**
+ * This interface provides the Answer methods.
+ */
+public interface HasAnswer {
+
+  public String getAnswer();
+
+  public void setAnswer(String answer);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/HasAsync.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/HasAsync.java
@@ -1,0 +1,16 @@
+package org.folio.rest.workflow.model.has;
+
+/**
+ * This interface provides the Camunda-specific Asynchronous related methods.
+ *
+ * This should likely be changed in some way once the Camunda-specific functionality is refactored out.
+ */
+public interface HasAsync {
+
+  public boolean isAsyncAfter();
+  public boolean isAsyncBefore();
+
+  public void setAsyncAfter(boolean asyncAfter);
+  public void setAsyncBefore(boolean asyncBefore);
+
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/HasCode.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/HasCode.java
@@ -1,0 +1,11 @@
+package org.folio.rest.workflow.model.has;
+
+/**
+ * This interface provides the Code methods.
+ */
+public interface HasCode {
+
+  public String getCode();
+
+  public void setCode(String code);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/HasDeploymentId.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/HasDeploymentId.java
@@ -1,0 +1,11 @@
+package org.folio.rest.workflow.model.has;
+
+/**
+ * This interface provides the DeploymentId methods.
+ */
+public interface HasDeploymentId {
+
+  public String getDeploymentId();
+
+  public void setDeploymentId(String deploymentId);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/HasDesignation.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/HasDesignation.java
@@ -1,0 +1,11 @@
+package org.folio.rest.workflow.model.has;
+
+/**
+ * This interface provides the Designation methods.
+ */
+public interface HasDesignation {
+
+  public String getDesignation();
+
+  public void setDesignation(String designation);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/HasDirection.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/HasDirection.java
@@ -1,0 +1,11 @@
+package org.folio.rest.workflow.model.has;
+
+import org.folio.rest.workflow.enums.Direction;
+
+public interface HasDirection {
+
+  public Direction getDirection();
+
+  public void setDirection(Direction direction);
+
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/HasExpression.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/HasExpression.java
@@ -1,0 +1,11 @@
+package org.folio.rest.workflow.model.has;
+
+/**
+ * This interface provides the Expression methods.
+ */
+public interface HasExpression {
+
+  public String getExpression();
+
+  public void setExpression(String expression);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/HasId.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/HasId.java
@@ -1,0 +1,15 @@
+package org.folio.rest.workflow.model.has;
+
+/**
+ * This interface provides the ID methods to be defined.
+ *
+ * This is intended to be used by just about every model.
+ * This has its own dedicated interface for cases where the UI may only need a list of IDs returned.
+ * This may often times be combined with {@link org.folio.rest.workflow.model.has.HasName HasName} to create a standard select list.
+ */
+public interface HasId {
+
+  public String getId();
+
+  public void setId(String id);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/HasInformational.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/HasInformational.java
@@ -1,0 +1,14 @@
+package org.folio.rest.workflow.model.has;
+
+/**
+ * This interface provides core methods classified as "informational".
+ *
+ * These methods are used to provide additional useful information.
+ * This is a list of those methods that are shared across most models.
+ */
+public interface HasInformational {
+
+  public String getDescription();
+
+  public void setDescription(String description);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/HasInputOutput.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/HasInputOutput.java
@@ -4,7 +4,7 @@ import java.util.Set;
 import org.folio.rest.workflow.model.EmbeddedVariable;
 
 /**
- * This interface provides methods associated with Nodes.
+ * This interface provides methods associated with {@link org.folio.rest.workflow.model.EmbeddedVariable EmbeddedVariables}.
  */
 public interface HasInputOutput {
 

--- a/components/src/main/java/org/folio/rest/workflow/model/has/HasInputOutput.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/HasInputOutput.java
@@ -1,0 +1,17 @@
+package org.folio.rest.workflow.model.has;
+
+import java.util.Set;
+import org.folio.rest.workflow.model.EmbeddedVariable;
+
+/**
+ * This interface provides methods associated with Nodes.
+ */
+public interface HasInputOutput {
+
+  public Set<EmbeddedVariable> getInputVariables();
+  public EmbeddedVariable getOutputVariable();
+
+  public void setInputVariables(Set<EmbeddedVariable> inputVariables);
+  public void setOutputVariable(EmbeddedVariable outputVariable);
+
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/HasMessage.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/HasMessage.java
@@ -1,0 +1,11 @@
+package org.folio.rest.workflow.model.has;
+
+/**
+ * This interface provides the Message methods.
+ */
+public interface HasMessage {
+
+  public String getMessage();
+
+  public void setMessage(String mesasge);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/HasMethod.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/HasMethod.java
@@ -1,0 +1,13 @@
+package org.folio.rest.workflow.model.has;
+
+import org.springframework.http.HttpMethod;
+
+/**
+ * This interface provides the "method" methods.
+ */
+public interface HasMethod {
+
+  public HttpMethod getMethod();
+
+  public void setMethod(HttpMethod method);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/HasName.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/HasName.java
@@ -1,0 +1,15 @@
+package org.folio.rest.workflow.model.has;
+
+/**
+ * This interface provides the Name methods to be defined.
+ *
+ * This is intended to be used by just about every model.
+ * This has its own dedicated interface for cases where the UI may only need a list of Names returned.
+ * This may often times be combined with {@link org.folio.rest.workflow.model.has.HasId HasId} to create a standard select list.
+ */
+public interface HasName {
+
+  public String getName();
+
+  public void setName(String name);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/HasNodeId.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/HasNodeId.java
@@ -1,0 +1,11 @@
+package org.folio.rest.workflow.model.has;
+
+/**
+ * This interface provides the Node ID methods.
+ */
+public interface HasNodeId {
+
+  public String getNodeId();
+
+  public void setNodeId(String nodeId);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/HasNodes.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/HasNodes.java
@@ -1,0 +1,14 @@
+package org.folio.rest.workflow.model.has;
+
+import java.util.List;
+import org.folio.rest.workflow.model.Node;
+
+/**
+ * This interface provides methods associated with Nodes.
+ */
+public interface HasNodes {
+
+  public List<Node> getNodes();
+
+  public void setNodes(List<Node> nodes);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/HasNodes.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/HasNodes.java
@@ -4,7 +4,7 @@ import java.util.List;
 import org.folio.rest.workflow.model.Node;
 
 /**
- * This interface provides methods associated with Nodes.
+ * This interface provides methods associated with {@link org.folio.rest.workflow.model.Node Nodes}.
  */
 public interface HasNodes {
 

--- a/components/src/main/java/org/folio/rest/workflow/model/has/HasPassword.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/HasPassword.java
@@ -1,0 +1,15 @@
+package org.folio.rest.workflow.model.has;
+
+/**
+ * This interface provides the Password methods.
+ *
+ * The password usually should not be transmitted.
+ * This is broken out into a separate interface so that it may be manually ignored.
+ * This should not be part of any "common" interface but should instead be explicitly added for security reasons.
+ */
+public interface HasPassword {
+
+  public String getPassword();
+
+  public void setPassword(String password);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/HasPath.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/HasPath.java
@@ -1,0 +1,11 @@
+package org.folio.rest.workflow.model.has;
+
+/**
+ * This interface provides the Path methods.
+ */
+public interface HasPath {
+
+  public String getPath();
+
+  public void setPath(String path);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/HasPathPattern.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/HasPathPattern.java
@@ -1,0 +1,11 @@
+package org.folio.rest.workflow.model.has;
+
+/**
+ * This interface provides the Path Pattern methods.
+ */
+public interface HasPathPattern {
+
+  public String getPathPattern();
+
+  public void setPathPattern(String pathPattern);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/HasService.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/HasService.java
@@ -1,0 +1,17 @@
+package org.folio.rest.workflow.model.has;
+
+/**
+ * This interface provides the Service connection related methods.
+ */
+public interface HasService extends HasUsername {
+
+  public String getBasePath();
+  public String getHost();
+  public int getPort();
+  public String getScheme();
+
+  public void setBasePath(String basePath);
+  public void setHost(String host);
+  public void setPort(int port);
+  public void setScheme(String scheme);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/HasUrl.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/HasUrl.java
@@ -1,0 +1,13 @@
+package org.folio.rest.workflow.model.has;
+
+/**
+ * This interface provides the URL methods.
+ *
+ * This should be broken-up and replaced with the HasService method.
+ */
+public interface HasUrl {
+
+  public String getUrl();
+
+  public void setUrl(String url);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/HasUsername.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/HasUsername.java
@@ -1,0 +1,14 @@
+package org.folio.rest.workflow.model.has;
+
+/**
+ * This interface provides the User Name methods.
+ *
+ * This is broken-out because of the current situation between HasService and HasUrl.
+ * Once HasUrl is fully replaced with HasService, then this should be moved into HasService and this HasUsername can be fully removed.
+ */
+public interface HasUsername {
+
+  public String getUsername();
+
+  public void setUsername(String username);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/HasVersionTag.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/HasVersionTag.java
@@ -1,0 +1,13 @@
+package org.folio.rest.workflow.model.has;
+
+/**
+ * This interface provides the Camunda-specific Version Tag methods.
+ *
+ * This should be replaced with HasVersioning once Camunda-specific code is refactored out.
+ */
+public interface HasVersionTag {
+
+  public String getVersionTag();
+
+  public void setVersionTag(String versionTag);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/HasVersioning.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/HasVersioning.java
@@ -1,0 +1,18 @@
+package org.folio.rest.workflow.model.has;
+
+/**
+ * This interface provides core methods classified as "versioning".
+ *
+ * These methods are used to provide tracking of particular version related details.
+ * This is a list of those methods that are shared across most models.
+ *
+ * Some models have "versionTag", which is camunda-specific.
+ * Such models should implement this for consistency purposes and then have these call the getVersionTag() or setVersionTag() for getVersion() and setVersion().
+ * This behavior should be removed once Camunda-specific functionality is refactored out.
+ */
+public interface HasVersioning {
+
+  public String getVersion();
+
+  public void setVersion(String version);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/common/HasCompressFileTaskCommon.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/common/HasCompressFileTaskCommon.java
@@ -1,0 +1,20 @@
+package org.folio.rest.workflow.model.has.common;
+
+import org.folio.rest.workflow.enums.CompressFileContainer;
+import org.folio.rest.workflow.enums.CompressFileFormat;
+
+/**
+ * This interface provides common methods for {@link org.folio.rest.workflow.model.CompressFileTask CompressFileTask}.
+ */
+public interface HasCompressFileTaskCommon {
+
+  public CompressFileContainer getContainer();
+  public String getDestination();
+  public CompressFileFormat getFormat();
+  public String getSource();
+
+  public void setContainer(CompressFileContainer container);
+  public void setDestination(String destination);
+  public void setFormat(CompressFileFormat format);
+  public void setSource(String source);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/common/HasDatabaseQueryTaskCommon.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/common/HasDatabaseQueryTaskCommon.java
@@ -1,0 +1,19 @@
+package org.folio.rest.workflow.model.has.common;
+
+import org.folio.rest.workflow.enums.DatabaseResultType;
+
+/**
+ * This interface provides common methods for {@link org.folio.rest.workflow.model.DatabaseQueryTask DatabaseQueryTask}.
+ */
+public interface HasDatabaseQueryTaskCommon {
+
+  public Boolean getIncludeHeader();
+  public String getOutputPath();
+  public String getQuery();
+  public DatabaseResultType getResultType();
+
+  public void setIncludeHeader(Boolean includeHeader);
+  public void setOutputPath(String outputPath);
+  public void setQuery(String query);
+  public void setResultType(DatabaseResultType resultType);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/common/HasDirectoryTaskCommon.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/common/HasDirectoryTaskCommon.java
@@ -1,0 +1,15 @@
+package org.folio.rest.workflow.model.has.common;
+
+import org.folio.rest.workflow.enums.DirectoryAction;
+
+/**
+ * This interface provides common methods for {@link org.folio.rest.workflow.model.DirectoryTask DirectoryTask}.
+ */
+public interface HasDirectoryTaskCommon {
+
+  public DirectoryAction getAction();
+  public String getWorkflow();
+
+  public void setAction(DirectoryAction action);
+  public void setWorkflow(String workflow);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/common/HasEmailTaskCommon.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/common/HasEmailTaskCommon.java
@@ -1,0 +1,27 @@
+package org.folio.rest.workflow.model.has.common;
+
+/**
+ * This interface provides common methods for {@link org.folio.rest.workflow.model.EmailTask EmailTask}.
+ */
+public interface HasEmailTaskCommon {
+
+  public String getAttachmentPath();
+  public String getIncludeAttachment();
+  public String getMailBcc();
+  public String getMailCc();
+  public String getMailFrom();
+  public String getMailMarkup();
+  public String getMailSubject();
+  public String getMailText();
+  public String getMailTo();
+
+  public void setAttachmentPath(String attachmentPath);
+  public void setIncludeAttachment(String includeAttachment);
+  public void setMailBcc(String mailBcc);
+  public void setMailCc(String mailCc);
+  public void setMailFrom(String mailFrom);
+  public void setMailMarkup(String mailMarkup);
+  public void setMailSubject(String mailSubject);
+  public void setMailText(String mailText);
+  public void setMailTo(String mailTo);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/common/HasEmbeddedLoopReferenceCommon.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/common/HasEmbeddedLoopReferenceCommon.java
@@ -1,0 +1,22 @@
+package org.folio.rest.workflow.model.has.common;
+
+/**
+ * This interface provides common methods for {@link org.folio.rest.workflow.model.EmbeddedLoopReference EmbeddedLoopReference}.
+ */
+public interface HasEmbeddedLoopReferenceCommon {
+
+  public String getCardinalityExpression();
+  public String getCompleteConditionExpression();
+  public String getDataInputRefExpression();
+  public String getInputDataName();
+  public boolean hasCardinalityExpression();
+  public boolean hasCompleteConditionExpression();
+  public boolean hasDataInput();
+  public boolean isParallel();
+
+  public void setCardinalityExpression(String cardinalityExpression);
+  public void setCompleteConditionExpression(String completeConditionExpression);
+  public void setDataInputRefExpression(String dataInputRefExpression);
+  public void setInputDataName(String inputDataName);
+  public void setParallel(boolean parallel);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/common/HasEmbeddedProcessorCommon.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/common/HasEmbeddedProcessorCommon.java
@@ -1,0 +1,21 @@
+package org.folio.rest.workflow.model.has.common;
+
+import org.folio.rest.workflow.enums.ScriptType;
+
+/**
+ * This interface provides common methods for {@link org.folio.rest.workflow.model.EmbeddedProcessor EmbeddedProcessor}.
+ */
+public interface HasEmbeddedProcessorCommon {
+
+  public int getBuffer();
+  public String getCode();
+  public int getDelay();
+  public String getFunctionName();
+  public ScriptType getScriptType();
+
+  public void setBuffer(int buffer);
+  public void setCode(String code);
+  public void setDelay(int delay);
+  public void setFunctionName(String functionName);
+  public void setScriptType(ScriptType scriptType);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/common/HasEmbeddedRequestCommon.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/common/HasEmbeddedRequestCommon.java
@@ -1,0 +1,25 @@
+package org.folio.rest.workflow.model.has.common;
+
+import org.springframework.http.HttpMethod;
+
+/**
+ * This interface provides common methods for {@link org.folio.rest.workflow.model.EmbeddedRequest EmbeddedRequest}.
+ */
+public interface HasEmbeddedRequestCommon {
+
+  public String getAccept();
+  public String getBodyTemplate();
+  public String getContentType();
+  public String getIterableKey();
+  public HttpMethod getMethod();
+  public String getResponseKey() ;
+  public boolean isIterable();
+
+  public void setAccept(String accept);
+  public void setBodyTemplate(String bodyTemplate);
+  public void setContentType(String contentType);
+  public void setIterable(boolean iterable);
+  public void setIterableKey(String iterableKey);
+  public void setMethod(HttpMethod method);
+  public void setResponseKey(String responseKey);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/common/HasEmbeddedVariableCommon.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/common/HasEmbeddedVariableCommon.java
@@ -1,0 +1,21 @@
+package org.folio.rest.workflow.model.has.common;
+
+import org.folio.rest.workflow.enums.VariableType;
+
+/**
+ * This interface provides common methods for {@link org.folio.rest.workflow.model.EmbeddedVariable EmbeddedVariable}.
+ */
+public interface HasEmbeddedVariableCommon {
+
+  public Boolean getAsJson();
+  public Boolean getAsTransient();
+  public VariableType getType();
+  public String getKey();
+  public boolean isSpin();
+
+  public void setAsJson(Boolean asJson);
+  public void setAsTransient(Boolean asTransient);
+  public void setType(VariableType type);
+  public void setKey(String key);
+  public void setSpin(boolean spin);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/common/HasFileTaskCommon.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/common/HasFileTaskCommon.java
@@ -1,0 +1,17 @@
+package org.folio.rest.workflow.model.has.common;
+
+import org.folio.rest.workflow.enums.FileOp;
+
+/**
+ * This interface provides common methods for {@link org.folio.rest.workflow.model.FileTask FileTask}.
+ */
+public interface HasFileTaskCommon {
+
+  public String getLine();
+  public FileOp getOp();
+  public String getTarget();
+
+  public void setLine(String line);
+  public void setOp(FileOp op);
+  public void setTarget(String target);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/common/HasFtpTaskCommon.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/common/HasFtpTaskCommon.java
@@ -1,0 +1,17 @@
+package org.folio.rest.workflow.model.has.common;
+
+import org.folio.rest.workflow.enums.SftpOp;
+
+/**
+ * This interface provides common methods for {@link org.folio.rest.workflow.model.FtpTask FtpTask}.
+ */
+public interface HasFtpTaskCommon {
+
+  public String getDestinationPath();
+  public SftpOp getOp();
+  public String getOriginPath();
+
+  public void setDestinationPath(String destinationPath);
+  public void setOp(SftpOp op);
+  public void setOriginPath(String originPath);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/common/HasMoveToNodeCommon.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/common/HasMoveToNodeCommon.java
@@ -1,0 +1,11 @@
+package org.folio.rest.workflow.model.has.common;
+
+/**
+ * This interface provides common methods for {@link org.folio.rest.workflow.model.MoveToNode MoveToNode}.
+ */
+public interface HasMoveToNodeCommon {
+
+  public String getGatewayId();
+
+  public void setGatewayId(String gatewayId);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/common/HasNodeCommon.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/common/HasNodeCommon.java
@@ -1,0 +1,12 @@
+package org.folio.rest.workflow.model.has.common;
+
+/**
+ * This interface provides common methods for {@link org.folio.rest.workflow.model.Node Node}.
+ */
+public interface HasNodeCommon {
+
+  public String getDeserializeAs();
+  public String getIdentifier();
+
+  public void setDeserializeAs(String deserializeAs);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/common/HasProcessorTaskCommon.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/common/HasProcessorTaskCommon.java
@@ -1,0 +1,13 @@
+package org.folio.rest.workflow.model.has.common;
+
+import org.folio.rest.workflow.model.EmbeddedProcessor;
+
+/**
+ * This interface provides common methods for {@link org.folio.rest.workflow.model.ProcessorTask ProcessorTask}.
+ */
+public interface HasProcessorTaskCommon {
+
+  public EmbeddedProcessor getProcessor();
+
+  public void setProcessor(EmbeddedProcessor processor);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/common/HasRequestTaskCommon.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/common/HasRequestTaskCommon.java
@@ -1,0 +1,17 @@
+package org.folio.rest.workflow.model.has.common;
+
+import java.util.Set;
+import org.folio.rest.workflow.model.EmbeddedRequest;
+import org.folio.rest.workflow.model.EmbeddedVariable;
+
+/**
+ * This interface provides common methods for {@link org.folio.rest.workflow.model.RequestTask RequestTask}.
+ */
+public interface HasRequestTaskCommon {
+
+  public Set<EmbeddedVariable> getHeaderOutputVariables();
+  public EmbeddedRequest getRequest();
+
+  public void setHeaderOutputVariables(Set<EmbeddedVariable> headerOutputVariables);
+  public void setRequest(EmbeddedRequest request);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/common/HasScriptTaskCommon.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/common/HasScriptTaskCommon.java
@@ -1,0 +1,15 @@
+package org.folio.rest.workflow.model.has.common;
+
+/**
+ * This interface provides common methods for {@link org.folio.rest.workflow.model.ScriptTask ScriptTask}.
+ */
+public interface HasScriptTaskCommon {
+
+  public String getResultVariable();
+  public String getScriptFormat();
+
+  public void setResultVariable(String resultVariable);
+  public void setScriptFormat(String scriptFormat);
+
+  public boolean hasResultVariable();
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/common/HasWorkflowCommon.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/common/HasWorkflowCommon.java
@@ -1,0 +1,23 @@
+package org.folio.rest.workflow.model.has.common;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Map;
+import org.folio.rest.workflow.model.Setup;
+
+/**
+ * This interface provides common methods for {@link org.folio.rest.workflow.model.Workflow Workflow}.
+ */
+public interface HasWorkflowCommon {
+
+  public String getDeploymentId();
+  public Integer getHistoryTimeToLive();
+  public Map<String, JsonNode> getInitialContext();
+  public Setup getSetup();
+  public boolean isActive();
+
+  public void setActive(boolean active);
+  public void setDeploymentId(String deploymentId);
+  public void setHistoryTimeToLive(Integer historyTimeToLive);
+  public void setInitialContext(Map<String, JsonNode> initialContext);
+  public void setSetup(Setup setup);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/common/HasWorkflowCommon.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/common/HasWorkflowCommon.java
@@ -9,14 +9,12 @@ import org.folio.rest.workflow.model.Setup;
  */
 public interface HasWorkflowCommon {
 
-  public String getDeploymentId();
   public Integer getHistoryTimeToLive();
   public Map<String, JsonNode> getInitialContext();
   public Setup getSetup();
   public boolean isActive();
 
   public void setActive(boolean active);
-  public void setDeploymentId(String deploymentId);
   public void setHistoryTimeToLive(Integer historyTimeToLive);
   public void setInitialContext(Map<String, JsonNode> initialContext);
   public void setSetup(Setup setup);

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -200,6 +200,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/service/ramls/directorytask.json
+++ b/service/ramls/directorytask.json
@@ -21,16 +21,6 @@
       "type" : "string",
       "maxLength" : 512
     },
-    "path" : {
-      "type" : "string"
-    },
-    "workflow" : {
-      "type" : "string"
-    },
-    "action" : {
-      "type" : "string",
-      "enum" : [ "READ_NEXT", "DELETE_NEXT", "LIST", "WRITE" ]
-    },
     "inputVariables" : {
       "type" : "array",
       "items" : {
@@ -46,11 +36,21 @@
     "asyncAfter" : {
       "type" : "boolean"
     },
+    "path" : {
+      "type" : "string"
+    },
+    "workflow" : {
+      "type" : "string"
+    },
+    "action" : {
+      "type" : "string",
+      "enum" : [ "READ_NEXT", "DELETE_NEXT", "LIST", "WRITE" ]
+    },
     "identifier" : {
       "type" : "string"
     }
   },
-  "required" : [ "deserializeAs", "name", "path", "workflow", "action", "asyncBefore", "asyncAfter" ],
+  "required" : [ "deserializeAs", "name", "asyncBefore", "asyncAfter", "path", "workflow", "action" ],
   "definitions" : {
     "EmbeddedVariable" : {
       "type" : "object",

--- a/service/ramls/eventsubprocess.json
+++ b/service/ramls/eventsubprocess.json
@@ -21,6 +21,12 @@
       "type" : "string",
       "maxLength" : 512
     },
+    "asyncBefore" : {
+      "type" : "boolean"
+    },
+    "asyncAfter" : {
+      "type" : "boolean"
+    },
     "nodes" : {
       "type" : "array",
       "items" : {
@@ -77,7 +83,7 @@
       "type" : "string"
     }
   },
-  "required" : [ "deserializeAs", "name" ],
+  "required" : [ "deserializeAs", "name", "asyncBefore", "asyncAfter" ],
   "definitions" : {
     "StartEvent" : {
       "type" : "object",
@@ -755,6 +761,12 @@
           "type" : "string",
           "maxLength" : 512
         },
+        "asyncBefore" : {
+          "type" : "boolean"
+        },
+        "asyncAfter" : {
+          "type" : "boolean"
+        },
         "nodes" : {
           "type" : "array",
           "items" : {
@@ -812,7 +824,7 @@
         }
       },
       "title" : "EventSubprocess",
-      "required" : [ "deserializeAs", "name" ]
+      "required" : [ "deserializeAs", "name", "asyncBefore", "asyncAfter" ]
     },
     "CompressFileTask" : {
       "type" : "object",
@@ -1250,6 +1262,9 @@
         "password" : {
           "type" : "string"
         },
+        "basePath" : {
+          "type" : "string"
+        },
         "identifier" : {
           "type" : "string"
         }
@@ -1278,9 +1293,6 @@
           "type" : "string",
           "maxLength" : 512
         },
-        "request" : {
-          "$ref" : "#/definitions/EmbeddedRequest"
-        },
         "inputVariables" : {
           "type" : "array",
           "items" : {
@@ -1301,6 +1313,9 @@
         },
         "asyncAfter" : {
           "type" : "boolean"
+        },
+        "request" : {
+          "$ref" : "#/definitions/EmbeddedRequest"
         },
         "identifier" : {
           "type" : "string"
@@ -1362,16 +1377,6 @@
           "type" : "string",
           "maxLength" : 512
         },
-        "path" : {
-          "type" : "string"
-        },
-        "workflow" : {
-          "type" : "string"
-        },
-        "action" : {
-          "type" : "string",
-          "enum" : [ "READ_NEXT", "DELETE_NEXT", "LIST", "WRITE" ]
-        },
         "inputVariables" : {
           "type" : "array",
           "items" : {
@@ -1387,12 +1392,22 @@
         "asyncAfter" : {
           "type" : "boolean"
         },
+        "path" : {
+          "type" : "string"
+        },
+        "workflow" : {
+          "type" : "string"
+        },
+        "action" : {
+          "type" : "string",
+          "enum" : [ "READ_NEXT", "DELETE_NEXT", "LIST", "WRITE" ]
+        },
         "identifier" : {
           "type" : "string"
         }
       },
       "title" : "DirectoryTask",
-      "required" : [ "deserializeAs", "name", "path", "workflow", "action", "asyncBefore", "asyncAfter" ]
+      "required" : [ "deserializeAs", "name", "asyncBefore", "asyncAfter", "path", "workflow", "action" ]
     },
     "ReceiveTask" : {
       "type" : "object",
@@ -1454,9 +1469,6 @@
           "type" : "string",
           "maxLength" : 512
         },
-        "processor" : {
-          "$ref" : "#/definitions/EmbeddedProcessor"
-        },
         "inputVariables" : {
           "type" : "array",
           "items" : {
@@ -1471,6 +1483,9 @@
         },
         "asyncAfter" : {
           "type" : "boolean"
+        },
+        "processor" : {
+          "$ref" : "#/definitions/EmbeddedProcessor"
         },
         "identifier" : {
           "type" : "string"

--- a/service/ramls/exclusivegateway.json
+++ b/service/ramls/exclusivegateway.json
@@ -759,6 +759,12 @@
           "type" : "string",
           "maxLength" : 512
         },
+        "asyncBefore" : {
+          "type" : "boolean"
+        },
+        "asyncAfter" : {
+          "type" : "boolean"
+        },
         "nodes" : {
           "type" : "array",
           "items" : {
@@ -816,7 +822,7 @@
         }
       },
       "title" : "EventSubprocess",
-      "required" : [ "deserializeAs", "name" ]
+      "required" : [ "deserializeAs", "name", "asyncBefore", "asyncAfter" ]
     },
     "CompressFileTask" : {
       "type" : "object",
@@ -1254,6 +1260,9 @@
         "password" : {
           "type" : "string"
         },
+        "basePath" : {
+          "type" : "string"
+        },
         "identifier" : {
           "type" : "string"
         }
@@ -1282,9 +1291,6 @@
           "type" : "string",
           "maxLength" : 512
         },
-        "request" : {
-          "$ref" : "#/definitions/EmbeddedRequest"
-        },
         "inputVariables" : {
           "type" : "array",
           "items" : {
@@ -1305,6 +1311,9 @@
         },
         "asyncAfter" : {
           "type" : "boolean"
+        },
+        "request" : {
+          "$ref" : "#/definitions/EmbeddedRequest"
         },
         "identifier" : {
           "type" : "string"
@@ -1366,16 +1375,6 @@
           "type" : "string",
           "maxLength" : 512
         },
-        "path" : {
-          "type" : "string"
-        },
-        "workflow" : {
-          "type" : "string"
-        },
-        "action" : {
-          "type" : "string",
-          "enum" : [ "READ_NEXT", "DELETE_NEXT", "LIST", "WRITE" ]
-        },
         "inputVariables" : {
           "type" : "array",
           "items" : {
@@ -1391,12 +1390,22 @@
         "asyncAfter" : {
           "type" : "boolean"
         },
+        "path" : {
+          "type" : "string"
+        },
+        "workflow" : {
+          "type" : "string"
+        },
+        "action" : {
+          "type" : "string",
+          "enum" : [ "READ_NEXT", "DELETE_NEXT", "LIST", "WRITE" ]
+        },
         "identifier" : {
           "type" : "string"
         }
       },
       "title" : "DirectoryTask",
-      "required" : [ "deserializeAs", "name", "path", "workflow", "action", "asyncBefore", "asyncAfter" ]
+      "required" : [ "deserializeAs", "name", "asyncBefore", "asyncAfter", "path", "workflow", "action" ]
     },
     "ReceiveTask" : {
       "type" : "object",
@@ -1458,9 +1467,6 @@
           "type" : "string",
           "maxLength" : 512
         },
-        "processor" : {
-          "$ref" : "#/definitions/EmbeddedProcessor"
-        },
         "inputVariables" : {
           "type" : "array",
           "items" : {
@@ -1475,6 +1481,9 @@
         },
         "asyncAfter" : {
           "type" : "boolean"
+        },
+        "processor" : {
+          "$ref" : "#/definitions/EmbeddedProcessor"
         },
         "identifier" : {
           "type" : "string"

--- a/service/ramls/ftptask.json
+++ b/service/ramls/ftptask.json
@@ -61,6 +61,9 @@
     "password" : {
       "type" : "string"
     },
+    "basePath" : {
+      "type" : "string"
+    },
     "identifier" : {
       "type" : "string"
     }

--- a/service/ramls/inclusivegateway.json
+++ b/service/ramls/inclusivegateway.json
@@ -759,6 +759,12 @@
           "type" : "string",
           "maxLength" : 512
         },
+        "asyncBefore" : {
+          "type" : "boolean"
+        },
+        "asyncAfter" : {
+          "type" : "boolean"
+        },
         "nodes" : {
           "type" : "array",
           "items" : {
@@ -816,7 +822,7 @@
         }
       },
       "title" : "EventSubprocess",
-      "required" : [ "deserializeAs", "name" ]
+      "required" : [ "deserializeAs", "name", "asyncBefore", "asyncAfter" ]
     },
     "CompressFileTask" : {
       "type" : "object",
@@ -1254,6 +1260,9 @@
         "password" : {
           "type" : "string"
         },
+        "basePath" : {
+          "type" : "string"
+        },
         "identifier" : {
           "type" : "string"
         }
@@ -1282,9 +1291,6 @@
           "type" : "string",
           "maxLength" : 512
         },
-        "request" : {
-          "$ref" : "#/definitions/EmbeddedRequest"
-        },
         "inputVariables" : {
           "type" : "array",
           "items" : {
@@ -1305,6 +1311,9 @@
         },
         "asyncAfter" : {
           "type" : "boolean"
+        },
+        "request" : {
+          "$ref" : "#/definitions/EmbeddedRequest"
         },
         "identifier" : {
           "type" : "string"
@@ -1366,16 +1375,6 @@
           "type" : "string",
           "maxLength" : 512
         },
-        "path" : {
-          "type" : "string"
-        },
-        "workflow" : {
-          "type" : "string"
-        },
-        "action" : {
-          "type" : "string",
-          "enum" : [ "READ_NEXT", "DELETE_NEXT", "LIST", "WRITE" ]
-        },
         "inputVariables" : {
           "type" : "array",
           "items" : {
@@ -1391,12 +1390,22 @@
         "asyncAfter" : {
           "type" : "boolean"
         },
+        "path" : {
+          "type" : "string"
+        },
+        "workflow" : {
+          "type" : "string"
+        },
+        "action" : {
+          "type" : "string",
+          "enum" : [ "READ_NEXT", "DELETE_NEXT", "LIST", "WRITE" ]
+        },
         "identifier" : {
           "type" : "string"
         }
       },
       "title" : "DirectoryTask",
-      "required" : [ "deserializeAs", "name", "path", "workflow", "action", "asyncBefore", "asyncAfter" ]
+      "required" : [ "deserializeAs", "name", "asyncBefore", "asyncAfter", "path", "workflow", "action" ]
     },
     "ReceiveTask" : {
       "type" : "object",
@@ -1458,9 +1467,6 @@
           "type" : "string",
           "maxLength" : 512
         },
-        "processor" : {
-          "$ref" : "#/definitions/EmbeddedProcessor"
-        },
         "inputVariables" : {
           "type" : "array",
           "items" : {
@@ -1475,6 +1481,9 @@
         },
         "asyncAfter" : {
           "type" : "boolean"
+        },
+        "processor" : {
+          "$ref" : "#/definitions/EmbeddedProcessor"
         },
         "identifier" : {
           "type" : "string"

--- a/service/ramls/movetolastgateway.json
+++ b/service/ramls/movetolastgateway.json
@@ -759,6 +759,12 @@
           "type" : "string",
           "maxLength" : 512
         },
+        "asyncBefore" : {
+          "type" : "boolean"
+        },
+        "asyncAfter" : {
+          "type" : "boolean"
+        },
         "nodes" : {
           "type" : "array",
           "items" : {
@@ -816,7 +822,7 @@
         }
       },
       "title" : "EventSubprocess",
-      "required" : [ "deserializeAs", "name" ]
+      "required" : [ "deserializeAs", "name", "asyncBefore", "asyncAfter" ]
     },
     "CompressFileTask" : {
       "type" : "object",
@@ -1254,6 +1260,9 @@
         "password" : {
           "type" : "string"
         },
+        "basePath" : {
+          "type" : "string"
+        },
         "identifier" : {
           "type" : "string"
         }
@@ -1282,9 +1291,6 @@
           "type" : "string",
           "maxLength" : 512
         },
-        "request" : {
-          "$ref" : "#/definitions/EmbeddedRequest"
-        },
         "inputVariables" : {
           "type" : "array",
           "items" : {
@@ -1305,6 +1311,9 @@
         },
         "asyncAfter" : {
           "type" : "boolean"
+        },
+        "request" : {
+          "$ref" : "#/definitions/EmbeddedRequest"
         },
         "identifier" : {
           "type" : "string"
@@ -1366,16 +1375,6 @@
           "type" : "string",
           "maxLength" : 512
         },
-        "path" : {
-          "type" : "string"
-        },
-        "workflow" : {
-          "type" : "string"
-        },
-        "action" : {
-          "type" : "string",
-          "enum" : [ "READ_NEXT", "DELETE_NEXT", "LIST", "WRITE" ]
-        },
         "inputVariables" : {
           "type" : "array",
           "items" : {
@@ -1391,12 +1390,22 @@
         "asyncAfter" : {
           "type" : "boolean"
         },
+        "path" : {
+          "type" : "string"
+        },
+        "workflow" : {
+          "type" : "string"
+        },
+        "action" : {
+          "type" : "string",
+          "enum" : [ "READ_NEXT", "DELETE_NEXT", "LIST", "WRITE" ]
+        },
         "identifier" : {
           "type" : "string"
         }
       },
       "title" : "DirectoryTask",
-      "required" : [ "deserializeAs", "name", "path", "workflow", "action", "asyncBefore", "asyncAfter" ]
+      "required" : [ "deserializeAs", "name", "asyncBefore", "asyncAfter", "path", "workflow", "action" ]
     },
     "ReceiveTask" : {
       "type" : "object",
@@ -1458,9 +1467,6 @@
           "type" : "string",
           "maxLength" : 512
         },
-        "processor" : {
-          "$ref" : "#/definitions/EmbeddedProcessor"
-        },
         "inputVariables" : {
           "type" : "array",
           "items" : {
@@ -1475,6 +1481,9 @@
         },
         "asyncAfter" : {
           "type" : "boolean"
+        },
+        "processor" : {
+          "$ref" : "#/definitions/EmbeddedProcessor"
         },
         "identifier" : {
           "type" : "string"

--- a/service/ramls/movetonode.json
+++ b/service/ramls/movetonode.json
@@ -758,6 +758,12 @@
           "type" : "string",
           "maxLength" : 512
         },
+        "asyncBefore" : {
+          "type" : "boolean"
+        },
+        "asyncAfter" : {
+          "type" : "boolean"
+        },
         "nodes" : {
           "type" : "array",
           "items" : {
@@ -815,7 +821,7 @@
         }
       },
       "title" : "EventSubprocess",
-      "required" : [ "deserializeAs", "name" ]
+      "required" : [ "deserializeAs", "name", "asyncBefore", "asyncAfter" ]
     },
     "CompressFileTask" : {
       "type" : "object",
@@ -1253,6 +1259,9 @@
         "password" : {
           "type" : "string"
         },
+        "basePath" : {
+          "type" : "string"
+        },
         "identifier" : {
           "type" : "string"
         }
@@ -1281,9 +1290,6 @@
           "type" : "string",
           "maxLength" : 512
         },
-        "request" : {
-          "$ref" : "#/definitions/EmbeddedRequest"
-        },
         "inputVariables" : {
           "type" : "array",
           "items" : {
@@ -1304,6 +1310,9 @@
         },
         "asyncAfter" : {
           "type" : "boolean"
+        },
+        "request" : {
+          "$ref" : "#/definitions/EmbeddedRequest"
         },
         "identifier" : {
           "type" : "string"
@@ -1365,16 +1374,6 @@
           "type" : "string",
           "maxLength" : 512
         },
-        "path" : {
-          "type" : "string"
-        },
-        "workflow" : {
-          "type" : "string"
-        },
-        "action" : {
-          "type" : "string",
-          "enum" : [ "READ_NEXT", "DELETE_NEXT", "LIST", "WRITE" ]
-        },
         "inputVariables" : {
           "type" : "array",
           "items" : {
@@ -1390,12 +1389,22 @@
         "asyncAfter" : {
           "type" : "boolean"
         },
+        "path" : {
+          "type" : "string"
+        },
+        "workflow" : {
+          "type" : "string"
+        },
+        "action" : {
+          "type" : "string",
+          "enum" : [ "READ_NEXT", "DELETE_NEXT", "LIST", "WRITE" ]
+        },
         "identifier" : {
           "type" : "string"
         }
       },
       "title" : "DirectoryTask",
-      "required" : [ "deserializeAs", "name", "path", "workflow", "action", "asyncBefore", "asyncAfter" ]
+      "required" : [ "deserializeAs", "name", "asyncBefore", "asyncAfter", "path", "workflow", "action" ]
     },
     "ReceiveTask" : {
       "type" : "object",
@@ -1457,9 +1466,6 @@
           "type" : "string",
           "maxLength" : 512
         },
-        "processor" : {
-          "$ref" : "#/definitions/EmbeddedProcessor"
-        },
         "inputVariables" : {
           "type" : "array",
           "items" : {
@@ -1474,6 +1480,9 @@
         },
         "asyncAfter" : {
           "type" : "boolean"
+        },
+        "processor" : {
+          "$ref" : "#/definitions/EmbeddedProcessor"
         },
         "identifier" : {
           "type" : "string"

--- a/service/ramls/parallelgateway.json
+++ b/service/ramls/parallelgateway.json
@@ -759,6 +759,12 @@
           "type" : "string",
           "maxLength" : 512
         },
+        "asyncBefore" : {
+          "type" : "boolean"
+        },
+        "asyncAfter" : {
+          "type" : "boolean"
+        },
         "nodes" : {
           "type" : "array",
           "items" : {
@@ -816,7 +822,7 @@
         }
       },
       "title" : "EventSubprocess",
-      "required" : [ "deserializeAs", "name" ]
+      "required" : [ "deserializeAs", "name", "asyncBefore", "asyncAfter" ]
     },
     "CompressFileTask" : {
       "type" : "object",
@@ -1254,6 +1260,9 @@
         "password" : {
           "type" : "string"
         },
+        "basePath" : {
+          "type" : "string"
+        },
         "identifier" : {
           "type" : "string"
         }
@@ -1282,9 +1291,6 @@
           "type" : "string",
           "maxLength" : 512
         },
-        "request" : {
-          "$ref" : "#/definitions/EmbeddedRequest"
-        },
         "inputVariables" : {
           "type" : "array",
           "items" : {
@@ -1305,6 +1311,9 @@
         },
         "asyncAfter" : {
           "type" : "boolean"
+        },
+        "request" : {
+          "$ref" : "#/definitions/EmbeddedRequest"
         },
         "identifier" : {
           "type" : "string"
@@ -1366,16 +1375,6 @@
           "type" : "string",
           "maxLength" : 512
         },
-        "path" : {
-          "type" : "string"
-        },
-        "workflow" : {
-          "type" : "string"
-        },
-        "action" : {
-          "type" : "string",
-          "enum" : [ "READ_NEXT", "DELETE_NEXT", "LIST", "WRITE" ]
-        },
         "inputVariables" : {
           "type" : "array",
           "items" : {
@@ -1391,12 +1390,22 @@
         "asyncAfter" : {
           "type" : "boolean"
         },
+        "path" : {
+          "type" : "string"
+        },
+        "workflow" : {
+          "type" : "string"
+        },
+        "action" : {
+          "type" : "string",
+          "enum" : [ "READ_NEXT", "DELETE_NEXT", "LIST", "WRITE" ]
+        },
         "identifier" : {
           "type" : "string"
         }
       },
       "title" : "DirectoryTask",
-      "required" : [ "deserializeAs", "name", "path", "workflow", "action", "asyncBefore", "asyncAfter" ]
+      "required" : [ "deserializeAs", "name", "asyncBefore", "asyncAfter", "path", "workflow", "action" ]
     },
     "ReceiveTask" : {
       "type" : "object",
@@ -1458,9 +1467,6 @@
           "type" : "string",
           "maxLength" : 512
         },
-        "processor" : {
-          "$ref" : "#/definitions/EmbeddedProcessor"
-        },
         "inputVariables" : {
           "type" : "array",
           "items" : {
@@ -1475,6 +1481,9 @@
         },
         "asyncAfter" : {
           "type" : "boolean"
+        },
+        "processor" : {
+          "$ref" : "#/definitions/EmbeddedProcessor"
         },
         "identifier" : {
           "type" : "string"

--- a/service/ramls/processortask.json
+++ b/service/ramls/processortask.json
@@ -21,9 +21,6 @@
       "type" : "string",
       "maxLength" : 512
     },
-    "processor" : {
-      "$ref" : "#/definitions/EmbeddedProcessor"
-    },
     "inputVariables" : {
       "type" : "array",
       "items" : {
@@ -39,37 +36,15 @@
     "asyncAfter" : {
       "type" : "boolean"
     },
+    "processor" : {
+      "$ref" : "#/definitions/EmbeddedProcessor"
+    },
     "identifier" : {
       "type" : "string"
     }
   },
   "required" : [ "deserializeAs", "name", "asyncBefore", "asyncAfter" ],
   "definitions" : {
-    "EmbeddedProcessor" : {
-      "type" : "object",
-      "additionalProperties" : false,
-      "properties" : {
-        "scriptType" : {
-          "type" : "string",
-          "enum" : [ "GROOVY", "JAVA", "JS", "PYTHON", "RUBY" ]
-        },
-        "functionName" : {
-          "type" : "string",
-          "minLength" : 4,
-          "maxLength" : 128
-        },
-        "code" : {
-          "type" : "string"
-        },
-        "buffer" : {
-          "type" : "integer"
-        },
-        "delay" : {
-          "type" : "integer"
-        }
-      },
-      "required" : [ "scriptType", "functionName", "code", "buffer", "delay" ]
-    },
     "EmbeddedVariable" : {
       "type" : "object",
       "additionalProperties" : false,
@@ -94,6 +69,31 @@
         }
       },
       "required" : [ "key", "spin" ]
+    },
+    "EmbeddedProcessor" : {
+      "type" : "object",
+      "additionalProperties" : false,
+      "properties" : {
+        "scriptType" : {
+          "type" : "string",
+          "enum" : [ "GROOVY", "JAVA", "JS", "PYTHON", "RUBY" ]
+        },
+        "functionName" : {
+          "type" : "string",
+          "minLength" : 4,
+          "maxLength" : 128
+        },
+        "code" : {
+          "type" : "string"
+        },
+        "buffer" : {
+          "type" : "integer"
+        },
+        "delay" : {
+          "type" : "integer"
+        }
+      },
+      "required" : [ "scriptType", "functionName", "code", "buffer", "delay" ]
     }
   }
 }

--- a/service/ramls/requesttask.json
+++ b/service/ramls/requesttask.json
@@ -21,9 +21,6 @@
       "type" : "string",
       "maxLength" : 512
     },
-    "request" : {
-      "$ref" : "#/definitions/EmbeddedRequest"
-    },
     "inputVariables" : {
       "type" : "array",
       "items" : {
@@ -45,12 +42,40 @@
     "asyncAfter" : {
       "type" : "boolean"
     },
+    "request" : {
+      "$ref" : "#/definitions/EmbeddedRequest"
+    },
     "identifier" : {
       "type" : "string"
     }
   },
   "required" : [ "deserializeAs", "name", "asyncBefore", "asyncAfter" ],
   "definitions" : {
+    "EmbeddedVariable" : {
+      "type" : "object",
+      "additionalProperties" : false,
+      "properties" : {
+        "key" : {
+          "type" : "string",
+          "minLength" : 4,
+          "maxLength" : 64
+        },
+        "type" : {
+          "type" : "string",
+          "enum" : [ "PROCESS", "LOCAL" ]
+        },
+        "spin" : {
+          "type" : "boolean"
+        },
+        "asJson" : {
+          "type" : "boolean"
+        },
+        "asTransient" : {
+          "type" : "boolean"
+        }
+      },
+      "required" : [ "key", "spin" ]
+    },
     "EmbeddedRequest" : {
       "type" : "object",
       "additionalProperties" : false,
@@ -82,31 +107,6 @@
         }
       },
       "required" : [ "url", "method", "contentType", "accept", "iterable" ]
-    },
-    "EmbeddedVariable" : {
-      "type" : "object",
-      "additionalProperties" : false,
-      "properties" : {
-        "key" : {
-          "type" : "string",
-          "minLength" : 4,
-          "maxLength" : 64
-        },
-        "type" : {
-          "type" : "string",
-          "enum" : [ "PROCESS", "LOCAL" ]
-        },
-        "spin" : {
-          "type" : "boolean"
-        },
-        "asJson" : {
-          "type" : "boolean"
-        },
-        "asTransient" : {
-          "type" : "boolean"
-        }
-      },
-      "required" : [ "key", "spin" ]
     }
   }
 }

--- a/service/ramls/subprocess.json
+++ b/service/ramls/subprocess.json
@@ -771,6 +771,12 @@
           "type" : "string",
           "maxLength" : 512
         },
+        "asyncBefore" : {
+          "type" : "boolean"
+        },
+        "asyncAfter" : {
+          "type" : "boolean"
+        },
         "nodes" : {
           "type" : "array",
           "items" : {
@@ -828,7 +834,7 @@
         }
       },
       "title" : "EventSubprocess",
-      "required" : [ "deserializeAs", "name" ]
+      "required" : [ "deserializeAs", "name", "asyncBefore", "asyncAfter" ]
     },
     "CompressFileTask" : {
       "type" : "object",
@@ -1266,6 +1272,9 @@
         "password" : {
           "type" : "string"
         },
+        "basePath" : {
+          "type" : "string"
+        },
         "identifier" : {
           "type" : "string"
         }
@@ -1294,9 +1303,6 @@
           "type" : "string",
           "maxLength" : 512
         },
-        "request" : {
-          "$ref" : "#/definitions/EmbeddedRequest"
-        },
         "inputVariables" : {
           "type" : "array",
           "items" : {
@@ -1317,6 +1323,9 @@
         },
         "asyncAfter" : {
           "type" : "boolean"
+        },
+        "request" : {
+          "$ref" : "#/definitions/EmbeddedRequest"
         },
         "identifier" : {
           "type" : "string"
@@ -1378,16 +1387,6 @@
           "type" : "string",
           "maxLength" : 512
         },
-        "path" : {
-          "type" : "string"
-        },
-        "workflow" : {
-          "type" : "string"
-        },
-        "action" : {
-          "type" : "string",
-          "enum" : [ "READ_NEXT", "DELETE_NEXT", "LIST", "WRITE" ]
-        },
         "inputVariables" : {
           "type" : "array",
           "items" : {
@@ -1403,12 +1402,22 @@
         "asyncAfter" : {
           "type" : "boolean"
         },
+        "path" : {
+          "type" : "string"
+        },
+        "workflow" : {
+          "type" : "string"
+        },
+        "action" : {
+          "type" : "string",
+          "enum" : [ "READ_NEXT", "DELETE_NEXT", "LIST", "WRITE" ]
+        },
         "identifier" : {
           "type" : "string"
         }
       },
       "title" : "DirectoryTask",
-      "required" : [ "deserializeAs", "name", "path", "workflow", "action", "asyncBefore", "asyncAfter" ]
+      "required" : [ "deserializeAs", "name", "asyncBefore", "asyncAfter", "path", "workflow", "action" ]
     },
     "ReceiveTask" : {
       "type" : "object",
@@ -1470,9 +1479,6 @@
           "type" : "string",
           "maxLength" : 512
         },
-        "processor" : {
-          "$ref" : "#/definitions/EmbeddedProcessor"
-        },
         "inputVariables" : {
           "type" : "array",
           "items" : {
@@ -1487,6 +1493,9 @@
         },
         "asyncAfter" : {
           "type" : "boolean"
+        },
+        "processor" : {
+          "$ref" : "#/definitions/EmbeddedProcessor"
         },
         "identifier" : {
           "type" : "string"

--- a/service/ramls/workflow.json
+++ b/service/ramls/workflow.json
@@ -12,6 +12,10 @@
       "minLength" : 4,
       "maxLength" : 64
     },
+    "description" : {
+      "type" : "string",
+      "maxLength" : 512
+    },
     "versionTag" : {
       "type" : "string",
       "minLength" : 1,
@@ -20,10 +24,6 @@
     "historyTimeToLive" : {
       "type" : "integer",
       "minimum" : 0
-    },
-    "description" : {
-      "type" : "string",
-      "maxLength" : 512
     },
     "active" : {
       "type" : "boolean"
@@ -782,6 +782,12 @@
           "type" : "string",
           "maxLength" : 512
         },
+        "asyncBefore" : {
+          "type" : "boolean"
+        },
+        "asyncAfter" : {
+          "type" : "boolean"
+        },
         "nodes" : {
           "type" : "array",
           "items" : {
@@ -839,7 +845,7 @@
         }
       },
       "title" : "EventSubprocess",
-      "required" : [ "deserializeAs", "name" ]
+      "required" : [ "deserializeAs", "name", "asyncBefore", "asyncAfter" ]
     },
     "CompressFileTask" : {
       "type" : "object",
@@ -1277,6 +1283,9 @@
         "password" : {
           "type" : "string"
         },
+        "basePath" : {
+          "type" : "string"
+        },
         "identifier" : {
           "type" : "string"
         }
@@ -1305,9 +1314,6 @@
           "type" : "string",
           "maxLength" : 512
         },
-        "request" : {
-          "$ref" : "#/definitions/EmbeddedRequest"
-        },
         "inputVariables" : {
           "type" : "array",
           "items" : {
@@ -1328,6 +1334,9 @@
         },
         "asyncAfter" : {
           "type" : "boolean"
+        },
+        "request" : {
+          "$ref" : "#/definitions/EmbeddedRequest"
         },
         "identifier" : {
           "type" : "string"
@@ -1389,16 +1398,6 @@
           "type" : "string",
           "maxLength" : 512
         },
-        "path" : {
-          "type" : "string"
-        },
-        "workflow" : {
-          "type" : "string"
-        },
-        "action" : {
-          "type" : "string",
-          "enum" : [ "READ_NEXT", "DELETE_NEXT", "LIST", "WRITE" ]
-        },
         "inputVariables" : {
           "type" : "array",
           "items" : {
@@ -1414,12 +1413,22 @@
         "asyncAfter" : {
           "type" : "boolean"
         },
+        "path" : {
+          "type" : "string"
+        },
+        "workflow" : {
+          "type" : "string"
+        },
+        "action" : {
+          "type" : "string",
+          "enum" : [ "READ_NEXT", "DELETE_NEXT", "LIST", "WRITE" ]
+        },
         "identifier" : {
           "type" : "string"
         }
       },
       "title" : "DirectoryTask",
-      "required" : [ "deserializeAs", "name", "path", "workflow", "action", "asyncBefore", "asyncAfter" ]
+      "required" : [ "deserializeAs", "name", "asyncBefore", "asyncAfter", "path", "workflow", "action" ]
     },
     "ReceiveTask" : {
       "type" : "object",
@@ -1481,9 +1490,6 @@
           "type" : "string",
           "maxLength" : 512
         },
-        "processor" : {
-          "$ref" : "#/definitions/EmbeddedProcessor"
-        },
         "inputVariables" : {
           "type" : "array",
           "items" : {
@@ -1498,6 +1504,9 @@
         },
         "asyncAfter" : {
           "type" : "boolean"
+        },
+        "processor" : {
+          "$ref" : "#/definitions/EmbeddedProcessor"
         },
         "identifier" : {
           "type" : "string"

--- a/service/src/main/java/org/folio/rest/workflow/dto/TriggerDto.java
+++ b/service/src/main/java/org/folio/rest/workflow/dto/TriggerDto.java
@@ -1,0 +1,14 @@
+package org.folio.rest.workflow.dto;
+
+import org.folio.rest.workflow.model.has.HasId;
+import org.folio.rest.workflow.model.has.HasInformational;
+import org.folio.rest.workflow.model.has.HasMethod;
+import org.folio.rest.workflow.model.has.HasName;
+import org.folio.rest.workflow.model.has.HasPathPattern;
+
+/**
+ * This is a DTO design for providing the entire {@link org.folio.rest.workflow.model.Trigger Trigger} model.
+ */
+public interface TriggerDto extends HasId, HasInformational, HasMethod, HasName, HasPathPattern {
+
+}

--- a/service/src/main/java/org/folio/rest/workflow/has/common/HasActionCommon.java
+++ b/service/src/main/java/org/folio/rest/workflow/has/common/HasActionCommon.java
@@ -1,0 +1,11 @@
+package org.folio.rest.workflow.has.common;
+
+/**
+ * This interface provides common methods for {@link org.folio.rest.workflow.model.Action Action}.
+ */
+public interface HasActionCommon {
+
+  public String getInterfaceName();
+
+  public void setInterfaceName(String interfaceName);
+}

--- a/service/src/main/java/org/folio/rest/workflow/has/common/HasHandlerCommon.java
+++ b/service/src/main/java/org/folio/rest/workflow/has/common/HasHandlerCommon.java
@@ -1,0 +1,20 @@
+package org.folio.rest.workflow.has.common;
+
+import java.util.List;
+import org.folio.rest.workflow.model.Action;
+
+/**
+ * This interface provides common methods for {@link org.folio.rest.workflow.model.Handler Handler}.
+ */
+public interface HasHandlerCommon {
+
+  public List<Action> getActionByInterface(String interfaceName);
+  public List<String> getMethods();
+  public List<String> getPermissionsDesired();
+  public List<String> getPermissionsRequired();
+
+  public void setMethods(List<String> methods);
+  public void setPermissionsDesired(List<String> permissionsDesired);
+  public void setPermissionsRequired(List<String> permissionsRequired);
+
+}

--- a/service/src/main/java/org/folio/rest/workflow/model/Action.java
+++ b/service/src/main/java/org/folio/rest/workflow/model/Action.java
@@ -5,20 +5,30 @@ import javax.persistence.Embeddable;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.validation.constraints.NotNull;
-
+import lombok.Getter;
+import lombok.Setter;
+import org.folio.rest.workflow.has.common.HasActionCommon;
+import org.folio.rest.workflow.model.has.HasMethod;
+import org.folio.rest.workflow.model.has.HasPathPattern;
 import org.springframework.http.HttpMethod;
 
 @Embeddable
-public class Action {
+public class Action implements HasActionCommon, HasMethod, HasPathPattern {
 
+  @Getter
+  @Setter
   @NotNull
   @Column(nullable = false)
   private String interfaceName;
 
+  @Getter
+  @Setter
   @NotNull
   @Column(nullable = false)
   private String pathPattern;
 
+  @Getter
+  @Setter
   @NotNull
   @Column(nullable = false)
   @Enumerated(EnumType.STRING)
@@ -30,33 +40,9 @@ public class Action {
 
   public Action(String interfaceName, String pathPattern, HttpMethod method) {
     this();
+
     this.interfaceName = interfaceName;
     this.pathPattern = pathPattern;
-    this.method = method;
-
-  }
-
-  public String getInterfaceName() {
-    return interfaceName;
-  }
-
-  public void setInterfaceName(String interfaceName) {
-    this.interfaceName = interfaceName;
-  }
-
-  public String getPathPattern() {
-    return pathPattern;
-  }
-
-  public void setPathPattern(String pathPattern) {
-    this.pathPattern = pathPattern;
-  }
-
-  public HttpMethod getMethod() {
-    return method;
-  }
-
-  public void setMethod(HttpMethod method) {
     this.method = method;
   }
 

--- a/service/src/main/java/org/folio/rest/workflow/model/Handler.java
+++ b/service/src/main/java/org/folio/rest/workflow/model/Handler.java
@@ -2,53 +2,32 @@ package org.folio.rest.workflow.model;
 
 import java.util.ArrayList;
 import java.util.List;
-
+import lombok.Getter;
+import lombok.Setter;
+import org.folio.rest.workflow.has.common.HasHandlerCommon;
+import org.folio.rest.workflow.model.has.HasPathPattern;
 import org.springframework.http.HttpMethod;
 
-public class Handler {
+public class Handler implements HasHandlerCommon, HasPathPattern {
 
+  @Getter
+  @Setter
   private List<String> methods;
 
+  @Getter
+  @Setter
   private String pathPattern;
 
+  @Getter
+  @Setter
   private List<String> permissionsRequired;
 
+  @Getter
+  @Setter
   private List<String> permissionsDesired;
 
   public Handler() {
     super();
-  }
-
-  public List<String> getMethods() {
-    return methods;
-  }
-
-  public void setMethods(List<String> methods) {
-    this.methods = methods;
-  }
-
-  public String getPathPattern() {
-    return pathPattern;
-  }
-
-  public void setPathPattern(String pathPattern) {
-    this.pathPattern = pathPattern;
-  }
-
-  public List<String> getPermissionsRequired() {
-    return permissionsRequired;
-  }
-
-  public void setPermissionsRequired(List<String> permissionsRequired) {
-    this.permissionsRequired = permissionsRequired;
-  }
-
-  public List<String> getPermissionsDesired() {
-    return permissionsDesired;
-  }
-
-  public void setPermissionsDesired(List<String> permissionsDesired) {
-    this.permissionsDesired = permissionsDesired;
   }
 
   public List<Action> getActionByInterface(String interfaceName) {

--- a/service/src/main/java/org/folio/rest/workflow/model/Trigger.java
+++ b/service/src/main/java/org/folio/rest/workflow/model/Trigger.java
@@ -6,27 +6,41 @@ import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
-
+import lombok.Getter;
+import lombok.Setter;
+import org.folio.rest.workflow.model.has.HasId;
+import org.folio.rest.workflow.model.has.HasInformational;
+import org.folio.rest.workflow.model.has.HasMethod;
+import org.folio.rest.workflow.model.has.HasName;
+import org.folio.rest.workflow.model.has.HasPathPattern;
 import org.folio.spring.domain.model.AbstractBaseEntity;
 import org.springframework.http.HttpMethod;
 
 @Entity
-public class Trigger extends AbstractBaseEntity {
+public class Trigger extends AbstractBaseEntity implements HasId, HasInformational, HasMethod, HasName, HasPathPattern {
 
+  @Getter
+  @Setter
   @NotNull
   @Size(min = 4, max = 64)
   @Column(unique = true)
   private String name;
 
+  @Getter
+  @Setter
   @Size(min = 0, max = 256)
   @Column(nullable = true)
   private String description;
 
+  @Getter
+  @Setter
   @NotNull
   @Size(min = 2, max = 256)
   @Column(nullable = false)
   private String pathPattern;
 
+  @Getter
+  @Setter
   @NotNull
   @Column(nullable = false)
   @Enumerated(EnumType.STRING)
@@ -34,38 +48,6 @@ public class Trigger extends AbstractBaseEntity {
 
   public Trigger() {
     super();
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  public String getPathPattern() {
-    return pathPattern;
-  }
-
-  public void setPathPattern(String pathPattern) {
-    this.pathPattern = pathPattern;
-  }
-
-  public HttpMethod getMethod() {
-    return method;
-  }
-
-  public void setMethod(HttpMethod method) {
-    this.method = method;
   }
 
 }

--- a/service/src/main/java/org/folio/rest/workflow/model/repo/TaskRepo.java
+++ b/service/src/main/java/org/folio/rest/workflow/model/repo/TaskRepo.java
@@ -6,4 +6,5 @@ import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 @RepositoryRestResource
 public interface TaskRepo extends JpaRepository<Node, String> {
+
 }

--- a/service/src/main/java/org/folio/rest/workflow/model/repo/TaskRepo.java
+++ b/service/src/main/java/org/folio/rest/workflow/model/repo/TaskRepo.java
@@ -6,5 +6,4 @@ import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 @RepositoryRestResource
 public interface TaskRepo extends JpaRepository<Node, String> {
-
 }

--- a/service/src/main/java/org/folio/rest/workflow/model/repo/TriggerRepo.java
+++ b/service/src/main/java/org/folio/rest/workflow/model/repo/TriggerRepo.java
@@ -1,9 +1,12 @@
 package org.folio.rest.workflow.model.repo;
 
+import java.util.List;
 import org.folio.rest.workflow.model.Trigger;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 @RepositoryRestResource
 public interface TriggerRepo extends JpaRepository<Trigger, String> {
+
+  public <T> List<T> findViewAllBy(Class<T> type);
 }

--- a/service/src/main/java/org/folio/rest/workflow/model/repo/TriggerRepo.java
+++ b/service/src/main/java/org/folio/rest/workflow/model/repo/TriggerRepo.java
@@ -6,5 +6,4 @@ import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 @RepositoryRestResource
 public interface TriggerRepo extends JpaRepository<Trigger, String> {
-
 }

--- a/service/src/main/java/org/folio/rest/workflow/model/repo/WorkflowRepo.java
+++ b/service/src/main/java/org/folio/rest/workflow/model/repo/WorkflowRepo.java
@@ -6,5 +6,4 @@ import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 @RepositoryRestResource
 public interface WorkflowRepo extends JpaRepository<Workflow, String> {
-
 }

--- a/service/src/main/java/org/folio/rest/workflow/model/repo/WorkflowRepo.java
+++ b/service/src/main/java/org/folio/rest/workflow/model/repo/WorkflowRepo.java
@@ -6,4 +6,6 @@ import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 @RepositoryRestResource
 public interface WorkflowRepo extends JpaRepository<Workflow, String> {
+
+  public <T> T getViewById(String id, Class<T> type);
 }

--- a/service/src/main/java/org/folio/rest/workflow/service/OkapiDiscoveryService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/OkapiDiscoveryService.java
@@ -1,11 +1,12 @@
 package org.folio.rest.workflow.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.folio.rest.workflow.model.Action;
 import org.folio.rest.workflow.model.Handler;
 import org.folio.spring.service.HttpService;
@@ -19,9 +20,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Service
 public class OkapiDiscoveryService {

--- a/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
@@ -1,5 +1,11 @@
 package org.folio.rest.workflow.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.folio.rest.workflow.dto.WorkflowDto;
+import org.folio.rest.workflow.dto.WorkflowOperationalDto;
 import org.folio.rest.workflow.exception.WorkflowEngineServiceException;
 import org.folio.rest.workflow.model.Workflow;
 import org.folio.rest.workflow.model.repo.WorkflowRepo;
@@ -15,11 +21,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 @Service
 public class WorkflowEngineService {
@@ -64,20 +65,22 @@ public class WorkflowEngineService {
 
   public Workflow activate(String workflowId, String tenant, String token)
       throws WorkflowEngineServiceException {
-    Workflow workflow = workflowRepo.getReferenceById(workflowId);
+
+    WorkflowDto workflow = workflowRepo.getViewById(workflowId, WorkflowDto.class);
     return sendWorkflowRequest(workflow, WORKFLOW_ENGINE_ACTIVATE_URL_TEMPLATE, tenant, token);
   }
 
   public Workflow deactivate(String workflowId, String tenant, String token)
       throws WorkflowEngineServiceException {
-    Workflow workflow = workflowRepo.getReferenceById(workflowId);
+
+    WorkflowDto workflow = workflowRepo.getViewById(workflowId, WorkflowDto.class);
     return sendWorkflowRequest(workflow, WORKFLOW_ENGINE_DEACTIVATE_URL_TEMPLATE, tenant, token);
   }
 
   public JsonNode start(String workflowId, String tenant, String token, JsonNode context)
       throws WorkflowEngineServiceException {
 
-    Workflow workflow = workflowRepo.getReferenceById(workflowId);
+    WorkflowOperationalDto workflow = workflowRepo.getViewById(workflowId, WorkflowOperationalDto.class);
     String id = workflow.getDeploymentId();
     String version = workflow.getVersionTag();
 
@@ -93,7 +96,7 @@ public class WorkflowEngineService {
   }
 
   public JsonNode history(String workflowId, String tenant, String token) throws WorkflowEngineServiceException {
-    Workflow workflow = workflowRepo.getReferenceById(workflowId);
+    WorkflowOperationalDto workflow = workflowRepo.getViewById(workflowId, WorkflowOperationalDto.class);
     String deploymentId = workflow.getDeploymentId();
     String version = workflow.getVersionTag();
 
@@ -171,10 +174,10 @@ public class WorkflowEngineService {
     return incidents;
   }
 
-  private Workflow sendWorkflowRequest(Workflow workflow, String requestPath, String tenant, String token)
+  private Workflow sendWorkflowRequest(WorkflowDto workflow, String requestPath, String tenant, String token)
       throws WorkflowEngineServiceException {
 
-    HttpEntity<Workflow> workflowHttpEntity = new HttpEntity<>(workflow, headers(tenant, token));
+    HttpEntity<WorkflowDto> workflowHttpEntity = new HttpEntity<>(workflow, headers(tenant, token));
 
     String url = String.format(requestPath, okapiUrl, basePath);
     ResponseEntity<Workflow> response = exchange(url, HttpMethod.POST, workflowHttpEntity, Workflow.class);


### PR DESCRIPTION
Resolves: [MODWRKFLOW-2](https://issues.folio.org/browse/MODWRKFLOW-2)

### Purpose
Provide and use DTOs rather than direct **Entities** when transmitting model data.
Add and use Lombok to simplify the code.

### Approach

#### Restructure Enumerations
Separate the enumerations from the models with the goal of helping make managing the different models somewhat easier.

#### Add and use Lombok
The methods are extracted into interfaces and have their interfaces prefixed with `Has`.
These are placed under the `has` directory.
There is a `has/common` directory (for lack of a better name) for interfaces that are specific to a given model.

The methods that are found to be used in multiple models have been provided in their own `Has` interface.
I attempted to break out the `Has` interfaces into groups of purpose, such as `HasVersioning`.
These could then support multiple methods that would be always grouped together.
The grouping of everything and how they should be group is not entirely clear at this point and so I opted to have most of the `Has` class be single purpose.
The `Has` `Common` interfaces are catch-all for a given model that is not broken out.
These may be changed in the future once the design is better hashed out.
Hashing this it out is considered out of scope.

This commit maintains the synthetic functions and keeps them on the model.
For an example see `hasCardinalityExpression()`.
This will need to be moved out into a DTO class in a subsequent commit.

#### Adding DTOs
The **Workflow** DTO and related are added.

The DTOs are used when fetching the data to reduce the data loaded from the database, such as with `WorkflowOperationDto`.
This required extracting out `HasDeploymentId` from `HasWorkflowCommon`.



### Additional Information

#### The "Has" Interfaces
There are `version` and `versionTag` properties.
It seems like these could be the same thing.
The `versionTag` is Camunda-specific.
This makes note of the situation and separates `version` under `Versioning` and `versionTag` remains as `VersionTag`.
Similarly, the `AsyncBefore` and `AsyncAfter` are also notable probably Camunda-specific properties.
There may be several more Camunda-specific properties.
Changing the behavior to remove Camunda-specific functionality is out of scope.

There is inconsistency in how properties are to be provided for connecting to services.
Some use a full URL and others have it broken up into parts.
This is either a previous design inconsistency or an inconsistency in Camunda.
The relevant `Has` interfaces are broken up to make room for fixing this at a later time.
Fixing the inconsistency is considered out of scope.

The password is broken out because ideally the password will not be specified all of the time.
This password should further be obfuscated.
The UI should not receive the password.
More work is needed to do this properly and that work is considered out of scope.
The only focus on the password is to separate it into its own `Has` interface.

Similarly, the username property is broken out.
It may or may not be moved into a combined property as I suggested in the comments or remain in its own separate `Has` interface for privacy and security considerations.
Deciding on this is out of scope.

#### RAML Files Rebuilt
This rebuilds the RAML files.
Rebuilding this revealed that some of the properties, namely `asyncBefore` and `asyncAfter`, are missing from the previous RAML files in some cases.

#### DTOs and Jackson
The Jackson handler as it is currently used cannot properly transfer an interface DTO (aka: a DTO Projection).
A concrete class is required.
For now, the **Workflow Entity** is directly used here.
This should be fine for the short term given that the entire **Workflow** is needed for these cases anyway.
Additional work is merited to better solve this.
Consider things like ModelMapper to assist with this.

The additional DTOs that should be created, like NodeDto, are not done due to an observed problem.
The `@JsonTypeInfo` and `@JsonSubTypes` using `deserializeAs` does not translate well into the interfaces that DTOs use.
This results in an invalid identifier and the **Workflow** cannot be activated.
This requires more research and work to determine a valid strategy to preserve the `getIdentifier()` needs but with an interface.

#### Lombok Getter and Setter
The `@Getter` and `@Setter` are used where `@Data` is preferred on the **Entities**.
Warnings and problems occur when the Had* interfaces exist on an **Entity** that has `@Data`.
To avoid this the more nuanced `@Getter` and `@Setter` are used for every property on the **Entity**.