### PR TITLE
Setup default liquibase setting path that works.

### DIFF
--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -22,6 +22,7 @@ server:
 spring:
   activemq.broker-url: tcp://localhost:61616
   application.name: mod-workflow
+  liquibase.changeLog: classpath:/changelog/changelog-master.xml
   data.rest:
     returnBodyOnCreate: true
     returnBodyOnUpdate: true


### PR DESCRIPTION
Without this setting, it attempts to access `classpath:/db/changelog/changelog-master.xml`. That path does not exist.
The path `classpath:/changelog/changelog-master.xml` does exist and so use that.

Once done deployment works.
This can also be set via the environment variable name `SPRING_LIQUIBASE_CHANGELOG`.