### PR TITLE
Fix problems relating to the pom, the application.yaml, and openapi.yaml generation.

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -332,21 +332,23 @@
             <artifactId>spring-boot-maven-plugin</artifactId>
             <configuration>
               <skip>false</skip>
+              <jvmArguments>-Dspring.application.admin.enabled=true -Dfolio.tenant.validation=false -Dheader.validation.x-okapi-tenant.exclude.base-paths=/</jvmArguments>
               <arguments>
                 <argument>--server.port=${openapi.server.port}</argument>
               </arguments>
               <systemPropertyVariables>
                 <server.port>${openapi.server.port}</server.port>
-                <spring.sql.init.platform>h2</spring.sql.init.platform>
-                <spring.datasource.driverClassName>org.h2.Driver</spring.datasource.driverClassName>
-                <spring.datasource.url>jdbc:h2:./target/mod-workflow;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</spring.datasource.url>
-                <spring.jpa.database-platform>org.hibernate.dialect.H2Dialect</spring.jpa.database-platform>
-                <spring.jpa.hibernate.ddl-auto>create-drop</spring.jpa.hibernate.ddl-auto>
+                <!--FIXME: The reason for this failing is unknown, for now postgresql can be used.-->
+                <!--<spring.sql.init.platform>h2</spring.sql.init.platform>-->
+                <!--<spring.datasource.driverClassName>org.h2.Driver</spring.datasource.driverClassName>-->
+                <!--<spring.datasource.url>jdbc:h2:./target/mod-workflow;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</spring.datasource.url>-->
+                <!--<spring.jpa.database-platform>org.hibernate.dialect.H2Dialect</spring.jpa.database-platform>-->
+                <!--<spring.jpa.hibernate.ddl-auto>create-drop</spring.jpa.hibernate.ddl-auto>-->
               </systemPropertyVariables>
             </configuration>
             <executions>
               <execution>
-                <id>repackage</id>
+                <id>openapi-repackage</id>
                 <goals>
                   <goal>repackage</goal>
                 </goals>
@@ -355,13 +357,13 @@
                 </configuration>
               </execution>
               <execution>
-                <id>pre-integration-test</id>
+                <id>openapi-repackage-start</id>
                 <goals>
                   <goal>start</goal>
                 </goals>
               </execution>
               <execution>
-                <id>post-integration-test</id>
+                <id>openapi-repackage-stop</id>
                 <goals>
                   <goal>stop</goal>
                 </goals>
@@ -373,13 +375,14 @@
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-maven-plugin</artifactId>
             <configuration>
+              <skip>false</skip>
               <apiDocsUrl>http://localhost:${openapi.server.port}/api-docs.yaml</apiDocsUrl>
               <outputFileName>openapi.yaml</outputFileName>
               <outputDir>src/main/resources/</outputDir>
             </configuration>
             <executions>
               <execution>
-              <id>integration-test</id>
+              <id>openapi-generate-api</id>
               <goals>
                 <goal>generate</goal>
               </goals>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -338,7 +338,7 @@
               </arguments>
               <systemPropertyVariables>
                 <server.port>${openapi.server.port}</server.port>
-                <!--FIXME: The reason for this failing is unknown, for now postgresql can be used.-->
+                <!--The reason for this failing is unknown, for now postgresql can be used.-->
                 <!--<spring.sql.init.platform>h2</spring.sql.init.platform>-->
                 <!--<spring.datasource.driverClassName>org.h2.Driver</spring.datasource.driverClassName>-->
                 <!--<spring.datasource.url>jdbc:h2:./target/mod-workflow;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</spring.datasource.url>-->

--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -94,6 +94,9 @@ event:
   queue:
     name: event.queue
 
+folio:
+  tenant.validation: false
+
 tenant:
   header-name: X-Okapi-Tenant
   force-tenant: false

--- a/service/src/main/resources/openapi.yaml
+++ b/service/src/main/resources/openapi.yaml
@@ -3,9 +3,11 @@ info:
   title: OpenAPI definition
   version: v0
 servers:
-- url: http://localhost:9000/mod-workflow
+- url: http://localhost:9000
   description: Generated server url
 tags:
+- name: tenant
+  description: the tenant API
 - name: Actuator
   description: Monitor and interact
   externalDocs:
