### PR TITLE
MODWRKFLOW-19: Allow for safe deletion of workflows.

### DIFF
--- a/service/src/main/java/org/folio/rest/workflow/controller/WorkflowController.java
+++ b/service/src/main/java/org/folio/rest/workflow/controller/WorkflowController.java
@@ -10,6 +10,8 @@ import org.folio.spring.tenant.annotation.TenantHeader;
 import org.folio.spring.web.annotation.TokenHeader;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -52,6 +54,19 @@ public class WorkflowController {
   ) throws WorkflowEngineServiceException {
     log.info("Deactivating: {}", id);
     return workflowEngineService.deactivate(id, tenant, token);
+  }
+
+  @DeleteMapping(value = {"/{id}/delete", "/{id}/delete/"})
+  public ResponseEntity<?> deleteWorkflow(
+    @PathVariable String id,
+    @TenantHeader String tenant,
+    @TokenHeader String token
+  ) throws WorkflowEngineServiceException {
+    log.info("Deleting: {}", id);
+    workflowEngineService.delete(id, tenant, token);
+
+    // Ensure that a HTTP 204 is returned on success.
+    return ResponseEntity.noContent().build();
   }
 
   @PostMapping(value = {"/{id}/start", "/{id}/start/"}, produces = { MediaType.APPLICATION_JSON_VALUE })

--- a/service/src/main/java/org/folio/rest/workflow/model/repo/WorkflowRepo.java
+++ b/service/src/main/java/org/folio/rest/workflow/model/repo/WorkflowRepo.java
@@ -3,9 +3,14 @@ package org.folio.rest.workflow.model.repo;
 import org.folio.rest.workflow.model.Workflow;
 import org.folio.spring.cql.JpaCqlRepository;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.data.rest.core.annotation.RestResource;
 
 @RepositoryRestResource
 public interface WorkflowRepo extends JpaCqlRepository<Workflow, String> {
 
   public <T> T getViewById(String id, Class<T> type);
+
+  @Override
+  @RestResource(exported = false)
+  public void deleteById(String id);
 }

--- a/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
@@ -5,13 +5,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Iterator;
+import lombok.extern.slf4j.Slf4j;
 import org.folio.rest.workflow.dto.WorkflowDto;
 import org.folio.rest.workflow.dto.WorkflowOperationalDto;
 import org.folio.rest.workflow.exception.WorkflowEngineServiceException;
 import org.folio.rest.workflow.model.Workflow;
 import org.folio.rest.workflow.model.repo.WorkflowRepo;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.client.RestTemplateBuilder;
