### PR TITLE
Remove Autowired constructor because it breaks constructors that are not Autowired.

### DIFF
--- a/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
@@ -52,17 +52,13 @@ public class WorkflowEngineService {
   @Value("${okapi.camunda.rest-path}")
   private String restPath;
 
+  @Autowired
   private WorkflowRepo workflowRepo;
 
+  @Autowired
   private ObjectMapper mapper;
 
   private RestTemplate restTemplate;
-
-  @Autowired
-  public WorkflowEngineService(WorkflowRepo workflowRepo, ObjectMapper mapper) {
-    this.workflowRepo = workflowRepo;
-    this.mapper = mapper;
-  }
 
   public WorkflowEngineService(RestTemplateBuilder restTemplateBuilder) {
     this.restTemplate = restTemplateBuilder.build();


### PR DESCRIPTION
The `@Autowired` on the constructor breaks behavior with the existing non-`@Autowired` constructor. The non-`@Autowired` constructor is instantiating the `RestTemplate`. Adding the `RestTemplate` to the `@Autowired` constructor would result in unsafe behavior where there are two allocations on `RestTemplate`. This produces potential undefined behavior such as constructor race conditions. This would likely cause obscure problems.

Do not use an `@Autowired` constructor in this specific case.