### PR TITLE
Deployment fixes

### DIFF
--- a/service/descriptors/DeploymentDescriptor-template.json
+++ b/service/descriptors/DeploymentDescriptor-template.json
@@ -1,7 +1,7 @@
 {
-  "srvcId": "mod-workflow-${project.version}",
+  "srvcId": "mod-workflow-@project.version@",
   "nodeId": "localhost",
   "descriptor": {
-    "exec": "java -Dport=%p -jar ../mod-workflow/service/target/${project.artifactId}-${project.version}.jar -Dspring.config.location=classpath:/ -Dhttp.port=%p --server.port=%p"
+    "exec": "java -Dport=%p -jar ../mod-workflow/service/target/@project.artifactId@-@project.version@.jar -Dspring.config.location=classpath:/ -Dhttp.port=%p --server.port=%p"
   }
 }

--- a/service/descriptors/ModuleDescriptor-template.json
+++ b/service/descriptors/ModuleDescriptor-template.json
@@ -1,5 +1,5 @@
 {
-  "id": "mod-workflow-${project.version}",
+  "id": "mod-workflow-@project.version@",
   "name": "Workflow Module",
   "provides": [
     {
@@ -453,7 +453,7 @@
   ],
   "requires": [ ],
   "launchDescriptor": {
-    "dockerImage": "mod-workflow:${project.version}",
+    "dockerImage": "mod-workflow:@project.version@",
     "dockerPull" : false,
     "dockerArgs": {
       "HostConfig": {

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -187,7 +187,6 @@
         <directory>src/main/resources</directory>
         <excludes>
           <exclude>application.yaml</exclude>
-          <exclude>descriptors/**</exclude>
         </excludes>
       </resource>
       <resource>
@@ -199,7 +198,7 @@
       </resource>
       <resource>
         <filtering>true</filtering>
-        <directory>src/main/resources/descriptors</directory>
+        <directory>descriptors</directory>
         <targetPath>descriptors</targetPath>
         <includes>
           <include>DeploymentDescriptor.json</include>
@@ -208,7 +207,7 @@
       </resource>
       <resource>
         <filtering>true</filtering>
-        <directory>src/main/resources/descriptors</directory>
+        <directory>descriptors</directory>
         <targetPath>../descriptors</targetPath>
         <includes>
           <include>DeploymentDescriptor.json</include>

--- a/service/src/main/resources/changelog/changelog-master.xml
+++ b/service/src/main/resources/changelog/changelog-master.xml
@@ -1,0 +1,6 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+</databaseChangeLog>


### PR DESCRIPTION
Deployment is not working as expected.
The upgrade to spring boot 3 and the addition of `folio-spring-support` has resulted in deployment regressions.

1. The resource variables syntax changed from say `${project.version}` into `@project.version@`.
2. A `changelog-master.xml` is now required due to Liquibase and `folio-spring-support` making that file be required (even if effectively empty).

This also removes some unused configuration, such as the resource exclusion for descriptors under `src/main/resources` (the descriptors are no longer stored there).

see: https://docs.spring.io/spring-boot/docs/current/reference/html/howto.html#howto.properties-and-configuration
see: https://github.com/folio-org/folio-spring-support/blob/9f3042f4c0b5a27071793bf0904a68de1b6acddd/folio-spring-base/src/main/java/org/folio/spring/liquibase/FolioLiquibaseConfiguration.java#L17C1-L17C93
see: https://github.com/folio-org/folio-spring-support/blob/9f3042f4c0b5a27071793bf0904a68de1b6acddd/folio-spring-base/src/main/java/org/folio/spring/service/TenantService.java#L23