@@ -23,10 +22,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+@Slf4j
 @Service
 public class WorkflowEngineService {
-
-  private static final Logger logger = LoggerFactory.getLogger(WorkflowEngineService.class);
 
   private static final String WORKFLOW_ENGINE_ACTIVATE_URL_TEMPLATE = "%s%s/workflow-engine/workflows/activate";
   private static final String WORKFLOW_ENGINE_DEACTIVATE_URL_TEMPLATE = "%s%s/workflow-engine/workflows/deactivate";
@@ -36,6 +34,8 @@ public class WorkflowEngineService {
 
   private static final String HISTORY_PROCESS_INSTANCE_URL_TEMPLATE = "%s%s/history/process-instance%s";
   private static final String HISTORY_INCIDENT_URL_TEMPLATE = "%s%s/history/incident%s";
+
+  private static final String LOG_RESPONSE_BODY = "Response body: {}";
 
   @Value("${tenant.headerName:X-Okapi-Tenant}")
   private String tenantHeaderName;
@@ -74,8 +74,36 @@ public class WorkflowEngineService {
   public Workflow deactivate(String workflowId, String tenant, String token)
       throws WorkflowEngineServiceException {
 
+    if (!workflowRepo.existsById(workflowId)) {
+      log.warn("Unable to find Workflow: {}", workflowId);
+      return null;
+    }
+
     WorkflowDto workflow = workflowRepo.getViewById(workflowId, WorkflowDto.class);
     return sendWorkflowRequest(workflow, WORKFLOW_ENGINE_DEACTIVATE_URL_TEMPLATE, tenant, token);
+  }
+
+  /**
+   * Delete the Workflow from the given Workflow ID.
+   *
+   * To be removed. This is just an experiment.
+   *
+   * @param workflowId ID of the Workflow to delete.
+   * @param tenant The tenant to use.
+   * @param token The token to use.
+   *
+   * @throws WorkflowEngineServiceException When the request fails in some way preventing the return of an HttpEntity.
+   */
+  public void delete(String workflowId, String tenant, String token)
+      throws WorkflowEngineServiceException {
+
+    try {
+      deactivate(workflowId, tenant, token);
+    } catch (WorkflowEngineServiceException e) {
+      throw new WorkflowEngineServiceException(String.format("Failed to delete Workflow '%s' due to deactivation failure: %s!", workflowId, e.getMessage()), e);
+    }
+
+    workflowRepo.deleteById(workflowId);
   }
 
   public JsonNode start(String workflowId, String tenant, String token, JsonNode context)
@@ -136,7 +164,7 @@ public class WorkflowEngineService {
 
       ArrayNode definitions = response.getBody();
       if (response.getStatusCode() == HttpStatus.OK && definitions != null && !definitions.isEmpty()) {
-        logger.debug("Response body: {}", definitions);
+        log.debug(LOG_RESPONSE_BODY, definitions);
 
         return definitions.get(0);
       }
@@ -160,7 +188,7 @@ public class WorkflowEngineService {
 
       ArrayNode definitions = response.getBody();
       if (response.getStatusCode() == HttpStatus.OK && definitions != null) {
-        logger.debug("Response body: {}", definitions);
+        log.debug(LOG_RESPONSE_BODY, definitions);
 
         return definitions;
       }
@@ -183,10 +211,10 @@ public class WorkflowEngineService {
 
       ArrayNode incidents = response.getBody();
       if (response.getStatusCode() == HttpStatus.OK && incidents != null) {
-        logger.debug("Response body: {}", incidents);
+        log.debug(LOG_RESPONSE_BODY, incidents);
       }
       else {
-        logger.debug("Unable to get workflow incidents history from workflow engine!");
+        log.debug("Unable to get workflow incidents history from workflow engine!");
 
         incidents = mapper.createArrayNode();
       }
@@ -197,22 +225,37 @@ public class WorkflowEngineService {
     }
   }
 
+  /**
+   * Send a HTTP request to perform an action to the Workflow Engine end point and update the workflow locally.
+   *
+   * @param workflow The workflow associated with the action.
+   * @param requestPath The end point being used.
+   * @param tenant The tenant to use.
+   * @param token The token to use.
+   *
+   * @return The updated Workflow.
+   *
+   * @throws WorkflowEngineServiceException On certain request failures or when failed to update the Workflow.
+   */
   private Workflow sendWorkflowRequest(WorkflowDto workflow, String requestPath, String tenant, String token)
       throws WorkflowEngineServiceException {
 
-    HttpEntity<WorkflowDto> workflowHttpEntity = new HttpEntity<>(workflow, headers(tenant, token));
-
+    HttpEntity<WorkflowDto> entity = new HttpEntity<WorkflowDto>(workflow, headers(tenant, token));
     String url = String.format(requestPath, okapiUrl, basePath);
+
     try {
-      ResponseEntity<Workflow> response = exchange(url, HttpMethod.POST, workflowHttpEntity, Workflow.class);
+      ResponseEntity<Workflow> response = exchange(url, HttpMethod.POST, entity, Workflow.class);
 
-      Workflow responseWorkflow = response.getBody();
-      if (response.getStatusCode() == HttpStatus.OK && responseWorkflow != null) {
-        logger.debug("Response body: {}", responseWorkflow);
+      if (response.getStatusCode() == HttpStatus.OK) {
+        Workflow responseWorkflow = response.getBody();
 
-        String deploymentId = responseWorkflow.getDeploymentId();
-        logger.info("Workflow is active = {}, deploymentID = {}", responseWorkflow.isActive(), deploymentId);
-        return workflowRepo.save(responseWorkflow);
+        if (responseWorkflow != null) {
+          log.debug(LOG_RESPONSE_BODY, responseWorkflow);
+
+          String deploymentId = responseWorkflow.getDeploymentId();
+          log.info("Workflow is active = {}, deploymentID = {}", responseWorkflow.isActive(), deploymentId);
+          return workflowRepo.save(responseWorkflow);
+        }
       }
     } catch (Exception e) {
       throw new WorkflowEngineServiceException(String.format("Failed to send workflow request: %s!", e.getMessage()), e);

--- a/service/src/test/java/org/folio/rest/workflow/service/WorkflowEngineServiceTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/service/WorkflowEngineServiceTest.java
@@ -1,0 +1,132 @@
+package org.folio.rest.workflow.service;
+
+import static org.folio.spring.test.mock.MockMvcConstant.OKAPI_TENANT;
+import static org.folio.spring.test.mock.MockMvcConstant.OKAPI_TOKEN;
+import static org.folio.spring.test.mock.MockMvcConstant.UUID;
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import java.io.IOException;
+import org.folio.rest.workflow.dto.WorkflowDto;
+import org.folio.rest.workflow.exception.WorkflowEngineServiceException;
+import org.folio.rest.workflow.model.Workflow;
+import org.folio.rest.workflow.model.repo.WorkflowRepo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.web.client.RestTemplate;
+
+@ExtendWith(SpringExtension.class)
+@ExtendWith(MockitoExtension.class)
+class WorkflowEngineServiceTest {
+
+  @Mock
+  private WorkflowRepo workflowRepo;
+
+  @Mock
+  private RestTemplate restTemplate;
+
+  private WorkflowAsDto workflow;
+
+  private WorkflowEngineService workflowEngineService;
+
+  @BeforeEach
+  void beforeEach() {
+    workflowEngineService = new WorkflowEngineService(new RestTemplateBuilder());
+
+    workflow = new WorkflowAsDto();
+    workflow.setId(UUID);
+    workflow.setDeploymentId(UUID);
+    workflow.setName(VALUE);
+
+    setField(workflowEngineService, "workflowRepo", workflowRepo);
+    setField(workflowEngineService, "restTemplate", restTemplate);
+    setField(workflowEngineService, "tenantHeaderName", OKAPI_TENANT);
+    setField(workflowEngineService, "tokenHeaderName", OKAPI_TOKEN);
+  }
+
+  @Test
+  void deleteWorksTest() throws WorkflowEngineServiceException {
+    WorkflowDto workflowDto = (WorkflowDto) workflow;
+    ResponseEntity<Workflow> responseEntity = new ResponseEntity<>(HttpStatus.OK);
+    setField(responseEntity, "body", workflow);
+
+    when(workflowRepo.existsById(anyString())).thenReturn(true);
+    when(workflowRepo.getViewById(anyString(), ArgumentMatchers.<Class<WorkflowDto>>any())).thenReturn(workflowDto);
+    when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<Workflow>>any())).thenReturn(responseEntity);
+    when(workflowRepo.save(any())).thenReturn(workflow);
+    doNothing().when(workflowRepo).deleteById(anyString());
+
+    workflowEngineService.delete(UUID, OKAPI_TENANT, OKAPI_TOKEN);
+
+    verify(workflowRepo).save(any());
+    verify(workflowRepo).deleteById(anyString());
+  }
+
+  @Test
+  void deleteWorksWithoutDeactivateTest() throws WorkflowEngineServiceException {
+    when(workflowRepo.existsById(anyString())).thenReturn(false);
+    doNothing().when(workflowRepo).deleteById(anyString());
+
+    workflowEngineService.delete(UUID, OKAPI_TENANT, OKAPI_TOKEN);
+
+    verify(workflowRepo, never()).save(any());
+    verify(workflowRepo).deleteById(anyString());
+  }
+
+  @Test
+  void deleteThrowsExceptionUnableGetUpdatedTest() throws IOException, WorkflowEngineServiceException {
+    WorkflowDto workflowDto = (WorkflowDto) workflow;
+    ResponseEntity<Workflow> responseEntity = new ResponseEntity<>(HttpStatus.ACCEPTED);
+    setField(responseEntity, "body", workflow);
+
+    when(workflowRepo.existsById(anyString())).thenReturn(true);
+    when(workflowRepo.getViewById(anyString(), ArgumentMatchers.<Class<WorkflowDto>>any())).thenReturn(workflowDto);
+    when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<Workflow>>any())).thenReturn(responseEntity);
+
+    assertThrows(WorkflowEngineServiceException.class, () ->
+      workflowEngineService.delete(UUID, OKAPI_TENANT, OKAPI_TOKEN)
+    );
+
+    verify(workflowRepo, never()).save(any());
+    verify(workflowRepo, never()).deleteById(anyString());
+  }
+
+  @Test
+  void deleteThrowsExceptionFailedToSendTest() throws IOException, WorkflowEngineServiceException {
+    WorkflowDto workflowDto = (WorkflowDto) workflow;
+    ResponseEntity<Workflow> responseEntity = new ResponseEntity<>(HttpStatus.OK);
+    setField(responseEntity, "body", workflow);
+
+    when(workflowRepo.existsById(anyString())).thenReturn(true);
+    when(workflowRepo.getViewById(anyString(), ArgumentMatchers.<Class<WorkflowDto>>any())).thenReturn(workflowDto);
+    when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<Workflow>>any())).thenReturn(responseEntity);
+    when(workflowRepo.save(any())).thenThrow(new RuntimeException("Trigger Failure"));
+
+    assertThrows(WorkflowEngineServiceException.class, () -> {
+      workflowEngineService.delete(UUID, OKAPI_TENANT, OKAPI_TOKEN);
+    });
+
+    verify(workflowRepo).save(any());
+    verify(workflowRepo, never()).deleteById(anyString());
+  }
+
+  private class WorkflowAsDto extends Workflow implements WorkflowDto {};
+
+}


### PR DESCRIPTION
resolves [MODWRKFLOW-19](https://folio-org.atlassian.net/browse/MODWRKFLOW-19)

This is designed to call the deactivate end point in mod-camunda on the expectation that mod-camunda is properly deactivating (setting cascade to true on deactivate/undeploy).

Disable the spring-data-rest end point for the `DELETE` on a Workflow.

Add a new dedicated end point for Workflow that performs the `DELETE`.
- This is done via a custom function in the `WorkflowEngineService`.
- An HTTP 204 must be explicitly returned because this end point does not return content.
- The mod-camunda end point is also expected to not throw an error when deactivating an already deactivated workflow.
  - This requires changes in mod-camunda.
- Fix potential logic problems in `sendWorkflowRequest` in regards to when `responseWorkflow` is NULL.
  - The `responseWorkflow` could be NULL on certain valid responses when status is not HTTP 200 (OK).

Perform "code smell" clean up by moving the `Response body: {}` message to a class constant.