### PR TITLE
MODWRKFLOW-12: Refactor column name from 'key' to 'vkey' for EmbeddedVariable.

### DIFF
--- a/components/src/main/java/org/folio/rest/workflow/model/EmbeddedVariable.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/EmbeddedVariable.java
@@ -18,7 +18,7 @@ public class EmbeddedVariable implements HasEmbeddedVariableCommon {
   @Setter
   @NotNull
   @Size(min = 4, max = 64)
-  @Column(nullable = true)
+  @Column(name = "vkey", nullable = true)
   private String key;
 
   @Getter


### PR DESCRIPTION
Resolves [MODWRKFLOW-12](https://issues.folio.org/browse/MODWRKFLOW-12)

Any existing databases will require an upgrade following this change.

A possibly way to quickly test if H2 is not working because of a problem like this may be to look into using `SET NON_KEYWORDS` in H2.

see: https://h2database.com/html/advanced.html#keywords
see: http://h2database.com/html/commands.html#set_non_keywords