@@ -368,6 +370,5290 @@ paths:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/EntityModelTrigger'
+  /triggers/search/findViewAllBy:
+    get:
+      tags:
+      - trigger-search-controller
+      operationId: executeSearch-trigger-get
+      parameters:
+      - name: type
+        in: query
+        schema:
+          type: object
+          properties:
+            name:
+              type: string
+            module:
+              type: object
+              properties:
+                name:
+                  type: string
+                classLoader:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    registeredAsParallelCapable:
+                      type: boolean
+                    parent:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        registeredAsParallelCapable:
+                          type: boolean
+                        definedPackages:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              sealed:
+                                type: boolean
+                              specificationTitle:
+                                type: string
+                              specificationVersion:
+                                type: string
+                              specificationVendor:
+                                type: string
+                              implementationTitle:
+                                type: string
+                              implementationVersion:
+                                type: string
+                              implementationVendor:
+                                type: string
+                        defaultAssertionStatus:
+                          type: boolean
+                          writeOnly: true
+                    definedPackages:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          sealed:
+                            type: boolean
+                          specificationTitle:
+                            type: string
+                          specificationVersion:
+                            type: string
+                          specificationVendor:
+                            type: string
+                          implementationTitle:
+                            type: string
+                          implementationVersion:
+                            type: string
+                          implementationVendor:
+                            type: string
+                    defaultAssertionStatus:
+                      type: boolean
+                      writeOnly: true
+                descriptor:
+                  type: object
+                  properties:
+                    open:
+                      type: boolean
+                    automatic:
+                      type: boolean
+                named:
+                  type: boolean
+                annotations:
+                  type: array
+                  items:
+                    type: object
+                declaredAnnotations:
+                  type: array
+                  items:
+                    type: object
+                packages:
+                  uniqueItems: true
+                  type: array
+                  items:
+                    type: string
+                layer:
+                  type: object
+            protectionDomain:
+              type: object
+              properties:
+                principals:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                permissions:
+                  type: object
+                  properties:
+                    readOnly:
+                      type: boolean
+                classLoader:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    registeredAsParallelCapable:
+                      type: boolean
+                    parent:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        registeredAsParallelCapable:
+                          type: boolean
+                        definedPackages:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              sealed:
+                                type: boolean
+                              specificationTitle:
+                                type: string
+                              specificationVersion:
+                                type: string
+                              specificationVendor:
+                                type: string
+                              implementationTitle:
+                                type: string
+                              implementationVersion:
+                                type: string
+                              implementationVendor:
+                                type: string
+                        defaultAssertionStatus:
+                          type: boolean
+                          writeOnly: true
+                    definedPackages:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          sealed:
+                            type: boolean
+                          specificationTitle:
+                            type: string
+                          specificationVersion:
+                            type: string
+                          specificationVendor:
+                            type: string
+                          implementationTitle:
+                            type: string
+                          implementationVersion:
+                            type: string
+                          implementationVendor:
+                            type: string
+                    defaultAssertionStatus:
+                      type: boolean
+                      writeOnly: true
+                codeSource:
+                  type: object
+                  properties:
+                    location:
+                      type: string
+                      format: url
+                    certificates:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          type:
+                            type: string
+                          encoded:
+                            type: string
+                            format: byte
+                          publicKey:
+                            type: object
+                            properties:
+                              encoded:
+                                type: string
+                                format: byte
+                              format:
+                                type: string
+                              algorithm:
+                                type: string
+                    codeSigners:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          signerCertPath:
+                            type: object
+                            properties:
+                              type:
+                                type: string
+                              encodings:
+                                type: object
+                              certificates:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    type:
+                                      type: string
+                                    encoded:
+                                      type: string
+                                      format: byte
+                                    publicKey:
+                                      type: object
+                                      properties:
+                                        encoded:
+                                          type: string
+                                          format: byte
+                                        format:
+                                          type: string
+                                        algorithm:
+                                          type: string
+                              encoded:
+                                type: string
+                                format: byte
+                          timestamp:
+                            type: object
+                            properties:
+                              timestamp:
+                                type: string
+                                format: date-time
+                              signerCertPath:
+                                type: object
+                                properties:
+                                  type:
+                                    type: string
+                                  encodings:
+                                    type: object
+                                  certificates:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                        encoded:
+                                          type: string
+                                          format: byte
+                                        publicKey:
+                                          type: object
+                                          properties:
+                                            encoded:
+                                              type: string
+                                              format: byte
+                                            format:
+                                              type: string
+                                            algorithm:
+                                              type: string
+                                  encoded:
+                                    type: string
+                                    format: byte
+            modifiers:
+              type: integer
+              format: int32
+            interface:
+              type: boolean
+            array:
+              type: boolean
+            primitive:
+              type: boolean
+            hidden:
+              type: boolean
+            annotation:
+              type: boolean
+            enum:
+              type: boolean
+            record:
+              type: boolean
+            typeParameters:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  bounds:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                  annotatedBounds:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        type:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                  typeName:
+                    type: string
+                  annotations:
+                    type: array
+                    items:
+                      type: object
+                  declaredAnnotations:
+                    type: array
+                    items:
+                      type: object
+            classLoader:
+              type: object
+              properties:
+                name:
+                  type: string
+                registeredAsParallelCapable:
+                  type: boolean
+                parent:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    registeredAsParallelCapable:
+                      type: boolean
+                    definedPackages:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          sealed:
+                            type: boolean
+                          specificationTitle:
+                            type: string
+                          specificationVersion:
+                            type: string
+                          specificationVendor:
+                            type: string
+                          implementationTitle:
+                            type: string
+                          implementationVersion:
+                            type: string
+                          implementationVendor:
+                            type: string
+                    defaultAssertionStatus:
+                      type: boolean
+                      writeOnly: true
+                unnamedModule:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    classLoader:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        registeredAsParallelCapable:
+                          type: boolean
+                        parent:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            registeredAsParallelCapable:
+                              type: boolean
+                            definedPackages:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  sealed:
+                                    type: boolean
+                                  specificationTitle:
+                                    type: string
+                                  specificationVersion:
+                                    type: string
+                                  specificationVendor:
+                                    type: string
+                                  implementationTitle:
+                                    type: string
+                                  implementationVersion:
+                                    type: string
+                                  implementationVendor:
+                                    type: string
+                            defaultAssertionStatus:
+                              type: boolean
+                              writeOnly: true
+                        definedPackages:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              sealed:
+                                type: boolean
+                              specificationTitle:
+                                type: string
+                              specificationVersion:
+                                type: string
+                              specificationVendor:
+                                type: string
+                              implementationTitle:
+                                type: string
+                              implementationVersion:
+                                type: string
+                              implementationVendor:
+                                type: string
+                        defaultAssertionStatus:
+                          type: boolean
+                          writeOnly: true
+                    descriptor:
+                      type: object
+                      properties:
+                        open:
+                          type: boolean
+                        automatic:
+                          type: boolean
+                    named:
+                      type: boolean
+                    annotations:
+                      type: array
+                      items:
+                        type: object
+                    declaredAnnotations:
+                      type: array
+                      items:
+                        type: object
+                    packages:
+                      uniqueItems: true
+                      type: array
+                      items:
+                        type: string
+                    layer:
+                      type: object
+                definedPackages:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      sealed:
+                        type: boolean
+                      specificationTitle:
+                        type: string
+                      specificationVersion:
+                        type: string
+                      specificationVendor:
+                        type: string
+                      implementationTitle:
+                        type: string
+                      implementationVersion:
+                        type: string
+                      implementationVendor:
+                        type: string
+                defaultAssertionStatus:
+                  type: boolean
+                  writeOnly: true
+            simpleName:
+              type: string
+            canonicalName:
+              type: string
+            packageName:
+              type: string
+            synthetic:
+              type: boolean
+            genericSuperclass:
+              type: object
+              properties:
+                typeName:
+                  type: string
+            package:
+              type: object
+              properties:
+                name:
+                  type: string
+                annotations:
+                  type: array
+                  items:
+                    type: object
+                declaredAnnotations:
+                  type: array
+                  items:
+                    type: object
+                sealed:
+                  type: boolean
+                specificationTitle:
+                  type: string
+                specificationVersion:
+                  type: string
+                specificationVendor:
+                  type: string
+                implementationTitle:
+                  type: string
+                implementationVersion:
+                  type: string
+                implementationVendor:
+                  type: string
+            genericInterfaces:
+              type: array
+              items:
+                type: object
+                properties:
+                  typeName:
+                    type: string
+            signers:
+              type: array
+              items:
+                type: object
+            enclosingMethod:
+              type: object
+              properties:
+                name:
+                  type: string
+                modifiers:
+                  type: integer
+                  format: int32
+                typeParameters:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      bounds:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                      genericDeclaration:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          modifiers:
+                            type: integer
+                            format: int32
+                          synthetic:
+                            type: boolean
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          accessible:
+                            type: boolean
+                            deprecated: true
+                          varArgs:
+                            type: boolean
+                          parameterCount:
+                            type: integer
+                            format: int32
+                          parameterAnnotations:
+                            type: array
+                            items:
+                              type: array
+                              items:
+                                type: object
+                          genericParameterTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                          genericExceptionTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                          default:
+                            type: boolean
+                          genericReturnType:
+                            type: object
+                            properties:
+                              typeName:
+                                type: string
+                          bridge:
+                            type: boolean
+                          defaultValue:
+                            type: object
+                          annotatedReturnType:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                          annotatedParameterTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                          parameters:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                modifiers:
+                                  type: integer
+                                  format: int32
+                                synthetic:
+                                  type: boolean
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                annotatedType:
+                                  type: object
+                                  properties:
+                                    annotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    declaredAnnotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    type:
+                                      type: object
+                                      properties:
+                                        typeName:
+                                          type: string
+                                parameterizedType:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                                varArgs:
+                                  type: boolean
+                                namePresent:
+                                  type: boolean
+                                declaringExecutable:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                    modifiers:
+                                      type: integer
+                                      format: int32
+                                    typeParameters:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          name:
+                                            type: string
+                                          bounds:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                          genericDeclaration:
+                                            type: object
+                                          annotatedBounds:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                annotations:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                declaredAnnotations:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                type:
+                                                  type: object
+                                                  properties:
+                                                    typeName:
+                                                      type: string
+                                          typeName:
+                                            type: string
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                    synthetic:
+                                      type: boolean
+                                    declaredAnnotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    varArgs:
+                                      type: boolean
+                                    annotatedParameterTypes:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                    parameterCount:
+                                      type: integer
+                                      format: int32
+                                    parameterAnnotations:
+                                      type: array
+                                      items:
+                                        type: array
+                                        items:
+                                          type: object
+                                    genericParameterTypes:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                    genericExceptionTypes:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                    annotatedReturnType:
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        declaredAnnotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        type:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                    annotatedReceiverType:
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        declaredAnnotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        type:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                    annotatedExceptionTypes:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                    annotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    accessible:
+                                      type: boolean
+                                      deprecated: true
+                                implicit:
+                                  type: boolean
+                          annotatedReceiverType:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                          annotatedExceptionTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                      annotatedBounds:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            type:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                      typeName:
+                        type: string
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                synthetic:
+                  type: boolean
+                declaredAnnotations:
+                  type: array
+                  items:
+                    type: object
+                accessible:
+                  type: boolean
+                  deprecated: true
+                varArgs:
+                  type: boolean
+                parameterCount:
+                  type: integer
+                  format: int32
+                parameterAnnotations:
+                  type: array
+                  items:
+                    type: array
+                    items:
+                      type: object
+                genericParameterTypes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      typeName:
+                        type: string
+                genericExceptionTypes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      typeName:
+                        type: string
+                default:
+                  type: boolean
+                genericReturnType:
+                  type: object
+                  properties:
+                    typeName:
+                      type: string
+                bridge:
+                  type: boolean
+                defaultValue:
+                  type: object
+                annotatedReturnType:
+                  type: object
+                  properties:
+                    annotations:
+                      type: array
+                      items:
+                        type: object
+                    declaredAnnotations:
+                      type: array
+                      items:
+                        type: object
+                    type:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                annotatedParameterTypes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                parameters:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      modifiers:
+                        type: integer
+                        format: int32
+                      synthetic:
+                        type: boolean
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      annotatedType:
+                        type: object
+                        properties:
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          type:
+                            type: object
+                            properties:
+                              typeName:
+                                type: string
+                      parameterizedType:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                      varArgs:
+                        type: boolean
+                      namePresent:
+                        type: boolean
+                      declaringExecutable:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          modifiers:
+                            type: integer
+                            format: int32
+                          typeParameters:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                bounds:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                                genericDeclaration:
+                                  type: object
+                                annotatedBounds:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      type:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                typeName:
+                                  type: string
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                          synthetic:
+                            type: boolean
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          varArgs:
+                            type: boolean
+                          annotatedParameterTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                          parameterCount:
+                            type: integer
+                            format: int32
+                          parameterAnnotations:
+                            type: array
+                            items:
+                              type: array
+                              items:
+                                type: object
+                          genericParameterTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                          genericExceptionTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                          annotatedReturnType:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                          annotatedReceiverType:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                          annotatedExceptionTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                          accessible:
+                            type: boolean
+                            deprecated: true
+                      implicit:
+                        type: boolean
+                annotatedReceiverType:
+                  type: object
+                  properties:
+                    annotations:
+                      type: array
+                      items:
+                        type: object
+                    declaredAnnotations:
+                      type: array
+                      items:
+                        type: object
+                    type:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                annotatedExceptionTypes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                annotations:
+                  type: array
+                  items:
+                    type: object
+            enclosingConstructor:
+              type: object
+              properties:
+                name:
+                  type: string
+                modifiers:
+                  type: integer
+                  format: int32
+                typeParameters:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      bounds:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                      genericDeclaration:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          modifiers:
+                            type: integer
+                            format: int32
+                          synthetic:
+                            type: boolean
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          accessible:
+                            type: boolean
+                            deprecated: true
+                          varArgs:
+                            type: boolean
+                          parameterCount:
+                            type: integer
+                            format: int32
+                          parameterAnnotations:
+                            type: array
+                            items:
+                              type: array
+                              items:
+                                type: object
+                          genericParameterTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                          genericExceptionTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                          annotatedReturnType:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                          annotatedReceiverType:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                          annotatedParameterTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                          parameters:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                modifiers:
+                                  type: integer
+                                  format: int32
+                                synthetic:
+                                  type: boolean
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                annotatedType:
+                                  type: object
+                                  properties:
+                                    annotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    declaredAnnotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    type:
+                                      type: object
+                                      properties:
+                                        typeName:
+                                          type: string
+                                parameterizedType:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                                varArgs:
+                                  type: boolean
+                                namePresent:
+                                  type: boolean
+                                declaringExecutable:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                    modifiers:
+                                      type: integer
+                                      format: int32
+                                    typeParameters:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          name:
+                                            type: string
+                                          bounds:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                          genericDeclaration:
+                                            type: object
+                                          annotatedBounds:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                annotations:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                declaredAnnotations:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                type:
+                                                  type: object
+                                                  properties:
+                                                    typeName:
+                                                      type: string
+                                          typeName:
+                                            type: string
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                    synthetic:
+                                      type: boolean
+                                    declaredAnnotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    varArgs:
+                                      type: boolean
+                                    annotatedParameterTypes:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                    parameterCount:
+                                      type: integer
+                                      format: int32
+                                    parameterAnnotations:
+                                      type: array
+                                      items:
+                                        type: array
+                                        items:
+                                          type: object
+                                    genericParameterTypes:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                    genericExceptionTypes:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                    annotatedReturnType:
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        declaredAnnotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        type:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                    annotatedReceiverType:
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        declaredAnnotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        type:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                    annotatedExceptionTypes:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                    annotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    accessible:
+                                      type: boolean
+                                      deprecated: true
+                                implicit:
+                                  type: boolean
+                          annotatedExceptionTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                      annotatedBounds:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            type:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                      typeName:
+                        type: string
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                synthetic:
+                  type: boolean
+                declaredAnnotations:
+                  type: array
+                  items:
+                    type: object
+                accessible:
+                  type: boolean
+                  deprecated: true
+                varArgs:
+                  type: boolean
+                parameterCount:
+                  type: integer
+                  format: int32
+                parameterAnnotations:
+                  type: array
+                  items:
+                    type: array
+                    items:
+                      type: object
+                genericParameterTypes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      typeName:
+                        type: string
+                genericExceptionTypes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      typeName:
+                        type: string
+                annotatedReturnType:
+                  type: object
+                  properties:
+                    annotations:
+                      type: array
+                      items:
+                        type: object
+                    declaredAnnotations:
+                      type: array
+                      items:
+                        type: object
+                    type:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                annotatedReceiverType:
+                  type: object
+                  properties:
+                    annotations:
+                      type: array
+                      items:
+                        type: object
+                    declaredAnnotations:
+                      type: array
+                      items:
+                        type: object
+                    type:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                annotatedParameterTypes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                parameters:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      modifiers:
+                        type: integer
+                        format: int32
+                      synthetic:
+                        type: boolean
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      annotatedType:
+                        type: object
+                        properties:
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          type:
+                            type: object
+                            properties:
+                              typeName:
+                                type: string
+                      parameterizedType:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                      varArgs:
+                        type: boolean
+                      namePresent:
+                        type: boolean
+                      declaringExecutable:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          modifiers:
+                            type: integer
+                            format: int32
+                          typeParameters:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                bounds:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                                genericDeclaration:
+                                  type: object
+                                annotatedBounds:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      type:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                typeName:
+                                  type: string
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                          synthetic:
+                            type: boolean
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          varArgs:
+                            type: boolean
+                          annotatedParameterTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                          parameterCount:
+                            type: integer
+                            format: int32
+                          parameterAnnotations:
+                            type: array
+                            items:
+                              type: array
+                              items:
+                                type: object
+                          genericParameterTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                          genericExceptionTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                          annotatedReturnType:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                          annotatedReceiverType:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                          annotatedExceptionTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                          accessible:
+                            type: boolean
+                            deprecated: true
+                      implicit:
+                        type: boolean
+                annotatedExceptionTypes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                annotations:
+                  type: array
+                  items:
+                    type: object
+            typeName:
+              type: string
+            anonymousClass:
+              type: boolean
+            localClass:
+              type: boolean
+            memberClass:
+              type: boolean
+            fields:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  modifiers:
+                    type: integer
+                    format: int32
+                  synthetic:
+                    type: boolean
+                  declaredAnnotations:
+                    type: array
+                    items:
+                      type: object
+                  accessible:
+                    type: boolean
+                    deprecated: true
+                  genericType:
+                    type: object
+                    properties:
+                      typeName:
+                        type: string
+                  enumConstant:
+                    type: boolean
+                  annotatedType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                  annotations:
+                    type: array
+                    items:
+                      type: object
+            methods:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  modifiers:
+                    type: integer
+                    format: int32
+                  typeParameters:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        bounds:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              typeName:
+                                type: string
+                        genericDeclaration:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            modifiers:
+                              type: integer
+                              format: int32
+                            synthetic:
+                              type: boolean
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            accessible:
+                              type: boolean
+                              deprecated: true
+                            varArgs:
+                              type: boolean
+                            parameterCount:
+                              type: integer
+                              format: int32
+                            parameterAnnotations:
+                              type: array
+                              items:
+                                type: array
+                                items:
+                                  type: object
+                            genericParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            genericExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            default:
+                              type: boolean
+                            genericReturnType:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                            bridge:
+                              type: boolean
+                            defaultValue:
+                              type: object
+                            annotatedReturnType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            parameters:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  modifiers:
+                                    type: integer
+                                    format: int32
+                                  synthetic:
+                                    type: boolean
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  annotatedType:
+                                    type: object
+                                    properties:
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      type:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                  parameterizedType:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                                  varArgs:
+                                    type: boolean
+                                  namePresent:
+                                    type: boolean
+                                  declaringExecutable:
+                                    type: object
+                                    properties:
+                                      name:
+                                        type: string
+                                      modifiers:
+                                        type: integer
+                                        format: int32
+                                      typeParameters:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            name:
+                                              type: string
+                                            bounds:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  typeName:
+                                                    type: string
+                                            genericDeclaration:
+                                              type: object
+                                            annotatedBounds:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  annotations:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                  declaredAnnotations:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                  type:
+                                                    type: object
+                                                    properties:
+                                                      typeName:
+                                                        type: string
+                                            typeName:
+                                              type: string
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                      synthetic:
+                                        type: boolean
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      varArgs:
+                                        type: boolean
+                                      annotatedParameterTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            type:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                      parameterCount:
+                                        type: integer
+                                        format: int32
+                                      parameterAnnotations:
+                                        type: array
+                                        items:
+                                          type: array
+                                          items:
+                                            type: object
+                                      genericParameterTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                      genericExceptionTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                      annotatedReturnType:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                      annotatedReceiverType:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                      annotatedExceptionTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            type:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      accessible:
+                                        type: boolean
+                                        deprecated: true
+                                  implicit:
+                                    type: boolean
+                            annotatedReceiverType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                        annotatedBounds:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                        typeName:
+                          type: string
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                  synthetic:
+                    type: boolean
+                  declaredAnnotations:
+                    type: array
+                    items:
+                      type: object
+                  accessible:
+                    type: boolean
+                    deprecated: true
+                  varArgs:
+                    type: boolean
+                  parameterCount:
+                    type: integer
+                    format: int32
+                  parameterAnnotations:
+                    type: array
+                    items:
+                      type: array
+                      items:
+                        type: object
+                  genericParameterTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                  genericExceptionTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                  default:
+                    type: boolean
+                  genericReturnType:
+                    type: object
+                    properties:
+                      typeName:
+                        type: string
+                  bridge:
+                    type: boolean
+                  defaultValue:
+                    type: object
+                  annotatedReturnType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                  annotatedParameterTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        type:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                  parameters:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        modifiers:
+                          type: integer
+                          format: int32
+                        synthetic:
+                          type: boolean
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        annotatedType:
+                          type: object
+                          properties:
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            type:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                        parameterizedType:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                        varArgs:
+                          type: boolean
+                        namePresent:
+                          type: boolean
+                        declaringExecutable:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            modifiers:
+                              type: integer
+                              format: int32
+                            typeParameters:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  bounds:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        typeName:
+                                          type: string
+                                  genericDeclaration:
+                                    type: object
+                                  annotatedBounds:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        declaredAnnotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        type:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                  typeName:
+                                    type: string
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                            synthetic:
+                              type: boolean
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            varArgs:
+                              type: boolean
+                            annotatedParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            parameterCount:
+                              type: integer
+                              format: int32
+                            parameterAnnotations:
+                              type: array
+                              items:
+                                type: array
+                                items:
+                                  type: object
+                            genericParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            genericExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            annotatedReturnType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedReceiverType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            accessible:
+                              type: boolean
+                              deprecated: true
+                        implicit:
+                          type: boolean
+                  annotatedReceiverType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                  annotatedExceptionTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        type:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                  annotations:
+                    type: array
+                    items:
+                      type: object
+            constructors:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  modifiers:
+                    type: integer
+                    format: int32
+                  typeParameters:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        bounds:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              typeName:
+                                type: string
+                        genericDeclaration:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            modifiers:
+                              type: integer
+                              format: int32
+                            synthetic:
+                              type: boolean
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            accessible:
+                              type: boolean
+                              deprecated: true
+                            varArgs:
+                              type: boolean
+                            parameterCount:
+                              type: integer
+                              format: int32
+                            parameterAnnotations:
+                              type: array
+                              items:
+                                type: array
+                                items:
+                                  type: object
+                            genericParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            genericExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            annotatedReturnType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedReceiverType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            parameters:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  modifiers:
+                                    type: integer
+                                    format: int32
+                                  synthetic:
+                                    type: boolean
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  annotatedType:
+                                    type: object
+                                    properties:
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      type:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                  parameterizedType:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                                  varArgs:
+                                    type: boolean
+                                  namePresent:
+                                    type: boolean
+                                  declaringExecutable:
+                                    type: object
+                                    properties:
+                                      name:
+                                        type: string
+                                      modifiers:
+                                        type: integer
+                                        format: int32
+                                      typeParameters:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            name:
+                                              type: string
+                                            bounds:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  typeName:
+                                                    type: string
+                                            genericDeclaration:
+                                              type: object
+                                            annotatedBounds:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  annotations:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                  declaredAnnotations:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                  type:
+                                                    type: object
+                                                    properties:
+                                                      typeName:
+                                                        type: string
+                                            typeName:
+                                              type: string
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                      synthetic:
+                                        type: boolean
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      varArgs:
+                                        type: boolean
+                                      annotatedParameterTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            type:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                      parameterCount:
+                                        type: integer
+                                        format: int32
+                                      parameterAnnotations:
+                                        type: array
+                                        items:
+                                          type: array
+                                          items:
+                                            type: object
+                                      genericParameterTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                      genericExceptionTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                      annotatedReturnType:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                      annotatedReceiverType:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                      annotatedExceptionTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            type:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      accessible:
+                                        type: boolean
+                                        deprecated: true
+                                  implicit:
+                                    type: boolean
+                            annotatedExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                        annotatedBounds:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                        typeName:
+                          type: string
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                  synthetic:
+                    type: boolean
+                  declaredAnnotations:
+                    type: array
+                    items:
+                      type: object
+                  accessible:
+                    type: boolean
+                    deprecated: true
+                  varArgs:
+                    type: boolean
+                  parameterCount:
+                    type: integer
+                    format: int32
+                  parameterAnnotations:
+                    type: array
+                    items:
+                      type: array
+                      items:
+                        type: object
+                  genericParameterTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                  genericExceptionTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                  annotatedReturnType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                  annotatedReceiverType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                  annotatedParameterTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        type:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                  parameters:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        modifiers:
+                          type: integer
+                          format: int32
+                        synthetic:
+                          type: boolean
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        annotatedType:
+                          type: object
+                          properties:
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            type:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                        parameterizedType:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                        varArgs:
+                          type: boolean
+                        namePresent:
+                          type: boolean
+                        declaringExecutable:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            modifiers:
+                              type: integer
+                              format: int32
+                            typeParameters:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  bounds:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        typeName:
+                                          type: string
+                                  genericDeclaration:
+                                    type: object
+                                  annotatedBounds:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        declaredAnnotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        type:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                  typeName:
+                                    type: string
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                            synthetic:
+                              type: boolean
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            varArgs:
+                              type: boolean
+                            annotatedParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            parameterCount:
+                              type: integer
+                              format: int32
+                            parameterAnnotations:
+                              type: array
+                              items:
+                                type: array
+                                items:
+                                  type: object
+                            genericParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            genericExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            annotatedReturnType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedReceiverType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            accessible:
+                              type: boolean
+                              deprecated: true
+                        implicit:
+                          type: boolean
+                  annotatedExceptionTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        type:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                  annotations:
+                    type: array
+                    items:
+                      type: object
+            declaredFields:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  modifiers:
+                    type: integer
+                    format: int32
+                  synthetic:
+                    type: boolean
+                  declaredAnnotations:
+                    type: array
+                    items:
+                      type: object
+                  accessible:
+                    type: boolean
+                    deprecated: true
+                  genericType:
+                    type: object
+                    properties:
+                      typeName:
+                        type: string
+                  enumConstant:
+                    type: boolean
+                  annotatedType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                  annotations:
+                    type: array
+                    items:
+                      type: object
+            recordComponents:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  accessor:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      modifiers:
+                        type: integer
+                        format: int32
+                      synthetic:
+                        type: boolean
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      accessible:
+                        type: boolean
+                        deprecated: true
+                      varArgs:
+                        type: boolean
+                      parameterCount:
+                        type: integer
+                        format: int32
+                      parameterAnnotations:
+                        type: array
+                        items:
+                          type: array
+                          items:
+                            type: object
+                      genericParameterTypes:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                      genericExceptionTypes:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                      default:
+                        type: boolean
+                      genericReturnType:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                      bridge:
+                        type: boolean
+                      defaultValue:
+                        type: object
+                      annotatedReturnType:
+                        type: object
+                        properties:
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          type:
+                            type: object
+                            properties:
+                              typeName:
+                                type: string
+                      annotatedParameterTypes:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            type:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                      parameters:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            modifiers:
+                              type: integer
+                              format: int32
+                            synthetic:
+                              type: boolean
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            annotatedType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            parameterizedType:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                            varArgs:
+                              type: boolean
+                            namePresent:
+                              type: boolean
+                            declaringExecutable:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                modifiers:
+                                  type: integer
+                                  format: int32
+                                typeParameters:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      name:
+                                        type: string
+                                      bounds:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                      genericDeclaration:
+                                        type: object
+                                      annotatedBounds:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            type:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                      typeName:
+                                        type: string
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                synthetic:
+                                  type: boolean
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                varArgs:
+                                  type: boolean
+                                annotatedParameterTypes:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      type:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                parameterCount:
+                                  type: integer
+                                  format: int32
+                                parameterAnnotations:
+                                  type: array
+                                  items:
+                                    type: array
+                                    items:
+                                      type: object
+                                genericParameterTypes:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                                genericExceptionTypes:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                                annotatedReturnType:
+                                  type: object
+                                  properties:
+                                    annotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    declaredAnnotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    type:
+                                      type: object
+                                      properties:
+                                        typeName:
+                                          type: string
+                                annotatedReceiverType:
+                                  type: object
+                                  properties:
+                                    annotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    declaredAnnotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    type:
+                                      type: object
+                                      properties:
+                                        typeName:
+                                          type: string
+                                annotatedExceptionTypes:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      type:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                accessible:
+                                  type: boolean
+                                  deprecated: true
+                            implicit:
+                              type: boolean
+                      annotatedReceiverType:
+                        type: object
+                        properties:
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          type:
+                            type: object
+                            properties:
+                              typeName:
+                                type: string
+                      annotatedExceptionTypes:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            type:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                  annotations:
+                    type: array
+                    items:
+                      type: object
+                  declaredAnnotations:
+                    type: array
+                    items:
+                      type: object
+                  genericSignature:
+                    type: string
+                  genericType:
+                    type: object
+                    properties:
+                      typeName:
+                        type: string
+                  annotatedType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+            declaredMethods:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  modifiers:
+                    type: integer
+                    format: int32
+                  typeParameters:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        bounds:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              typeName:
+                                type: string
+                        genericDeclaration:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            modifiers:
+                              type: integer
+                              format: int32
+                            synthetic:
+                              type: boolean
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            accessible:
+                              type: boolean
+                              deprecated: true
+                            varArgs:
+                              type: boolean
+                            parameterCount:
+                              type: integer
+                              format: int32
+                            parameterAnnotations:
+                              type: array
+                              items:
+                                type: array
+                                items:
+                                  type: object
+                            genericParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            genericExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            default:
+                              type: boolean
+                            genericReturnType:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                            bridge:
+                              type: boolean
+                            defaultValue:
+                              type: object
+                            annotatedReturnType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            parameters:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  modifiers:
+                                    type: integer
+                                    format: int32
+                                  synthetic:
+                                    type: boolean
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  annotatedType:
+                                    type: object
+                                    properties:
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      type:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                  parameterizedType:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                                  varArgs:
+                                    type: boolean
+                                  namePresent:
+                                    type: boolean
+                                  declaringExecutable:
+                                    type: object
+                                    properties:
+                                      name:
+                                        type: string
+                                      modifiers:
+                                        type: integer
+                                        format: int32
+                                      typeParameters:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            name:
+                                              type: string
+                                            bounds:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  typeName:
+                                                    type: string
+                                            genericDeclaration:
+                                              type: object
+                                            annotatedBounds:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  annotations:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                  declaredAnnotations:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                  type:
+                                                    type: object
+                                                    properties:
+                                                      typeName:
+                                                        type: string
+                                            typeName:
+                                              type: string
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                      synthetic:
+                                        type: boolean
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      varArgs:
+                                        type: boolean
+                                      annotatedParameterTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            type:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                      parameterCount:
+                                        type: integer
+                                        format: int32
+                                      parameterAnnotations:
+                                        type: array
+                                        items:
+                                          type: array
+                                          items:
+                                            type: object
+                                      genericParameterTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                      genericExceptionTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                      annotatedReturnType:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                      annotatedReceiverType:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                      annotatedExceptionTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            type:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      accessible:
+                                        type: boolean
+                                        deprecated: true
+                                  implicit:
+                                    type: boolean
+                            annotatedReceiverType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                        annotatedBounds:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                        typeName:
+                          type: string
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                  synthetic:
+                    type: boolean
+                  declaredAnnotations:
+                    type: array
+                    items:
+                      type: object
+                  accessible:
+                    type: boolean
+                    deprecated: true
+                  varArgs:
+                    type: boolean
+                  parameterCount:
+                    type: integer
+                    format: int32
+                  parameterAnnotations:
+                    type: array
+                    items:
+                      type: array
+                      items:
+                        type: object
+                  genericParameterTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                  genericExceptionTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                  default:
+                    type: boolean
+                  genericReturnType:
+                    type: object
+                    properties:
+                      typeName:
+                        type: string
+                  bridge:
+                    type: boolean
+                  defaultValue:
+                    type: object
+                  annotatedReturnType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                  annotatedParameterTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        type:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                  parameters:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        modifiers:
+                          type: integer
+                          format: int32
+                        synthetic:
+                          type: boolean
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        annotatedType:
+                          type: object
+                          properties:
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            type:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                        parameterizedType:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                        varArgs:
+                          type: boolean
+                        namePresent:
+                          type: boolean
+                        declaringExecutable:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            modifiers:
+                              type: integer
+                              format: int32
+                            typeParameters:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  bounds:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        typeName:
+                                          type: string
+                                  genericDeclaration:
+                                    type: object
+                                  annotatedBounds:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        declaredAnnotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        type:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                  typeName:
+                                    type: string
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                            synthetic:
+                              type: boolean
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            varArgs:
+                              type: boolean
+                            annotatedParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            parameterCount:
+                              type: integer
+                              format: int32
+                            parameterAnnotations:
+                              type: array
+                              items:
+                                type: array
+                                items:
+                                  type: object
+                            genericParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            genericExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            annotatedReturnType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedReceiverType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            accessible:
+                              type: boolean
+                              deprecated: true
+                        implicit:
+                          type: boolean
+                  annotatedReceiverType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                  annotatedExceptionTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        type:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                  annotations:
+                    type: array
+                    items:
+                      type: object
+            declaredConstructors:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  modifiers:
+                    type: integer
+                    format: int32
+                  typeParameters:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        bounds:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              typeName:
+                                type: string
+                        genericDeclaration:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            modifiers:
+                              type: integer
+                              format: int32
+                            synthetic:
+                              type: boolean
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            accessible:
+                              type: boolean
+                              deprecated: true
+                            varArgs:
+                              type: boolean
+                            parameterCount:
+                              type: integer
+                              format: int32
+                            parameterAnnotations:
+                              type: array
+                              items:
+                                type: array
+                                items:
+                                  type: object
+                            genericParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            genericExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            annotatedReturnType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedReceiverType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            parameters:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  modifiers:
+                                    type: integer
+                                    format: int32
+                                  synthetic:
+                                    type: boolean
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  annotatedType:
+                                    type: object
+                                    properties:
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      type:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                  parameterizedType:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                                  varArgs:
+                                    type: boolean
+                                  namePresent:
+                                    type: boolean
+                                  declaringExecutable:
+                                    type: object
+                                    properties:
+                                      name:
+                                        type: string
+                                      modifiers:
+                                        type: integer
+                                        format: int32
+                                      typeParameters:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            name:
+                                              type: string
+                                            bounds:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  typeName:
+                                                    type: string
+                                            genericDeclaration:
+                                              type: object
+                                            annotatedBounds:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  annotations:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                  declaredAnnotations:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                  type:
+                                                    type: object
+                                                    properties:
+                                                      typeName:
+                                                        type: string
+                                            typeName:
+                                              type: string
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                      synthetic:
+                                        type: boolean
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      varArgs:
+                                        type: boolean
+                                      annotatedParameterTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            type:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                      parameterCount:
+                                        type: integer
+                                        format: int32
+                                      parameterAnnotations:
+                                        type: array
+                                        items:
+                                          type: array
+                                          items:
+                                            type: object
+                                      genericParameterTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                      genericExceptionTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                      annotatedReturnType:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                      annotatedReceiverType:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                      annotatedExceptionTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            type:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      accessible:
+                                        type: boolean
+                                        deprecated: true
+                                  implicit:
+                                    type: boolean
+                            annotatedExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                        annotatedBounds:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                        typeName:
+                          type: string
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                  synthetic:
+                    type: boolean
+                  declaredAnnotations:
+                    type: array
+                    items:
+                      type: object
+                  accessible:
+                    type: boolean
+                    deprecated: true
+                  varArgs:
+                    type: boolean
+                  parameterCount:
+                    type: integer
+                    format: int32
+                  parameterAnnotations:
+                    type: array
+                    items:
+                      type: array
+                      items:
+                        type: object
+                  genericParameterTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                  genericExceptionTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                  annotatedReturnType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                  annotatedReceiverType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                  annotatedParameterTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        type:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                  parameters:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        modifiers:
+                          type: integer
+                          format: int32
+                        synthetic:
+                          type: boolean
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        annotatedType:
+                          type: object
+                          properties:
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            type:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                        parameterizedType:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                        varArgs:
+                          type: boolean
+                        namePresent:
+                          type: boolean
+                        declaringExecutable:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            modifiers:
+                              type: integer
+                              format: int32
+                            typeParameters:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  bounds:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        typeName:
+                                          type: string
+                                  genericDeclaration:
+                                    type: object
+                                  annotatedBounds:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        declaredAnnotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        type:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                  typeName:
+                                    type: string
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                            synthetic:
+                              type: boolean
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            varArgs:
+                              type: boolean
+                            annotatedParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            parameterCount:
+                              type: integer
+                              format: int32
+                            parameterAnnotations:
+                              type: array
+                              items:
+                                type: array
+                                items:
+                                  type: object
+                            genericParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            genericExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            annotatedReturnType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedReceiverType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            accessible:
+                              type: boolean
+                              deprecated: true
+                        implicit:
+                          type: boolean
+                  annotatedExceptionTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        type:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                  annotations:
+                    type: array
+                    items:
+                      type: object
+            enumConstants:
+              type: array
+              items:
+                type: object
+            annotations:
+              type: array
+              items:
+                type: object
+            declaredAnnotations:
+              type: array
+              items:
+                type: object
+            annotatedSuperclass:
+              type: object
+              properties:
+                annotations:
+                  type: array
+                  items:
+                    type: object
+                declaredAnnotations:
+                  type: array
+                  items:
+                    type: object
+                type:
+                  type: object
+                  properties:
+                    typeName:
+                      type: string
+            annotatedInterfaces:
+              type: array
+              items:
+                type: object
+                properties:
+                  annotations:
+                    type: array
+                    items:
+                      type: object
+                  declaredAnnotations:
+                    type: array
+                    items:
+                      type: object
+                  type:
+                    type: object
+                    properties:
+                      typeName:
+                        type: string
+            sealed:
+              type: boolean
+      responses:
+        "200":
+          description: OK
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/CollectionModelEntityModelTrigger'
+        "404":
+          description: Not Found
   /triggers/{id}:
     get:
       tags:
@@ -526,6 +5812,5294 @@ paths:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/EntityModelWorkflow'
+  /workflows/search/getViewById:
+    get:
+      tags:
+      - workflow-search-controller
+      operationId: executeSearch-workflow-get
+      parameters:
+      - name: id
+        in: query
+        schema:
+          type: string
+      - name: type
+        in: query
+        schema:
+          type: object
+          properties:
+            name:
+              type: string
+            module:
+              type: object
+              properties:
+                name:
+                  type: string
+                classLoader:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    registeredAsParallelCapable:
+                      type: boolean
+                    parent:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        registeredAsParallelCapable:
+                          type: boolean
+                        definedPackages:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              sealed:
+                                type: boolean
+                              specificationTitle:
+                                type: string
+                              specificationVersion:
+                                type: string
+                              specificationVendor:
+                                type: string
+                              implementationTitle:
+                                type: string
+                              implementationVersion:
+                                type: string
+                              implementationVendor:
+                                type: string
+                        defaultAssertionStatus:
+                          type: boolean
+                          writeOnly: true
+                    definedPackages:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          sealed:
+                            type: boolean
+                          specificationTitle:
+                            type: string
+                          specificationVersion:
+                            type: string
+                          specificationVendor:
+                            type: string
+                          implementationTitle:
+                            type: string
+                          implementationVersion:
+                            type: string
+                          implementationVendor:
+                            type: string
+                    defaultAssertionStatus:
+                      type: boolean
+                      writeOnly: true
+                descriptor:
+                  type: object
+                  properties:
+                    open:
+                      type: boolean
+                    automatic:
+                      type: boolean
+                named:
+                  type: boolean
+                annotations:
+                  type: array
+                  items:
+                    type: object
+                declaredAnnotations:
+                  type: array
+                  items:
+                    type: object
+                packages:
+                  uniqueItems: true
+                  type: array
+                  items:
+                    type: string
+                layer:
+                  type: object
+            protectionDomain:
+              type: object
+              properties:
+                principals:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                permissions:
+                  type: object
+                  properties:
+                    readOnly:
+                      type: boolean
+                classLoader:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    registeredAsParallelCapable:
+                      type: boolean
+                    parent:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        registeredAsParallelCapable:
+                          type: boolean
+                        definedPackages:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              sealed:
+                                type: boolean
+                              specificationTitle:
+                                type: string
+                              specificationVersion:
+                                type: string
+                              specificationVendor:
+                                type: string
+                              implementationTitle:
+                                type: string
+                              implementationVersion:
+                                type: string
+                              implementationVendor:
+                                type: string
+                        defaultAssertionStatus:
+                          type: boolean
+                          writeOnly: true
+                    definedPackages:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          sealed:
+                            type: boolean
+                          specificationTitle:
+                            type: string
+                          specificationVersion:
+                            type: string
+                          specificationVendor:
+                            type: string
+                          implementationTitle:
+                            type: string
+                          implementationVersion:
+                            type: string
+                          implementationVendor:
+                            type: string
+                    defaultAssertionStatus:
+                      type: boolean
+                      writeOnly: true
+                codeSource:
+                  type: object
+                  properties:
+                    location:
+                      type: string
+                      format: url
+                    certificates:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          type:
+                            type: string
+                          encoded:
+                            type: string
+                            format: byte
+                          publicKey:
+                            type: object
+                            properties:
+                              encoded:
+                                type: string
+                                format: byte
+                              format:
+                                type: string
+                              algorithm:
+                                type: string
+                    codeSigners:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          signerCertPath:
+                            type: object
+                            properties:
+                              type:
+                                type: string
+                              encodings:
+                                type: object
+                              certificates:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    type:
+                                      type: string
+                                    encoded:
+                                      type: string
+                                      format: byte
+                                    publicKey:
+                                      type: object
+                                      properties:
+                                        encoded:
+                                          type: string
+                                          format: byte
+                                        format:
+                                          type: string
+                                        algorithm:
+                                          type: string
+                              encoded:
+                                type: string
+                                format: byte
+                          timestamp:
+                            type: object
+                            properties:
+                              timestamp:
+                                type: string
+                                format: date-time
+                              signerCertPath:
+                                type: object
+                                properties:
+                                  type:
+                                    type: string
+                                  encodings:
+                                    type: object
+                                  certificates:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                        encoded:
+                                          type: string
+                                          format: byte
+                                        publicKey:
+                                          type: object
+                                          properties:
+                                            encoded:
+                                              type: string
+                                              format: byte
+                                            format:
+                                              type: string
+                                            algorithm:
+                                              type: string
+                                  encoded:
+                                    type: string
+                                    format: byte
+            modifiers:
+              type: integer
+              format: int32
+            interface:
+              type: boolean
+            array:
+              type: boolean
+            primitive:
+              type: boolean
+            hidden:
+              type: boolean
+            annotation:
+              type: boolean
+            enum:
+              type: boolean
+            record:
+              type: boolean
+            typeParameters:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  bounds:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                  annotatedBounds:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        type:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                  typeName:
+                    type: string
+                  annotations:
+                    type: array
+                    items:
+                      type: object
+                  declaredAnnotations:
+                    type: array
+                    items:
+                      type: object
+            classLoader:
+              type: object
+              properties:
+                name:
+                  type: string
+                registeredAsParallelCapable:
+                  type: boolean
+                parent:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    registeredAsParallelCapable:
+                      type: boolean
+                    definedPackages:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          sealed:
+                            type: boolean
+                          specificationTitle:
+                            type: string
+                          specificationVersion:
+                            type: string
+                          specificationVendor:
+                            type: string
+                          implementationTitle:
+                            type: string
+                          implementationVersion:
+                            type: string
+                          implementationVendor:
+                            type: string
+                    defaultAssertionStatus:
+                      type: boolean
+                      writeOnly: true
+                unnamedModule:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    classLoader:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        registeredAsParallelCapable:
+                          type: boolean
+                        parent:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            registeredAsParallelCapable:
+                              type: boolean
+                            definedPackages:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  sealed:
+                                    type: boolean
+                                  specificationTitle:
+                                    type: string
+                                  specificationVersion:
+                                    type: string
+                                  specificationVendor:
+                                    type: string
+                                  implementationTitle:
+                                    type: string
+                                  implementationVersion:
+                                    type: string
+                                  implementationVendor:
+                                    type: string
+                            defaultAssertionStatus:
+                              type: boolean
+                              writeOnly: true
+                        definedPackages:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              sealed:
+                                type: boolean
+                              specificationTitle:
+                                type: string
+                              specificationVersion:
+                                type: string
+                              specificationVendor:
+                                type: string
+                              implementationTitle:
+                                type: string
+                              implementationVersion:
+                                type: string
+                              implementationVendor:
+                                type: string
+                        defaultAssertionStatus:
+                          type: boolean
+                          writeOnly: true
+                    descriptor:
+                      type: object
+                      properties:
+                        open:
+                          type: boolean
+                        automatic:
+                          type: boolean
+                    named:
+                      type: boolean
+                    annotations:
+                      type: array
+                      items:
+                        type: object
+                    declaredAnnotations:
+                      type: array
+                      items:
+                        type: object
+                    packages:
+                      uniqueItems: true
+                      type: array
+                      items:
+                        type: string
+                    layer:
+                      type: object
+                definedPackages:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      sealed:
+                        type: boolean
+                      specificationTitle:
+                        type: string
+                      specificationVersion:
+                        type: string
+                      specificationVendor:
+                        type: string
+                      implementationTitle:
+                        type: string
+                      implementationVersion:
+                        type: string
+                      implementationVendor:
+                        type: string
+                defaultAssertionStatus:
+                  type: boolean
+                  writeOnly: true
+            simpleName:
+              type: string
+            canonicalName:
+              type: string
+            packageName:
+              type: string
+            synthetic:
+              type: boolean
+            genericSuperclass:
+              type: object
+              properties:
+                typeName:
+                  type: string
+            package:
+              type: object
+              properties:
+                name:
+                  type: string
+                annotations:
+                  type: array
+                  items:
+                    type: object
+                declaredAnnotations:
+                  type: array
+                  items:
+                    type: object
+                sealed:
+                  type: boolean
+                specificationTitle:
+                  type: string
+                specificationVersion:
+                  type: string
+                specificationVendor:
+                  type: string
+                implementationTitle:
+                  type: string
+                implementationVersion:
+                  type: string
+                implementationVendor:
+                  type: string
+            genericInterfaces:
+              type: array
+              items:
+                type: object
+                properties:
+                  typeName:
+                    type: string
+            signers:
+              type: array
+              items:
+                type: object
+            enclosingMethod:
+              type: object
+              properties:
+                name:
+                  type: string
+                modifiers:
+                  type: integer
+                  format: int32
+                typeParameters:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      bounds:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                      genericDeclaration:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          modifiers:
+                            type: integer
+                            format: int32
+                          synthetic:
+                            type: boolean
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          accessible:
+                            type: boolean
+                            deprecated: true
+                          varArgs:
+                            type: boolean
+                          parameterCount:
+                            type: integer
+                            format: int32
+                          parameterAnnotations:
+                            type: array
+                            items:
+                              type: array
+                              items:
+                                type: object
+                          genericParameterTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                          genericExceptionTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                          default:
+                            type: boolean
+                          genericReturnType:
+                            type: object
+                            properties:
+                              typeName:
+                                type: string
+                          bridge:
+                            type: boolean
+                          defaultValue:
+                            type: object
+                          annotatedReturnType:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                          annotatedParameterTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                          parameters:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                modifiers:
+                                  type: integer
+                                  format: int32
+                                synthetic:
+                                  type: boolean
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                annotatedType:
+                                  type: object
+                                  properties:
+                                    annotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    declaredAnnotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    type:
+                                      type: object
+                                      properties:
+                                        typeName:
+                                          type: string
+                                parameterizedType:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                                varArgs:
+                                  type: boolean
+                                namePresent:
+                                  type: boolean
+                                declaringExecutable:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                    modifiers:
+                                      type: integer
+                                      format: int32
+                                    typeParameters:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          name:
+                                            type: string
+                                          bounds:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                          genericDeclaration:
+                                            type: object
+                                          annotatedBounds:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                annotations:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                declaredAnnotations:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                type:
+                                                  type: object
+                                                  properties:
+                                                    typeName:
+                                                      type: string
+                                          typeName:
+                                            type: string
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                    synthetic:
+                                      type: boolean
+                                    declaredAnnotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    varArgs:
+                                      type: boolean
+                                    annotatedParameterTypes:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                    parameterCount:
+                                      type: integer
+                                      format: int32
+                                    parameterAnnotations:
+                                      type: array
+                                      items:
+                                        type: array
+                                        items:
+                                          type: object
+                                    genericParameterTypes:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                    genericExceptionTypes:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                    annotatedReturnType:
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        declaredAnnotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        type:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                    annotatedReceiverType:
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        declaredAnnotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        type:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                    annotatedExceptionTypes:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                    annotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    accessible:
+                                      type: boolean
+                                      deprecated: true
+                                implicit:
+                                  type: boolean
+                          annotatedReceiverType:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                          annotatedExceptionTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                      annotatedBounds:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            type:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                      typeName:
+                        type: string
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                synthetic:
+                  type: boolean
+                declaredAnnotations:
+                  type: array
+                  items:
+                    type: object
+                accessible:
+                  type: boolean
+                  deprecated: true
+                varArgs:
+                  type: boolean
+                parameterCount:
+                  type: integer
+                  format: int32
+                parameterAnnotations:
+                  type: array
+                  items:
+                    type: array
+                    items:
+                      type: object
+                genericParameterTypes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      typeName:
+                        type: string
+                genericExceptionTypes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      typeName:
+                        type: string
+                default:
+                  type: boolean
+                genericReturnType:
+                  type: object
+                  properties:
+                    typeName:
+                      type: string
+                bridge:
+                  type: boolean
+                defaultValue:
+                  type: object
+                annotatedReturnType:
+                  type: object
+                  properties:
+                    annotations:
+                      type: array
+                      items:
+                        type: object
+                    declaredAnnotations:
+                      type: array
+                      items:
+                        type: object
+                    type:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                annotatedParameterTypes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                parameters:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      modifiers:
+                        type: integer
+                        format: int32
+                      synthetic:
+                        type: boolean
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      annotatedType:
+                        type: object
+                        properties:
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          type:
+                            type: object
+                            properties:
+                              typeName:
+                                type: string
+                      parameterizedType:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                      varArgs:
+                        type: boolean
+                      namePresent:
+                        type: boolean
+                      declaringExecutable:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          modifiers:
+                            type: integer
+                            format: int32
+                          typeParameters:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                bounds:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                                genericDeclaration:
+                                  type: object
+                                annotatedBounds:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      type:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                typeName:
+                                  type: string
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                          synthetic:
+                            type: boolean
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          varArgs:
+                            type: boolean
+                          annotatedParameterTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                          parameterCount:
+                            type: integer
+                            format: int32
+                          parameterAnnotations:
+                            type: array
+                            items:
+                              type: array
+                              items:
+                                type: object
+                          genericParameterTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                          genericExceptionTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                          annotatedReturnType:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                          annotatedReceiverType:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                          annotatedExceptionTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                          accessible:
+                            type: boolean
+                            deprecated: true
+                      implicit:
+                        type: boolean
+                annotatedReceiverType:
+                  type: object
+                  properties:
+                    annotations:
+                      type: array
+                      items:
+                        type: object
+                    declaredAnnotations:
+                      type: array
+                      items:
+                        type: object
+                    type:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                annotatedExceptionTypes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                annotations:
+                  type: array
+                  items:
+                    type: object
+            enclosingConstructor:
+              type: object
+              properties:
+                name:
+                  type: string
+                modifiers:
+                  type: integer
+                  format: int32
+                typeParameters:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      bounds:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                      genericDeclaration:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          modifiers:
+                            type: integer
+                            format: int32
+                          synthetic:
+                            type: boolean
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          accessible:
+                            type: boolean
+                            deprecated: true
+                          varArgs:
+                            type: boolean
+                          parameterCount:
+                            type: integer
+                            format: int32
+                          parameterAnnotations:
+                            type: array
+                            items:
+                              type: array
+                              items:
+                                type: object
+                          genericParameterTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                          genericExceptionTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                          annotatedReturnType:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                          annotatedReceiverType:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                          annotatedParameterTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                          parameters:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                modifiers:
+                                  type: integer
+                                  format: int32
+                                synthetic:
+                                  type: boolean
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                annotatedType:
+                                  type: object
+                                  properties:
+                                    annotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    declaredAnnotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    type:
+                                      type: object
+                                      properties:
+                                        typeName:
+                                          type: string
+                                parameterizedType:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                                varArgs:
+                                  type: boolean
+                                namePresent:
+                                  type: boolean
+                                declaringExecutable:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                    modifiers:
+                                      type: integer
+                                      format: int32
+                                    typeParameters:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          name:
+                                            type: string
+                                          bounds:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                          genericDeclaration:
+                                            type: object
+                                          annotatedBounds:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                annotations:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                declaredAnnotations:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                type:
+                                                  type: object
+                                                  properties:
+                                                    typeName:
+                                                      type: string
+                                          typeName:
+                                            type: string
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                    synthetic:
+                                      type: boolean
+                                    declaredAnnotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    varArgs:
+                                      type: boolean
+                                    annotatedParameterTypes:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                    parameterCount:
+                                      type: integer
+                                      format: int32
+                                    parameterAnnotations:
+                                      type: array
+                                      items:
+                                        type: array
+                                        items:
+                                          type: object
+                                    genericParameterTypes:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                    genericExceptionTypes:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                    annotatedReturnType:
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        declaredAnnotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        type:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                    annotatedReceiverType:
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        declaredAnnotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        type:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                    annotatedExceptionTypes:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                    annotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    accessible:
+                                      type: boolean
+                                      deprecated: true
+                                implicit:
+                                  type: boolean
+                          annotatedExceptionTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                      annotatedBounds:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            type:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                      typeName:
+                        type: string
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                synthetic:
+                  type: boolean
+                declaredAnnotations:
+                  type: array
+                  items:
+                    type: object
+                accessible:
+                  type: boolean
+                  deprecated: true
+                varArgs:
+                  type: boolean
+                parameterCount:
+                  type: integer
+                  format: int32
+                parameterAnnotations:
+                  type: array
+                  items:
+                    type: array
+                    items:
+                      type: object
+                genericParameterTypes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      typeName:
+                        type: string
+                genericExceptionTypes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      typeName:
+                        type: string
+                annotatedReturnType:
+                  type: object
+                  properties:
+                    annotations:
+                      type: array
+                      items:
+                        type: object
+                    declaredAnnotations:
+                      type: array
+                      items:
+                        type: object
+                    type:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                annotatedReceiverType:
+                  type: object
+                  properties:
+                    annotations:
+                      type: array
+                      items:
+                        type: object
+                    declaredAnnotations:
+                      type: array
+                      items:
+                        type: object
+                    type:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                annotatedParameterTypes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                parameters:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      modifiers:
+                        type: integer
+                        format: int32
+                      synthetic:
+                        type: boolean
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      annotatedType:
+                        type: object
+                        properties:
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          type:
+                            type: object
+                            properties:
+                              typeName:
+                                type: string
+                      parameterizedType:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                      varArgs:
+                        type: boolean
+                      namePresent:
+                        type: boolean
+                      declaringExecutable:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          modifiers:
+                            type: integer
+                            format: int32
+                          typeParameters:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                bounds:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                                genericDeclaration:
+                                  type: object
+                                annotatedBounds:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      type:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                typeName:
+                                  type: string
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                          synthetic:
+                            type: boolean
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          varArgs:
+                            type: boolean
+                          annotatedParameterTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                          parameterCount:
+                            type: integer
+                            format: int32
+                          parameterAnnotations:
+                            type: array
+                            items:
+                              type: array
+                              items:
+                                type: object
+                          genericParameterTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                          genericExceptionTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                          annotatedReturnType:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                          annotatedReceiverType:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                          annotatedExceptionTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                          accessible:
+                            type: boolean
+                            deprecated: true
+                      implicit:
+                        type: boolean
+                annotatedExceptionTypes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                annotations:
+                  type: array
+                  items:
+                    type: object
+            typeName:
+              type: string
+            anonymousClass:
+              type: boolean
+            localClass:
+              type: boolean
+            memberClass:
+              type: boolean
+            fields:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  modifiers:
+                    type: integer
+                    format: int32
+                  synthetic:
+                    type: boolean
+                  declaredAnnotations:
+                    type: array
+                    items:
+                      type: object
+                  accessible:
+                    type: boolean
+                    deprecated: true
+                  genericType:
+                    type: object
+                    properties:
+                      typeName:
+                        type: string
+                  enumConstant:
+                    type: boolean
+                  annotatedType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                  annotations:
+                    type: array
+                    items:
+                      type: object
+            methods:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  modifiers:
+                    type: integer
+                    format: int32
+                  typeParameters:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        bounds:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              typeName:
+                                type: string
+                        genericDeclaration:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            modifiers:
+                              type: integer
+                              format: int32
+                            synthetic:
+                              type: boolean
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            accessible:
+                              type: boolean
+                              deprecated: true
+                            varArgs:
+                              type: boolean
+                            parameterCount:
+                              type: integer
+                              format: int32
+                            parameterAnnotations:
+                              type: array
+                              items:
+                                type: array
+                                items:
+                                  type: object
+                            genericParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            genericExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            default:
+                              type: boolean
+                            genericReturnType:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                            bridge:
+                              type: boolean
+                            defaultValue:
+                              type: object
+                            annotatedReturnType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            parameters:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  modifiers:
+                                    type: integer
+                                    format: int32
+                                  synthetic:
+                                    type: boolean
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  annotatedType:
+                                    type: object
+                                    properties:
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      type:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                  parameterizedType:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                                  varArgs:
+                                    type: boolean
+                                  namePresent:
+                                    type: boolean
+                                  declaringExecutable:
+                                    type: object
+                                    properties:
+                                      name:
+                                        type: string
+                                      modifiers:
+                                        type: integer
+                                        format: int32
+                                      typeParameters:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            name:
+                                              type: string
+                                            bounds:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  typeName:
+                                                    type: string
+                                            genericDeclaration:
+                                              type: object
+                                            annotatedBounds:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  annotations:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                  declaredAnnotations:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                  type:
+                                                    type: object
+                                                    properties:
+                                                      typeName:
+                                                        type: string
+                                            typeName:
+                                              type: string
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                      synthetic:
+                                        type: boolean
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      varArgs:
+                                        type: boolean
+                                      annotatedParameterTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            type:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                      parameterCount:
+                                        type: integer
+                                        format: int32
+                                      parameterAnnotations:
+                                        type: array
+                                        items:
+                                          type: array
+                                          items:
+                                            type: object
+                                      genericParameterTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                      genericExceptionTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                      annotatedReturnType:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                      annotatedReceiverType:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                      annotatedExceptionTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            type:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      accessible:
+                                        type: boolean
+                                        deprecated: true
+                                  implicit:
+                                    type: boolean
+                            annotatedReceiverType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                        annotatedBounds:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                        typeName:
+                          type: string
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                  synthetic:
+                    type: boolean
+                  declaredAnnotations:
+                    type: array
+                    items:
+                      type: object
+                  accessible:
+                    type: boolean
+                    deprecated: true
+                  varArgs:
+                    type: boolean
+                  parameterCount:
+                    type: integer
+                    format: int32
+                  parameterAnnotations:
+                    type: array
+                    items:
+                      type: array
+                      items:
+                        type: object
+                  genericParameterTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                  genericExceptionTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                  default:
+                    type: boolean
+                  genericReturnType:
+                    type: object
+                    properties:
+                      typeName:
+                        type: string
+                  bridge:
+                    type: boolean
+                  defaultValue:
+                    type: object
+                  annotatedReturnType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                  annotatedParameterTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        type:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                  parameters:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        modifiers:
+                          type: integer
+                          format: int32
+                        synthetic:
+                          type: boolean
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        annotatedType:
+                          type: object
+                          properties:
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            type:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                        parameterizedType:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                        varArgs:
+                          type: boolean
+                        namePresent:
+                          type: boolean
+                        declaringExecutable:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            modifiers:
+                              type: integer
+                              format: int32
+                            typeParameters:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  bounds:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        typeName:
+                                          type: string
+                                  genericDeclaration:
+                                    type: object
+                                  annotatedBounds:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        declaredAnnotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        type:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                  typeName:
+                                    type: string
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                            synthetic:
+                              type: boolean
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            varArgs:
+                              type: boolean
+                            annotatedParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            parameterCount:
+                              type: integer
+                              format: int32
+                            parameterAnnotations:
+                              type: array
+                              items:
+                                type: array
+                                items:
+                                  type: object
+                            genericParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            genericExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            annotatedReturnType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedReceiverType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            accessible:
+                              type: boolean
+                              deprecated: true
+                        implicit:
+                          type: boolean
+                  annotatedReceiverType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                  annotatedExceptionTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        type:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                  annotations:
+                    type: array
+                    items:
+                      type: object
+            constructors:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  modifiers:
+                    type: integer
+                    format: int32
+                  typeParameters:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        bounds:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              typeName:
+                                type: string
+                        genericDeclaration:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            modifiers:
+                              type: integer
+                              format: int32
+                            synthetic:
+                              type: boolean
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            accessible:
+                              type: boolean
+                              deprecated: true
+                            varArgs:
+                              type: boolean
+                            parameterCount:
+                              type: integer
+                              format: int32
+                            parameterAnnotations:
+                              type: array
+                              items:
+                                type: array
+                                items:
+                                  type: object
+                            genericParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            genericExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            annotatedReturnType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedReceiverType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            parameters:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  modifiers:
+                                    type: integer
+                                    format: int32
+                                  synthetic:
+                                    type: boolean
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  annotatedType:
+                                    type: object
+                                    properties:
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      type:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                  parameterizedType:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                                  varArgs:
+                                    type: boolean
+                                  namePresent:
+                                    type: boolean
+                                  declaringExecutable:
+                                    type: object
+                                    properties:
+                                      name:
+                                        type: string
+                                      modifiers:
+                                        type: integer
+                                        format: int32
+                                      typeParameters:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            name:
+                                              type: string
+                                            bounds:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  typeName:
+                                                    type: string
+                                            genericDeclaration:
+                                              type: object
+                                            annotatedBounds:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  annotations:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                  declaredAnnotations:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                  type:
+                                                    type: object
+                                                    properties:
+                                                      typeName:
+                                                        type: string
+                                            typeName:
+                                              type: string
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                      synthetic:
+                                        type: boolean
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      varArgs:
+                                        type: boolean
+                                      annotatedParameterTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            type:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                      parameterCount:
+                                        type: integer
+                                        format: int32
+                                      parameterAnnotations:
+                                        type: array
+                                        items:
+                                          type: array
+                                          items:
+                                            type: object
+                                      genericParameterTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                      genericExceptionTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                      annotatedReturnType:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                      annotatedReceiverType:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                      annotatedExceptionTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            type:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      accessible:
+                                        type: boolean
+                                        deprecated: true
+                                  implicit:
+                                    type: boolean
+                            annotatedExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                        annotatedBounds:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                        typeName:
+                          type: string
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                  synthetic:
+                    type: boolean
+                  declaredAnnotations:
+                    type: array
+                    items:
+                      type: object
+                  accessible:
+                    type: boolean
+                    deprecated: true
+                  varArgs:
+                    type: boolean
+                  parameterCount:
+                    type: integer
+                    format: int32
+                  parameterAnnotations:
+                    type: array
+                    items:
+                      type: array
+                      items:
+                        type: object
+                  genericParameterTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                  genericExceptionTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                  annotatedReturnType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                  annotatedReceiverType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                  annotatedParameterTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        type:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                  parameters:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        modifiers:
+                          type: integer
+                          format: int32
+                        synthetic:
+                          type: boolean
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        annotatedType:
+                          type: object
+                          properties:
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            type:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                        parameterizedType:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                        varArgs:
+                          type: boolean
+                        namePresent:
+                          type: boolean
+                        declaringExecutable:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            modifiers:
+                              type: integer
+                              format: int32
+                            typeParameters:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  bounds:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        typeName:
+                                          type: string
+                                  genericDeclaration:
+                                    type: object
+                                  annotatedBounds:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        declaredAnnotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        type:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                  typeName:
+                                    type: string
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                            synthetic:
+                              type: boolean
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            varArgs:
+                              type: boolean
+                            annotatedParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            parameterCount:
+                              type: integer
+                              format: int32
+                            parameterAnnotations:
+                              type: array
+                              items:
+                                type: array
+                                items:
+                                  type: object
+                            genericParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            genericExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            annotatedReturnType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedReceiverType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            accessible:
+                              type: boolean
+                              deprecated: true
+                        implicit:
+                          type: boolean
+                  annotatedExceptionTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        type:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                  annotations:
+                    type: array
+                    items:
+                      type: object
+            declaredFields:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  modifiers:
+                    type: integer
+                    format: int32
+                  synthetic:
+                    type: boolean
+                  declaredAnnotations:
+                    type: array
+                    items:
+                      type: object
+                  accessible:
+                    type: boolean
+                    deprecated: true
+                  genericType:
+                    type: object
+                    properties:
+                      typeName:
+                        type: string
+                  enumConstant:
+                    type: boolean
+                  annotatedType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                  annotations:
+                    type: array
+                    items:
+                      type: object
+            recordComponents:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  accessor:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      modifiers:
+                        type: integer
+                        format: int32
+                      synthetic:
+                        type: boolean
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      accessible:
+                        type: boolean
+                        deprecated: true
+                      varArgs:
+                        type: boolean
+                      parameterCount:
+                        type: integer
+                        format: int32
+                      parameterAnnotations:
+                        type: array
+                        items:
+                          type: array
+                          items:
+                            type: object
+                      genericParameterTypes:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                      genericExceptionTypes:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                      default:
+                        type: boolean
+                      genericReturnType:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                      bridge:
+                        type: boolean
+                      defaultValue:
+                        type: object
+                      annotatedReturnType:
+                        type: object
+                        properties:
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          type:
+                            type: object
+                            properties:
+                              typeName:
+                                type: string
+                      annotatedParameterTypes:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            type:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                      parameters:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            modifiers:
+                              type: integer
+                              format: int32
+                            synthetic:
+                              type: boolean
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            annotatedType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            parameterizedType:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                            varArgs:
+                              type: boolean
+                            namePresent:
+                              type: boolean
+                            declaringExecutable:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                modifiers:
+                                  type: integer
+                                  format: int32
+                                typeParameters:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      name:
+                                        type: string
+                                      bounds:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                      genericDeclaration:
+                                        type: object
+                                      annotatedBounds:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            type:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                      typeName:
+                                        type: string
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                synthetic:
+                                  type: boolean
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                varArgs:
+                                  type: boolean
+                                annotatedParameterTypes:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      type:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                parameterCount:
+                                  type: integer
+                                  format: int32
+                                parameterAnnotations:
+                                  type: array
+                                  items:
+                                    type: array
+                                    items:
+                                      type: object
+                                genericParameterTypes:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                                genericExceptionTypes:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                                annotatedReturnType:
+                                  type: object
+                                  properties:
+                                    annotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    declaredAnnotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    type:
+                                      type: object
+                                      properties:
+                                        typeName:
+                                          type: string
+                                annotatedReceiverType:
+                                  type: object
+                                  properties:
+                                    annotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    declaredAnnotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    type:
+                                      type: object
+                                      properties:
+                                        typeName:
+                                          type: string
+                                annotatedExceptionTypes:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      type:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                accessible:
+                                  type: boolean
+                                  deprecated: true
+                            implicit:
+                              type: boolean
+                      annotatedReceiverType:
+                        type: object
+                        properties:
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          type:
+                            type: object
+                            properties:
+                              typeName:
+                                type: string
+                      annotatedExceptionTypes:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            type:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                  annotations:
+                    type: array
+                    items:
+                      type: object
+                  declaredAnnotations:
+                    type: array
+                    items:
+                      type: object
+                  genericSignature:
+                    type: string
+                  genericType:
+                    type: object
+                    properties:
+                      typeName:
+                        type: string
+                  annotatedType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+            declaredMethods:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  modifiers:
+                    type: integer
+                    format: int32
+                  typeParameters:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        bounds:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              typeName:
+                                type: string
+                        genericDeclaration:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            modifiers:
+                              type: integer
+                              format: int32
+                            synthetic:
+                              type: boolean
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            accessible:
+                              type: boolean
+                              deprecated: true
+                            varArgs:
+                              type: boolean
+                            parameterCount:
+                              type: integer
+                              format: int32
+                            parameterAnnotations:
+                              type: array
+                              items:
+                                type: array
+                                items:
+                                  type: object
+                            genericParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            genericExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            default:
+                              type: boolean
+                            genericReturnType:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                            bridge:
+                              type: boolean
+                            defaultValue:
+                              type: object
+                            annotatedReturnType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            parameters:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  modifiers:
+                                    type: integer
+                                    format: int32
+                                  synthetic:
+                                    type: boolean
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  annotatedType:
+                                    type: object
+                                    properties:
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      type:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                  parameterizedType:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                                  varArgs:
+                                    type: boolean
+                                  namePresent:
+                                    type: boolean
+                                  declaringExecutable:
+                                    type: object
+                                    properties:
+                                      name:
+                                        type: string
+                                      modifiers:
+                                        type: integer
+                                        format: int32
+                                      typeParameters:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            name:
+                                              type: string
+                                            bounds:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  typeName:
+                                                    type: string
+                                            genericDeclaration:
+                                              type: object
+                                            annotatedBounds:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  annotations:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                  declaredAnnotations:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                  type:
+                                                    type: object
+                                                    properties:
+                                                      typeName:
+                                                        type: string
+                                            typeName:
+                                              type: string
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                      synthetic:
+                                        type: boolean
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      varArgs:
+                                        type: boolean
+                                      annotatedParameterTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            type:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                      parameterCount:
+                                        type: integer
+                                        format: int32
+                                      parameterAnnotations:
+                                        type: array
+                                        items:
+                                          type: array
+                                          items:
+                                            type: object
+                                      genericParameterTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                      genericExceptionTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                      annotatedReturnType:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                      annotatedReceiverType:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                      annotatedExceptionTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            type:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      accessible:
+                                        type: boolean
+                                        deprecated: true
+                                  implicit:
+                                    type: boolean
+                            annotatedReceiverType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                        annotatedBounds:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                        typeName:
+                          type: string
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                  synthetic:
+                    type: boolean
+                  declaredAnnotations:
+                    type: array
+                    items:
+                      type: object
+                  accessible:
+                    type: boolean
+                    deprecated: true
+                  varArgs:
+                    type: boolean
+                  parameterCount:
+                    type: integer
+                    format: int32
+                  parameterAnnotations:
+                    type: array
+                    items:
+                      type: array
+                      items:
+                        type: object
+                  genericParameterTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                  genericExceptionTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                  default:
+                    type: boolean
+                  genericReturnType:
+                    type: object
+                    properties:
+                      typeName:
+                        type: string
+                  bridge:
+                    type: boolean
+                  defaultValue:
+                    type: object
+                  annotatedReturnType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                  annotatedParameterTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        type:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                  parameters:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        modifiers:
+                          type: integer
+                          format: int32
+                        synthetic:
+                          type: boolean
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        annotatedType:
+                          type: object
+                          properties:
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            type:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                        parameterizedType:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                        varArgs:
+                          type: boolean
+                        namePresent:
+                          type: boolean
+                        declaringExecutable:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            modifiers:
+                              type: integer
+                              format: int32
+                            typeParameters:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  bounds:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        typeName:
+                                          type: string
+                                  genericDeclaration:
+                                    type: object
+                                  annotatedBounds:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        declaredAnnotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        type:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                  typeName:
+                                    type: string
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                            synthetic:
+                              type: boolean
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            varArgs:
+                              type: boolean
+                            annotatedParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            parameterCount:
+                              type: integer
+                              format: int32
+                            parameterAnnotations:
+                              type: array
+                              items:
+                                type: array
+                                items:
+                                  type: object
+                            genericParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            genericExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            annotatedReturnType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedReceiverType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            accessible:
+                              type: boolean
+                              deprecated: true
+                        implicit:
+                          type: boolean
+                  annotatedReceiverType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                  annotatedExceptionTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        type:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                  annotations:
+                    type: array
+                    items:
+                      type: object
+            declaredConstructors:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  modifiers:
+                    type: integer
+                    format: int32
+                  typeParameters:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        bounds:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              typeName:
+                                type: string
+                        genericDeclaration:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            modifiers:
+                              type: integer
+                              format: int32
+                            synthetic:
+                              type: boolean
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            accessible:
+                              type: boolean
+                              deprecated: true
+                            varArgs:
+                              type: boolean
+                            parameterCount:
+                              type: integer
+                              format: int32
+                            parameterAnnotations:
+                              type: array
+                              items:
+                                type: array
+                                items:
+                                  type: object
+                            genericParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            genericExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            annotatedReturnType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedReceiverType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            parameters:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  modifiers:
+                                    type: integer
+                                    format: int32
+                                  synthetic:
+                                    type: boolean
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  annotatedType:
+                                    type: object
+                                    properties:
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      type:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                  parameterizedType:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                                  varArgs:
+                                    type: boolean
+                                  namePresent:
+                                    type: boolean
+                                  declaringExecutable:
+                                    type: object
+                                    properties:
+                                      name:
+                                        type: string
+                                      modifiers:
+                                        type: integer
+                                        format: int32
+                                      typeParameters:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            name:
+                                              type: string
+                                            bounds:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  typeName:
+                                                    type: string
+                                            genericDeclaration:
+                                              type: object
+                                            annotatedBounds:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  annotations:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                  declaredAnnotations:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                  type:
+                                                    type: object
+                                                    properties:
+                                                      typeName:
+                                                        type: string
+                                            typeName:
+                                              type: string
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                      synthetic:
+                                        type: boolean
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      varArgs:
+                                        type: boolean
+                                      annotatedParameterTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            type:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                      parameterCount:
+                                        type: integer
+                                        format: int32
+                                      parameterAnnotations:
+                                        type: array
+                                        items:
+                                          type: array
+                                          items:
+                                            type: object
+                                      genericParameterTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                      genericExceptionTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                      annotatedReturnType:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                      annotatedReceiverType:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                      annotatedExceptionTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            type:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      accessible:
+                                        type: boolean
+                                        deprecated: true
+                                  implicit:
+                                    type: boolean
+                            annotatedExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                        annotatedBounds:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                        typeName:
+                          type: string
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                  synthetic:
+                    type: boolean
+                  declaredAnnotations:
+                    type: array
+                    items:
+                      type: object
+                  accessible:
+                    type: boolean
+                    deprecated: true
+                  varArgs:
+                    type: boolean
+                  parameterCount:
+                    type: integer
+                    format: int32
+                  parameterAnnotations:
+                    type: array
+                    items:
+                      type: array
+                      items:
+                        type: object
+                  genericParameterTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                  genericExceptionTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                  annotatedReturnType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                  annotatedReceiverType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                  annotatedParameterTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        type:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                  parameters:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        modifiers:
+                          type: integer
+                          format: int32
+                        synthetic:
+                          type: boolean
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        annotatedType:
+                          type: object
+                          properties:
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            type:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                        parameterizedType:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                        varArgs:
+                          type: boolean
+                        namePresent:
+                          type: boolean
+                        declaringExecutable:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            modifiers:
+                              type: integer
+                              format: int32
+                            typeParameters:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  bounds:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        typeName:
+                                          type: string
+                                  genericDeclaration:
+                                    type: object
+                                  annotatedBounds:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        declaredAnnotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        type:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                  typeName:
+                                    type: string
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                            synthetic:
+                              type: boolean
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            varArgs:
+                              type: boolean
+                            annotatedParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            parameterCount:
+                              type: integer
+                              format: int32
+                            parameterAnnotations:
+                              type: array
+                              items:
+                                type: array
+                                items:
+                                  type: object
+                            genericParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            genericExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            annotatedReturnType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedReceiverType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            accessible:
+                              type: boolean
+                              deprecated: true
+                        implicit:
+                          type: boolean
+                  annotatedExceptionTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        type:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                  annotations:
+                    type: array
+                    items:
+                      type: object
+            enumConstants:
+              type: array
+              items:
+                type: object
+            annotations:
+              type: array
+              items:
+                type: object
+            declaredAnnotations:
+              type: array
+              items:
+                type: object
+            annotatedSuperclass:
+              type: object
+              properties:
+                annotations:
+                  type: array
+                  items:
+                    type: object
+                declaredAnnotations:
+                  type: array
+                  items:
+                    type: object
+                type:
+                  type: object
+                  properties:
+                    typeName:
+                      type: string
+            annotatedInterfaces:
+              type: array
+              items:
+                type: object
+                properties:
+                  annotations:
+                    type: array
+                    items:
+                      type: object
+                  declaredAnnotations:
+                    type: array
+                    items:
+                      type: object
+                  type:
+                    type: object
+                    properties:
+                      typeName:
+                        type: string
+            sealed:
+              type: boolean
+      responses:
+        "200":
+          description: OK
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/EntityModelWorkflow'
+        "404":
+          description: Not Found
   /workflows/{id}:
     get:
       tags:
@@ -778,7 +11352,7 @@ paths:
           description: No Content
         "404":
           description: Not Found
-  /workflows/{id}/deactivate:
+  /workflows/{id}/deactivate/:
     put:
       tags:
       - workflow-controller
@@ -800,14 +11374,14 @@ paths:
                 token:
                   type: string
       responses:
-        "500":
-          description: Internal Server Error
+        "400":
+          description: Bad Request
           content:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/ResponseErrors'
-        "400":
-          description: Bad Request
+        "500":
+          description: Internal Server Error
           content:
             application/hal+json:
               schema:
@@ -833,7 +11407,65 @@ paths:
         "200":
           description: OK
           content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Workflow'
+  /workflows/{id}/deactivate:
+    put:
+      tags:
+      - workflow-controller
+      operationId: deactivateWorkflow_1
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                tenant:
+                  type: string
+                token:
+                  type: string
+      responses:
+        "400":
+          description: Bad Request
+          content:
             application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "500":
+          description: Internal Server Error
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "404":
+          description: Not Found
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "403":
+          description: Forbidden
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "204":
+          description: No Content
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "200":
+          description: OK
+          content:
+            application/json:
               schema:
                 $ref: '#/components/schemas/Workflow'
   /workflows/{id}/activate:
@@ -858,14 +11490,14 @@ paths:
                 token:
                   type: string
       responses:
-        "500":
-          description: Internal Server Error
+        "400":
+          description: Bad Request
           content:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/ResponseErrors'
-        "400":
-          description: Bad Request
+        "500":
+          description: Internal Server Error
           content:
             application/hal+json:
               schema:
@@ -891,10 +11523,68 @@ paths:
         "200":
           description: OK
           content:
-            application/hal+json:
+            application/json:
               schema:
                 $ref: '#/components/schemas/Workflow'
-  /workflows/{id}/start:
+  /workflows/{id}/activate/:
+    put:
+      tags:
+      - workflow-controller
+      operationId: activateWorkflow_1
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                tenant:
+                  type: string
+                token:
+                  type: string
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "500":
+          description: Internal Server Error
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "404":
+          description: Not Found
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "403":
+          description: Forbidden
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "204":
+          description: No Content
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Workflow'
+  /workflows/{id}/start/:
     post:
       tags:
       - workflow-controller
@@ -919,14 +11609,14 @@ paths:
                   $ref: '#/components/schemas/JsonNode'
         required: true
       responses:
-        "500":
-          description: Internal Server Error
+        "400":
+          description: Bad Request
           content:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/ResponseErrors'
-        "400":
-          description: Bad Request
+        "500":
+          description: Internal Server Error
           content:
             application/hal+json:
               schema:
