### PR TITLE
Restore module descriptor generation.

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -261,6 +261,57 @@
               </execution>
             </executions>
           </plugin>
+
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>filter-descriptor-inputs</id>
+                <phase>generate-resources</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>${project.build.directory}</outputDirectory>
+                  <resources>
+                    <resource>
+                      <directory>${basedir}/descriptors</directory>
+                      <include>*Descriptor*-template.json</include>
+                      <filtering>true</filtering>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>com.coderplus.maven.plugins</groupId>
+            <artifactId>copy-rename-maven-plugin</artifactId>
+            <version>1.0.1</version>
+            <executions>
+              <execution>
+                <id>rename-descriptor-outputs</id>
+                <phase>generate-resources</phase>
+                <goals>
+                  <goal>rename</goal>
+                </goals>
+                <configuration>
+                  <fileSets>
+                    <fileSet>
+                      <sourceFile>${project.build.directory}/ModuleDescriptor-template.json</sourceFile>
+                      <destinationFile>${project.build.directory}/ModuleDescriptor.json</destinationFile>
+                    </fileSet>
+                    <fileSet>
+                      <sourceFile>${project.build.directory}/DeploymentDescriptor-template.json</sourceFile>
+                      <destinationFile>${project.build.directory}/DeploymentDescriptor.json</destinationFile>
+                    </fileSet>
+                  </fileSets>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
       </build>
     </profile>


### PR DESCRIPTION
These changes got lost during massive changes from spring boot 2 to spring boot 3.

This is currently restoring the old paths.
Once merged, I may end up having to get the files to appear at the top directory of the project rather than on the service directory.