@@ -952,7 +11642,68 @@ paths:
         "200":
           description: OK
           content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsonNode'
+  /workflows/{id}/start:
+    post:
+      tags:
+      - workflow-controller
+      operationId: startWorkflow_1
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                tenant:
+                  type: string
+                token:
+                  type: string
+                context:
+                  $ref: '#/components/schemas/JsonNode'
+        required: true
+      responses:
+        "400":
+          description: Bad Request
+          content:
             application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "500":
+          description: Internal Server Error
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "404":
+          description: Not Found
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "403":
+          description: Forbidden
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "204":
+          description: No Content
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "200":
+          description: OK
+          content:
+            application/json:
               schema:
                 $ref: '#/components/schemas/JsonNode'
   /events/**:
@@ -983,14 +11734,14 @@ paths:
             schema:
               $ref: '#/components/schemas/JsonNode'
       responses:
-        "500":
-          description: Internal Server Error
+        "400":
+          description: Bad Request
           content:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/ResponseErrors'
-        "400":
-          description: Bad Request
+        "500":
+          description: Internal Server Error
           content:
             application/hal+json:
               schema:
@@ -1016,38 +11767,53 @@ paths:
         "200":
           description: OK
           content:
-            application/hal+json:
+            application/json:
               schema:
                 $ref: '#/components/schemas/JsonNode'
   /_/tenant:
     post:
       tags:
       - tenant-controller
-      operationId: create
+      - tenant
+      description: "Create tenant job (create, upgrade, delete)"
+      operationId: postTenant_1
+      parameters:
+      - name: accept
+        in: header
+        required: false
+        schema:
+          type: string
       requestBody:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                tenant:
-                  type: string
-                attributes:
-                  $ref: '#/components/schemas/TenantAttributes'
+              $ref: '#/components/schemas/tenantAttributes'
         required: true
       responses:
-        "500":
-          description: Internal Server Error
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
         "400":
-          description: Bad Request
+          description: Bad request
           content:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/ResponseErrors'
+            application/json:
+              schema:
+                type: string
+            text/plain:
+              schema:
+                type: string
+        "500":
+          description: Internal server error
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+            application/json:
+              schema:
+                type: string
+            text/plain:
+              schema:
+                type: string
         "404":
           description: Not Found
           content:
@@ -1061,7 +11827,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ResponseErrors'
         "204":
-          description: No Content
+          description: Job completed
           content:
             application/hal+json:
               schema:
@@ -1072,24 +11838,39 @@ paths:
             application/hal+json:
               schema:
                 type: string
+        "422":
+          description: Validation errors
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errors'
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/errors'
     delete:
       tags:
       - tenant-controller
       operationId: delete
+      parameters:
+      - name: accept
+        in: header
+        required: false
+        schema:
+          type: string
       requestBody:
         content:
           application/json:
             schema:
               type: string
       responses:
-        "500":
-          description: Internal Server Error
+        "400":
+          description: Bad Request
           content:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/ResponseErrors'
-        "400":
-          description: Bad Request
+        "500":
+          description: Internal Server Error
           content:
             application/hal+json:
               schema:
@@ -1136,14 +11917,14 @@ paths:
         schema:
           type: string
       responses:
-        "500":
-          description: Internal Server Error
+        "400":
+          description: Bad Request
           content:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/ResponseErrors'
-        "400":
-          description: Bad Request
+        "500":
+          description: Internal Server Error
           content:
             application/hal+json:
               schema:
@@ -1169,23 +11950,216 @@ paths:
         "200":
           description: OK
           content:
-            application/hal+json:
+            application/json:
               schema:
                 $ref: '#/components/schemas/JsonNode'
-  /actuator:
+  /workflows/{id}/history/:
+    get:
+      tags:
+      - workflow-controller
+      operationId: workflowHistory_1
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: tenant
+        in: query
+        required: true
+        schema:
+          type: string
+      - name: token
+        in: query
+        required: true
+        schema:
+          type: string
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "500":
+          description: Internal Server Error
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "404":
+          description: Not Found
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "403":
+          description: Forbidden
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "204":
+          description: No Content
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsonNode'
+  /workflows/search:
+    get:
+      tags:
+      - workflow-controller
+      operationId: searchWorkflows
+      parameters:
+      - name: query
+        in: query
+        required: true
+        schema:
+          type: string
+      - name: offset
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int64
+          default: 0
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 20
+      - name: tenant
+        in: query
+        required: true
+        schema:
+          type: string
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "500":
+          description: Internal Server Error
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "404":
+          description: Not Found
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "403":
+          description: Forbidden
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "204":
+          description: No Content
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsonNode'
+  /workflows/search/:
+    get:
+      tags:
+      - workflow-controller
+      operationId: searchWorkflows_1
+      parameters:
+      - name: query
+        in: query
+        required: true
+        schema:
+          type: string
+      - name: offset
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int64
+          default: 0
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 20
+      - name: tenant
+        in: query
+        required: true
+        schema:
+          type: string
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "500":
+          description: Internal Server Error
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "404":
+          description: Not Found
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "403":
+          description: Forbidden
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "204":
+          description: No Content
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsonNode'
+  /admin:
     get:
       tags:
       - Actuator
+      summary: Actuator root web endpoint
       operationId: links
       responses:
-        "500":
-          description: Internal Server Error
+        "400":
+          description: Bad Request
           content:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/ResponseErrors'
-        "400":
-          description: Bad Request
+        "500":
+          description: Internal Server Error
           content:
             application/hal+json:
               schema:
@@ -1232,20 +12206,21 @@ paths:
                   type: object
                   additionalProperties:
                     $ref: '#/components/schemas/Link'
-  /actuator/info:
+  /admin/info:
     get:
       tags:
       - Actuator
-      operationId: handle
+      summary: Actuator web endpoint 'info'
+      operationId: info
       responses:
-        "500":
-          description: Internal Server Error
+        "400":
+          description: Bad Request
           content:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/ResponseErrors'
-        "400":
-          description: Bad Request
+        "500":
+          description: Internal Server Error
           content:
             application/hal+json:
               schema:
@@ -1280,20 +12255,21 @@ paths:
             application/json:
               schema:
                 type: object
-  /actuator/health:
+  /admin/health:
     get:
       tags:
       - Actuator
-      operationId: handle_1
+      summary: Actuator web endpoint 'health'
+      operationId: health
       responses:
-        "500":
-          description: Internal Server Error
+        "400":
+          description: Bad Request
           content:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/ResponseErrors'
-        "400":
-          description: Bad Request
+        "500":
+          description: Internal Server Error
           content:
             application/hal+json:
               schema:
@@ -1328,20 +12304,21 @@ paths:
             application/json:
               schema:
                 type: object
-  /actuator/health/**:
+  /admin/health/**:
     get:
       tags:
       - Actuator
-      operationId: handle_2
+      summary: Actuator web endpoint 'health-path'
+      operationId: health-path
       responses:
-        "500":
-          description: Internal Server Error
+        "400":
+          description: Bad Request
           content:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/ResponseErrors'
-        "400":
-          description: Bad Request
+        "500":
+          description: Internal Server Error
           content:
             application/hal+json:
               schema:
@@ -1376,20 +12353,21 @@ paths:
             application/json:
               schema:
                 type: object
-  /actuator/flyway:
+  /admin/flyway:
     get:
       tags:
       - Actuator
-      operationId: handle_3
+      summary: Actuator web endpoint 'flyway'
+      operationId: flyway
       responses:
-        "500":
-          description: Internal Server Error
+        "400":
+          description: Bad Request
           content:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/ResponseErrors'
-        "400":
-          description: Bad Request
+        "500":
+          description: Internal Server Error
           content:
             application/hal+json:
               schema:
@@ -1424,7 +12402,7 @@ paths:
             application/json:
               schema:
                 type: object
-  /actions:
+  /actions/:
     get:
       tags:
       - action-controller
@@ -1436,14 +12414,14 @@ paths:
         schema:
           type: string
       responses:
-        "500":
-          description: Internal Server Error
+        "400":
+          description: Bad Request
           content:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/ResponseErrors'
-        "400":
-          description: Bad Request
+        "500":
+          description: Internal Server Error
           content:
             application/hal+json:
               schema:
@@ -1469,11 +12447,148 @@ paths:
         "200":
           description: OK
           content:
-            application/hal+json:
+            application/json:
               schema:
                 type: array
                 items:
                   $ref: '#/components/schemas/Action'
+  /actions:
+    get:
+      tags:
+      - action-controller
+      operationId: getActions_1
+      parameters:
+      - name: tenant
+        in: query
+        required: true
+        schema:
+          type: string
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "500":
+          description: Internal Server Error
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "404":
+          description: Not Found
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "403":
+          description: Forbidden
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "204":
+          description: No Content
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Action'
+  /_/tenant/{operationId}:
+    get:
+      tags:
+      - tenant
+      description: Does tenant id already exist
+      operationId: getTenant
+      parameters:
+      - name: operationId
+        in: path
+        description: Operation ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "500":
+          description: Internal server error
+          content:
+            text/plain:
+              schema:
+                type: string
+        "404":
+          description: Not Found
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "403":
+          description: Forbidden
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "204":
+          description: No Content
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "200":
+          description: true or false indicator
+          content:
+            text/plain:
+              schema:
+                type: string
+    delete:
+      tags:
+      - tenant
+      description: drop tenant id
+      operationId: deleteTenant
+      parameters:
+      - name: operationId
+        in: path
+        description: Operation ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "400":
+          description: Bad request
+        "500":
+          description: Internal server error
+          content:
+            text/plain:
+              schema:
+                type: string
+        "404":
+          description: Not Found
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "403":
+          description: Forbidden
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "204":
+          description: Delete succeeded
+        "200":
+          description: OK
   /_/ramls:
     get:
       tags:
@@ -1490,15 +12605,20 @@ paths:
         required: true
         schema:
           type: string
+      - name: accept
+        in: header
+        required: false
+        schema:
+          type: string
       responses:
-        "500":
-          description: Internal Server Error
+        "400":
+          description: Bad Request
           content:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/ResponseErrors'
-        "400":
-          description: Bad Request
+        "500":
+          description: Internal Server Error
           content:
             application/hal+json:
               schema:
@@ -1543,15 +12663,20 @@ paths:
         required: true
         schema:
           type: string
+      - name: accept
+        in: header
+        required: false
+        schema:
+          type: string
       responses:
-        "500":
-          description: Internal Server Error
+        "400":
+          description: Bad Request
           content:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/ResponseErrors'
-        "400":
-          description: Bad Request
+        "500":
+          description: Internal Server Error
           content:
             application/hal+json:
               schema:
@@ -1666,67 +12791,232 @@ components:
       properties:
         _links:
           $ref: '#/components/schemas/Links'
-    EntityModelTrigger:
+    CompressFileTask:
       required:
-      - method
       - name
-      - pathPattern
       type: object
-      properties:
-        name:
-          maxLength: 64
-          minLength: 4
-          type: string
-        description:
-          maxLength: 256
-          minLength: 0
-          type: string
-        pathPattern:
-          maxLength: 256
-          minLength: 2
-          type: string
-        method:
-          type: string
-          enum:
-          - GET
-          - HEAD
-          - POST
-          - PUT
-          - PATCH
-          - DELETE
-          - OPTIONS
-          - TRACE
-        _links:
-          $ref: '#/components/schemas/Links'
-    PageMetadata:
+      allOf:
+      - $ref: '#/components/schemas/Node'
+      - type: object
+        properties:
+          inputVariables:
+            uniqueItems: true
+            type: array
+            items:
+              $ref: '#/components/schemas/EmbeddedVariable'
+          outputVariable:
+            $ref: '#/components/schemas/EmbeddedVariable'
+          asyncBefore:
+            type: boolean
+          asyncAfter:
+            type: boolean
+          source:
+            type: string
+          destination:
+            type: string
+          format:
+            type: string
+            enum:
+            - BZIP2
+            - GZIP
+            - ZIP
+          container:
+            type: string
+            enum:
+            - NONE
+            - TAR
+    Condition:
+      required:
+      - answer
+      - expression
+      - name
       type: object
-      properties:
-        size:
-          type: integer
-          format: int64
-        totalElements:
-          type: integer
-          format: int64
-        totalPages:
-          type: integer
-          format: int64
-        number:
-          type: integer
-          format: int64
-    PagedModelEntityModelTrigger:
+      allOf:
+      - $ref: '#/components/schemas/Node'
+      - type: object
+        properties:
+          expression:
+            maxLength: 128
+            minLength: 4
+            type: string
+          answer:
+            maxLength: 64
+            minLength: 2
+            type: string
+    ConnectTo:
+      required:
+      - name
+      - nodeId
       type: object
-      properties:
-        _embedded:
-          type: object
-          properties:
-            triggers:
-              type: array
-              items:
-                $ref: '#/components/schemas/EntityModelTrigger'
-        _links:
-          $ref: '#/components/schemas/Links'
-        page:
-          $ref: '#/components/schemas/PageMetadata'
+      allOf:
+      - $ref: '#/components/schemas/Node'
+      - type: object
+        properties:
+          nodeId:
+            type: string
+    DatabaseConnectionTask:
+      required:
+      - name
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/Node'
+      - type: object
+        properties:
+          inputVariables:
+            uniqueItems: true
+            type: array
+            items:
+              $ref: '#/components/schemas/EmbeddedVariable'
+          outputVariable:
+            $ref: '#/components/schemas/EmbeddedVariable'
+          asyncBefore:
+            type: boolean
+          asyncAfter:
+            type: boolean
+          designation:
+            type: string
+          url:
+            type: string
+          username:
+            type: string
+          password:
+            type: string
+    DatabaseDisconnectTask:
+      required:
+      - name
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/Node'
+      - type: object
+        properties:
+          inputVariables:
+            uniqueItems: true
+            type: array
+            items:
+              $ref: '#/components/schemas/EmbeddedVariable'
+          outputVariable:
+            $ref: '#/components/schemas/EmbeddedVariable'
+          asyncBefore:
+            type: boolean
+          asyncAfter:
+            type: boolean
+          designation:
+            type: string
+    DatabaseQueryTask:
+      required:
+      - name
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/Node'
+      - type: object
+        properties:
+          inputVariables:
+            uniqueItems: true
+            type: array
+            items:
+              $ref: '#/components/schemas/EmbeddedVariable'
+          outputVariable:
+            $ref: '#/components/schemas/EmbeddedVariable'
+          asyncBefore:
+            type: boolean
+          asyncAfter:
+            type: boolean
+          designation:
+            type: string
+          query:
+            type: string
+          outputPath:
+            type: string
+          resultType:
+            type: string
+            enum:
+            - CSV
+            - TSV
+            - JSON
+          includeHeader:
+            type: boolean
+    DirectoryTask:
+      required:
+      - action
+      - name
+      - path
+      - workflow
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/Node'
+      - type: object
+        properties:
+          inputVariables:
+            uniqueItems: true
+            type: array
+            items:
+              $ref: '#/components/schemas/EmbeddedVariable'
+          outputVariable:
+            $ref: '#/components/schemas/EmbeddedVariable'
+          asyncBefore:
+            type: boolean
+          asyncAfter:
+            type: boolean
+          path:
+            type: string
+          workflow:
+            type: string
+          action:
+            type: string
+            enum:
+            - READ_NEXT
+            - DELETE_NEXT
+            - LIST
+            - WRITE
+    EmailTask:
+      required:
+      - mailFrom
+      - mailSubject
+      - mailText
+      - mailTo
+      - name
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/Node'
+      - type: object
+        properties:
+          inputVariables:
+            uniqueItems: true
+            type: array
+            items:
+              $ref: '#/components/schemas/EmbeddedVariable'
+          outputVariable:
+            $ref: '#/components/schemas/EmbeddedVariable'
+          asyncBefore:
+            type: boolean
+          asyncAfter:
+            type: boolean
+          mailTo:
+            maxLength: 256
+            minLength: 3
+            type: string
+          mailCc:
+            type: string
+          mailBcc:
+            type: string
+          mailFrom:
+            maxLength: 256
+            minLength: 3
+            type: string
+          mailSubject:
+            maxLength: 256
+            minLength: 2
+            type: string
+          mailText:
+            maxLength: 2147483647
+            minLength: 2
+            type: string
+          mailMarkup:
+            type: string
+          attachmentPath:
+            type: string
+          includeAttachment:
+            type: string
     EmbeddedLoopReference:
       required:
       - parallel
@@ -1822,26 +13112,163 @@ components:
           type: boolean
         asTransient:
           type: boolean
-    EntityModelNode:
+    EndEvent:
       required:
       - name
       type: object
-      properties:
-        name:
-          maxLength: 64
-          minLength: 3
-          type: string
-        description:
-          maxLength: 512
-          minLength: 0
-          type: string
-        deserializeAs:
-          type: string
-          readOnly: true
-        identifier:
-          type: string
-        _links:
-          $ref: '#/components/schemas/Links'
+      allOf:
+      - $ref: '#/components/schemas/Node'
+    EventSubprocess:
+      required:
+      - name
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/Node'
+      - type: object
+        properties:
+          asyncBefore:
+            type: boolean
+          asyncAfter:
+            type: boolean
+    ExclusiveGateway:
+      required:
+      - name
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/Node'
+      - type: object
+        properties:
+          direction:
+            type: string
+            enum:
+            - UNSPECIFIED
+            - CONVERGING
+            - DIVERGING
+            - MIXED
+          nodes:
+            type: array
+            items:
+              $ref: '#/components/schemas/Node'
+    FileTask:
+      required:
+      - name
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/Node'
+      - type: object
+        properties:
+          inputVariables:
+            uniqueItems: true
+            type: array
+            items:
+              $ref: '#/components/schemas/EmbeddedVariable'
+          outputVariable:
+            $ref: '#/components/schemas/EmbeddedVariable'
+          asyncBefore:
+            type: boolean
+          asyncAfter:
+            type: boolean
+          op:
+            type: string
+            enum:
+            - LIST
+            - READ
+            - WRITE
+            - COPY
+            - MOVE
+            - DELETE
+            - LINE_COUNT
+            - READ_LINE
+            - PUSH
+            - POP
+          path:
+            type: string
+          target:
+            type: string
+          line:
+            type: string
+    FtpTask:
+      required:
+      - name
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/Node'
+      - type: object
+        properties:
+          inputVariables:
+            uniqueItems: true
+            type: array
+            items:
+              $ref: '#/components/schemas/EmbeddedVariable'
+          outputVariable:
+            $ref: '#/components/schemas/EmbeddedVariable'
+          asyncBefore:
+            type: boolean
+          asyncAfter:
+            type: boolean
+          originPath:
+            type: string
+          destinationPath:
+            type: string
+          op:
+            type: string
+            enum:
+            - GET
+            - PUT
+          scheme:
+            type: string
+          host:
+            type: string
+          port:
+            type: integer
+            format: int32
+          username:
+            type: string
+          password:
+            type: string
+          basePath:
+            type: string
+    InclusiveGateway:
+      required:
+      - name
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/Node'
+      - type: object
+        properties:
+          direction:
+            type: string
+            enum:
+            - UNSPECIFIED
+            - CONVERGING
+            - DIVERGING
+            - MIXED
+    MoveToLastGateway:
+      required:
+      - name
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/Node'
+      - type: object
+        properties:
+          direction:
+            type: string
+            enum:
+            - UNSPECIFIED
+            - CONVERGING
+            - DIVERGING
+            - MIXED
+    MoveToNode:
+      required:
+      - gatewayId
+      - name
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/Node'
+      - type: object
+        properties:
+          gatewayId:
+            type: string
     Node:
       required:
       - name
@@ -1864,6 +13291,185 @@ components:
           type: string
       discriminator:
         propertyName: deserializeAs
+    ParallelGateway:
+      required:
+      - name
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/Node'
+      - type: object
+        properties:
+          direction:
+            type: string
+            enum:
+            - UNSPECIFIED
+            - CONVERGING
+            - DIVERGING
+            - MIXED
+    ProcessorTask:
+      required:
+      - name
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/Node'
+      - type: object
+        properties:
+          inputVariables:
+            uniqueItems: true
+            type: array
+            items:
+              $ref: '#/components/schemas/EmbeddedVariable'
+          outputVariable:
+            $ref: '#/components/schemas/EmbeddedVariable'
+          asyncBefore:
+            type: boolean
+          asyncAfter:
+            type: boolean
+          processor:
+            $ref: '#/components/schemas/EmbeddedProcessor'
+    ReceiveTask:
+      required:
+      - message
+      - name
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/Node'
+      - type: object
+        properties:
+          message:
+            maxLength: 256
+            minLength: 4
+            type: string
+          asyncBefore:
+            type: boolean
+          asyncAfter:
+            type: boolean
+    RequestTask:
+      required:
+      - name
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/Node'
+      - type: object
+        properties:
+          inputVariables:
+            uniqueItems: true
+            type: array
+            items:
+              $ref: '#/components/schemas/EmbeddedVariable'
+          headerOutputVariables:
+            uniqueItems: true
+            type: array
+            items:
+              $ref: '#/components/schemas/EmbeddedVariable'
+          outputVariable:
+            $ref: '#/components/schemas/EmbeddedVariable'
+          asyncBefore:
+            type: boolean
+          asyncAfter:
+            type: boolean
+          request:
+            $ref: '#/components/schemas/EmbeddedRequest'
+    ScriptTask:
+      required:
+      - code
+      - name
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/Node'
+      - type: object
+        properties:
+          scriptFormat:
+            type: string
+          code:
+            type: string
+          resultVariable:
+            type: string
+          asyncBefore:
+            type: boolean
+          asyncAfter:
+            type: boolean
+    StartEvent:
+      required:
+      - name
+      - type
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/Node'
+      - type: object
+        properties:
+          type:
+            type: string
+            enum:
+            - MESSAGE_CORRELATION
+            - SCHEDULED
+            - SIGNAL
+            - NONE
+          expression:
+            maxLength: 256
+            minLength: 4
+            type: string
+          interrupting:
+            type: boolean
+          asyncBefore:
+            type: boolean
+    Subprocess:
+      required:
+      - name
+      - type
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/Node'
+      - type: object
+        properties:
+          type:
+            type: string
+            enum:
+            - EMBEDDED
+            - TRANSACTION
+          asyncBefore:
+            type: boolean
+          asyncAfter:
+            type: boolean
+          loopRef:
+            $ref: '#/components/schemas/EmbeddedLoopReference'
+          multiInstance:
+            type: boolean
+    EntityModelNode:
+      required:
+      - name
+      type: object
+      properties:
+        name:
+          maxLength: 64
+          minLength: 3
+          type: string
+        description:
+          maxLength: 512
+          minLength: 0
+          type: string
+        deserializeAs:
+          type: string
+          readOnly: true
+        identifier:
+          type: string
+        _links:
+          $ref: '#/components/schemas/Links'
+    PageMetadata:
+      type: object
+      properties:
+        size:
+          type: integer
+          format: int64
+        totalElements:
+          type: integer
+          format: int64
+        totalPages:
+          type: integer
+          format: int64
+        number:
+          type: integer
+          format: int64
     PagedModelEntityModelNode:
       type: object
       properties:
@@ -1878,56 +13484,8 @@ components:
           $ref: '#/components/schemas/Links'
         page:
           $ref: '#/components/schemas/PageMetadata'
-    EntityModelWorkflow:
-      required:
-      - name
-      - versionTag
-      type: object
-      properties:
-        name:
-          maxLength: 64
-          minLength: 4
-          type: string
-        versionTag:
-          maxLength: 64
-          minLength: 1
-          type: string
-        historyTimeToLive:
-          minimum: 0
-          type: integer
-          format: int32
-        description:
-          maxLength: 512
-          minLength: 0
-          type: string
-        active:
-          type: boolean
-        deploymentId:
-          type: string
-        setup:
-          $ref: '#/components/schemas/Setup'
-        initialContext:
-          type: object
-          additionalProperties:
-            $ref: '#/components/schemas/JsonNode'
-        _links:
-          $ref: '#/components/schemas/Links'
     JsonNode:
       type: object
-    PagedModelEntityModelWorkflow:
-      type: object
-      properties:
-        _embedded:
-          type: object
-          properties:
-            workflows:
-              type: array
-              items:
-                $ref: '#/components/schemas/EntityModelWorkflow'
-        _links:
-          $ref: '#/components/schemas/Links'
-        page:
-          $ref: '#/components/schemas/PageMetadata'
     Setup:
       type: object
       properties:
@@ -1947,6 +13505,10 @@ components:
           maxLength: 64
           minLength: 4
           type: string
+        description:
+          maxLength: 512
+          minLength: 0
+          type: string
         versionTag:
           maxLength: 64
           minLength: 1
@@ -1955,10 +13517,6 @@ components:
           minimum: 0
           type: integer
           format: int32
-        description:
-          maxLength: 512
-          minLength: 0
-          type: string
         active:
           type: boolean
         deploymentId:
@@ -1968,11 +13526,82 @@ components:
         nodes:
           type: array
           items:
-            $ref: '#/components/schemas/Node'
+            oneOf:
+            - $ref: '#/components/schemas/CompressFileTask'
+            - $ref: '#/components/schemas/Condition'
+            - $ref: '#/components/schemas/ConnectTo'
+            - $ref: '#/components/schemas/DatabaseConnectionTask'
+            - $ref: '#/components/schemas/DatabaseDisconnectTask'
+            - $ref: '#/components/schemas/DatabaseQueryTask'
+            - $ref: '#/components/schemas/DirectoryTask'
+            - $ref: '#/components/schemas/EmailTask'
+            - $ref: '#/components/schemas/EndEvent'
+            - $ref: '#/components/schemas/EventSubprocess'
+            - $ref: '#/components/schemas/ExclusiveGateway'
+            - $ref: '#/components/schemas/FileTask'
+            - $ref: '#/components/schemas/FtpTask'
+            - $ref: '#/components/schemas/InclusiveGateway'
+            - $ref: '#/components/schemas/MoveToLastGateway'
+            - $ref: '#/components/schemas/MoveToNode'
+            - $ref: '#/components/schemas/ParallelGateway'
+            - $ref: '#/components/schemas/ProcessorTask'
+            - $ref: '#/components/schemas/ReceiveTask'
+            - $ref: '#/components/schemas/RequestTask'
+            - $ref: '#/components/schemas/ScriptTask'
+            - $ref: '#/components/schemas/StartEvent'
+            - $ref: '#/components/schemas/Subprocess'
         initialContext:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/JsonNode'
+    EntityModelWorkflow:
+      required:
+      - name
+      - versionTag
+      type: object
+      properties:
+        name:
+          maxLength: 64
+          minLength: 4
+          type: string
+        description:
+          maxLength: 512
+          minLength: 0
+          type: string
+        versionTag:
+          maxLength: 64
+          minLength: 1
+          type: string
+        historyTimeToLive:
+          minimum: 0
+          type: integer
+          format: int32
+        active:
+          type: boolean
+        deploymentId:
+          type: string
+        setup:
+          $ref: '#/components/schemas/Setup'
+        initialContext:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/JsonNode'
+        _links:
+          $ref: '#/components/schemas/Links'
+    PagedModelEntityModelWorkflow:
+      type: object
+      properties:
+        _embedded:
+          type: object
+          properties:
+            workflows:
+              type: array
+              items:
+                $ref: '#/components/schemas/EntityModelWorkflow'
+        _links:
+          $ref: '#/components/schemas/Links'
+        page:
+          $ref: '#/components/schemas/PageMetadata'
     CollectionModelNode:
       type: object
       properties:
@@ -2018,6 +13647,64 @@ components:
               type: array
               items:
                 type: object
+        _links:
+          $ref: '#/components/schemas/Links'
+    EntityModelTrigger:
+      required:
+      - method
+      - name
+      - pathPattern
+      type: object
+      properties:
+        name:
+          maxLength: 64
+          minLength: 4
+          type: string
+        description:
+          maxLength: 256
+          minLength: 0
+          type: string
+        pathPattern:
+          maxLength: 256
+          minLength: 2
+          type: string
+        method:
+          type: string
+          enum:
+          - GET
+          - HEAD
+          - POST
+          - PUT
+          - PATCH
+          - DELETE
+          - OPTIONS
+          - TRACE
+        _links:
+          $ref: '#/components/schemas/Links'
+    PagedModelEntityModelTrigger:
+      type: object
+      properties:
+        _embedded:
+          type: object
+          properties:
+            triggers:
+              type: array
+              items:
+                $ref: '#/components/schemas/EntityModelTrigger'
+        _links:
+          $ref: '#/components/schemas/Links'
+        page:
+          $ref: '#/components/schemas/PageMetadata'
+    CollectionModelEntityModelTrigger:
+      type: object
+      properties:
+        _embedded:
+          type: object
+          properties:
+            triggers:
+              type: array
+              items:
+                $ref: '#/components/schemas/EntityModelTrigger'
         _links:
           $ref: '#/components/schemas/Links'
     TriggerRequestBody:
@@ -2207,17 +13894,6 @@ components:
       - $ref: '#/components/schemas/NodeRequestBody'
       - type: object
         properties:
-          path:
-            type: string
-          workflow:
-            type: string
-          action:
-            type: string
-            enum:
-            - READ_NEXT
-            - DELETE_NEXT
-            - LIST
-            - WRITE
           inputVariables:
             uniqueItems: true
             type: array
@@ -2229,6 +13905,17 @@ components:
             type: boolean
           asyncAfter:
             type: boolean
+          path:
+            type: string
+          workflow:
+            type: string
+          action:
+            type: string
+            enum:
+            - READ_NEXT
+            - DELETE_NEXT
+            - LIST
+            - WRITE
     EmailTaskRequestBody:
       required:
       - mailFrom
@@ -2290,6 +13977,12 @@ components:
       type: object
       allOf:
       - $ref: '#/components/schemas/NodeRequestBody'
+      - type: object
+        properties:
+          asyncBefore:
+            type: boolean
+          asyncAfter:
+            type: boolean
     ExclusiveGatewayRequestBody:
       required:
       - name
@@ -2382,6 +14075,8 @@ components:
             type: string
           password:
             type: string
+          basePath:
+            type: string
     InclusiveGatewayRequestBody:
       required:
       - name
@@ -2468,8 +14163,6 @@ components:
       - $ref: '#/components/schemas/NodeRequestBody'
       - type: object
         properties:
-          processor:
-            $ref: '#/components/schemas/EmbeddedProcessor'
           inputVariables:
             uniqueItems: true
             type: array
@@ -2481,6 +14174,8 @@ components:
             type: boolean
           asyncAfter:
             type: boolean
+          processor:
+            $ref: '#/components/schemas/EmbeddedProcessor'
     ReceiveTaskRequestBody:
       required:
       - message
@@ -2506,8 +14201,6 @@ components:
       - $ref: '#/components/schemas/NodeRequestBody'
       - type: object
         properties:
-          request:
-            $ref: '#/components/schemas/EmbeddedRequest'
           inputVariables:
             uniqueItems: true
             type: array
@@ -2524,6 +14217,8 @@ components:
             type: boolean
           asyncAfter:
             type: boolean
+          request:
+            $ref: '#/components/schemas/EmbeddedRequest'
     ScriptTaskRequestBody:
       required:
       - code
@@ -2601,6 +14296,10 @@ components:
           maxLength: 64
           minLength: 4
           type: string
+        description:
+          maxLength: 512
+          minLength: 0
+          type: string
         versionTag:
           maxLength: 64
           minLength: 1
@@ -2609,10 +14308,6 @@ components:
           minimum: 0
           type: integer
           format: int32
-        description:
-          maxLength: 512
-          minLength: 0
-          type: string
         active:
           type: boolean
         deploymentId:
@@ -2627,13 +14322,71 @@ components:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/JsonNode'
-    TenantAttributes:
+    error:
+      required:
+      - message
       type: object
       properties:
-        moduleTo:
+        message:
           type: string
-        moduleFrom:
+          description: Error message text
+        type:
           type: string
+          description: Error message type
+        code:
+          type: string
+          description: Error message code
+        parameters:
+          type: array
+          description: List of key/value parameters
+          items:
+            $ref: '#/components/schemas/parameter'
+      description: An error message
+    errors:
+      type: object
+      properties:
+        errors:
+          type: array
+          description: List of error messages
+          items:
+            $ref: '#/components/schemas/error'
+        total_records:
+          type: integer
+          description: Total number of errors
+          format: int32
+      description: A set of error messages
+    parameter:
+      required:
+      - key
+      type: object
+      properties:
+        key:
+          type: string
+          description: The key for this parameter
+        value:
+          type: string
+          description: The value of this parameter
+      description: Key/value parameter
+    tenantAttributes:
+      type: object
+      properties:
+        module_from:
+          type: string
+          description: "Existing module ID. If omitted, the module is not enabled\
+            \ already"
+        module_to:
+          type: string
+          description: "Target module ID. If omitted, the existing module is disabled"
+        purge:
+          type: boolean
+          description: On disable should data also be purged
+        parameters:
+          type: array
+          description: List of key/value parameters
+          items:
+            $ref: '#/components/schemas/parameter'
+      description: "Configuration how to install, upgrade or delete a module for a\
+        \ tenant"
     Link:
       type: object
       properties:

--- a/service/src/test/resources/application.yaml
+++ b/service/src/test/resources/application.yaml
@@ -5,11 +5,12 @@ logging:
   level:
     com:
       zaxxer:
-        hikari: INFO
+        hikari: ERROR
     org:
-      folio: INFO
-      hibernate: INFO
-      springframework: INFO
+      folio: WARN
+      hibernate: WARN
+      springframework: WARN
+      springframework.test: INFO
 
       # Uncomment to enable MockMvc unit test logging.
       #springframework.test.web.servlet.result: DEBUG
@@ -89,6 +90,9 @@ event:
     path: events
   queue:
     name: event.queue
+
+folio:
+  tenant.validation: false
 
 tenant:
   header-name: X-Okapi-Tenant


### PR DESCRIPTION
There is one unresolved issue relating to H2 and that has been commented out in the pom with an appropriate "FIXME" line.

The `folio-spring-support` introduces additional processing that inteferes with the processing by `mod-workflow`.
These can be found here:
- https://github.com/search?q=repo%3Afolio-org%2Ffolio-spring-support%20ConditionalOnProperty&type=code .

Of particular note are the `folio.tenant.validation` and the `header.validation.x-okapi-tenant.exclude.base-paths`.
Explicitly setting these in the `pom.xml` gets past several of these problems and allows for the `openapi.yaml` to be properly generated.

The `openapi.yaml` is still not being generated because the parent `pom.xml` has the `skip` configuration set to `true` for several of the required plugins.
Add the missing `skip`, setting it to `false`, in the service `pom.xml` to ensure that these plugins actually run.

This also makes tests easier to discern by reducing excess logging by default while keeping important logging and by providing more descriptive IDs for the openapi modes.
The more descriptive IDs should make reading the logs to determine what is going on when investigating openapi build problems.

This brings in the updated `openapi.yaml` file after building with these changes.
The command being run to do this looks something like:
```shell
DB_USERNAME=folio DB_PASSWORD=folio mvn clean verify -P openapi
```