### PR TITLE
MODWRKFLOW-18: Add components model unit tests.

### DIFF
--- a/components/pom.xml
+++ b/components/pom.xml
@@ -22,6 +22,13 @@
     </dependency>
 
     <dependency>
+      <groupId>org.folio</groupId>
+      <artifactId>spring-test</artifactId>
+      <version>${spring-module-core.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-rest</artifactId>
     </dependency>
@@ -37,11 +44,20 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <skip>false</skip>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <configuration>
           <skip>false</skip>
         </configuration>
       </plugin>
+
       <plugin>
         <groupId>org.graalvm.buildtools</groupId>
         <artifactId>native-maven-plugin</artifactId>
@@ -49,6 +65,7 @@
           <skip>true</skip>
         </configuration>
       </plugin>
+
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>

--- a/components/src/main/java/org/folio/rest/workflow/model/DatabaseConnectionTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/DatabaseConnectionTask.java
@@ -8,13 +8,14 @@ import java.util.Set;
 import lombok.Getter;
 import lombok.Setter;
 import org.folio.rest.workflow.model.components.DelegateTask;
+import org.folio.rest.workflow.model.has.HasAsync;
 import org.folio.rest.workflow.model.has.HasDesignation;
 import org.folio.rest.workflow.model.has.HasPassword;
 import org.folio.rest.workflow.model.has.HasUrl;
 import org.folio.rest.workflow.model.has.HasUsername;
 
 @Entity
-public class DatabaseConnectionTask extends Node implements DelegateTask, HasDesignation, HasPassword, HasUrl, HasUsername {
+public class DatabaseConnectionTask extends Node implements DelegateTask, HasAsync, HasDesignation, HasPassword, HasUrl, HasUsername {
 
   @Getter
   @Setter

--- a/components/src/main/java/org/folio/rest/workflow/model/DatabaseDisconnectTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/DatabaseDisconnectTask.java
@@ -8,10 +8,11 @@ import java.util.Set;
 import lombok.Getter;
 import lombok.Setter;
 import org.folio.rest.workflow.model.components.DelegateTask;
+import org.folio.rest.workflow.model.has.HasAsync;
 import org.folio.rest.workflow.model.has.HasDesignation;
 
 @Entity
-public class DatabaseDisconnectTask extends Node implements DelegateTask, HasDesignation {
+public class DatabaseDisconnectTask extends Node implements DelegateTask, HasAsync, HasDesignation {
 
   @Getter
   @Setter

--- a/components/src/main/java/org/folio/rest/workflow/model/DatabaseQueryTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/DatabaseQueryTask.java
@@ -11,11 +11,12 @@ import lombok.Getter;
 import lombok.Setter;
 import org.folio.rest.workflow.enums.DatabaseResultType;
 import org.folio.rest.workflow.model.components.DelegateTask;
+import org.folio.rest.workflow.model.has.HasAsync;
 import org.folio.rest.workflow.model.has.HasDesignation;
 import org.folio.rest.workflow.model.has.common.HasDatabaseQueryTaskCommon;
 
 @Entity
-public class DatabaseQueryTask extends Node implements DelegateTask, HasDatabaseQueryTaskCommon, HasDesignation {
+public class DatabaseQueryTask extends Node implements DelegateTask, HasAsync, HasDatabaseQueryTaskCommon, HasDesignation {
 
   @Getter
   @Setter

--- a/components/src/main/java/org/folio/rest/workflow/model/DirectoryTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/DirectoryTask.java
@@ -13,10 +13,11 @@ import lombok.Getter;
 import lombok.Setter;
 import org.folio.rest.workflow.enums.DirectoryAction;
 import org.folio.rest.workflow.model.components.DelegateTask;
+import org.folio.rest.workflow.model.has.HasAsync;
 import org.folio.rest.workflow.model.has.common.HasDirectoryTaskCommon;
 
 @Entity
-public class DirectoryTask extends Node implements DelegateTask, HasDirectoryTaskCommon {
+public class DirectoryTask extends Node implements DelegateTask, HasAsync, HasDirectoryTaskCommon {
 
   @Getter
   @Setter

--- a/components/src/main/java/org/folio/rest/workflow/model/EmailTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/EmailTask.java
@@ -10,11 +10,12 @@ import java.util.Set;
 import lombok.Getter;
 import lombok.Setter;
 import org.folio.rest.workflow.model.components.DelegateTask;
+import org.folio.rest.workflow.model.has.HasAsync;
 import org.folio.rest.workflow.model.has.common.HasEmailTaskCommon;
 import org.springframework.lang.NonNull;
 
 @Entity
-public class EmailTask extends Node implements DelegateTask, HasEmailTaskCommon {
+public class EmailTask extends Node implements DelegateTask, HasAsync, HasEmailTaskCommon {
 
   @Getter
   @Setter

--- a/components/src/main/java/org/folio/rest/workflow/model/FileTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/FileTask.java
@@ -12,10 +12,11 @@ import lombok.Getter;
 import lombok.Setter;
 import org.folio.rest.workflow.enums.FileOp;
 import org.folio.rest.workflow.model.components.DelegateTask;
+import org.folio.rest.workflow.model.has.HasAsync;
 import org.folio.rest.workflow.model.has.common.HasFileTaskCommon;
 
 @Entity
-public class FileTask extends Node implements DelegateTask, HasFileTaskCommon {
+public class FileTask extends Node implements DelegateTask, HasAsync, HasFileTaskCommon {
 
   @Getter
   @Setter

--- a/components/src/main/java/org/folio/rest/workflow/model/FtpTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/FtpTask.java
@@ -12,13 +12,14 @@ import lombok.Getter;
 import lombok.Setter;
 import org.folio.rest.workflow.enums.SftpOp;
 import org.folio.rest.workflow.model.components.DelegateTask;
+import org.folio.rest.workflow.model.has.HasAsync;
 import org.folio.rest.workflow.model.has.HasPassword;
 import org.folio.rest.workflow.model.has.HasService;
 import org.folio.rest.workflow.model.has.HasUsername;
 import org.folio.rest.workflow.model.has.common.HasFtpTaskCommon;
 
 @Entity
-public class FtpTask extends Node implements DelegateTask, HasFtpTaskCommon, HasPassword, HasService, HasUsername {
+public class FtpTask extends Node implements DelegateTask, HasAsync, HasFtpTaskCommon, HasPassword, HasService, HasUsername {
 
   @Getter
   @Setter

--- a/components/src/main/java/org/folio/rest/workflow/model/ProcessorTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/ProcessorTask.java
@@ -9,10 +9,11 @@ import java.util.Set;
 import lombok.Getter;
 import lombok.Setter;
 import org.folio.rest.workflow.model.components.DelegateTask;
+import org.folio.rest.workflow.model.has.HasAsync;
 import org.folio.rest.workflow.model.has.common.HasProcessorTaskCommon;
 
 @Entity
-public class ProcessorTask extends Node implements DelegateTask, HasProcessorTaskCommon {
+public class ProcessorTask extends Node implements DelegateTask, HasAsync, HasProcessorTaskCommon {
 
   @Getter
   @Setter

--- a/components/src/main/java/org/folio/rest/workflow/model/RequestTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/RequestTask.java
@@ -9,10 +9,11 @@ import java.util.Set;
 import lombok.Getter;
 import lombok.Setter;
 import org.folio.rest.workflow.model.components.DelegateTask;
+import org.folio.rest.workflow.model.has.HasAsync;
 import org.folio.rest.workflow.model.has.common.HasRequestTaskCommon;
 
 @Entity
-public class RequestTask extends Node implements DelegateTask, HasRequestTaskCommon {
+public class RequestTask extends Node implements DelegateTask, HasAsync, HasRequestTaskCommon {
 
   @Getter
   @Setter

--- a/components/src/main/java/org/folio/rest/workflow/model/ScriptTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/ScriptTask.java
@@ -6,11 +6,12 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 import org.folio.rest.workflow.model.components.Task;
+import org.folio.rest.workflow.model.has.HasAsync;
 import org.folio.rest.workflow.model.has.HasCode;
 import org.folio.rest.workflow.model.has.common.HasScriptTaskCommon;
 
 @Entity
-public class ScriptTask extends Node implements HasCode, HasScriptTaskCommon, Task {
+public class ScriptTask extends Node implements HasCode, HasAsync, HasScriptTaskCommon, Task {
 
   @Getter
   @Setter

--- a/components/src/main/java/org/folio/rest/workflow/model/Subprocess.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/Subprocess.java
@@ -13,9 +13,10 @@ import java.util.List;
 import org.folio.rest.workflow.enums.SubprocessType;
 import org.folio.rest.workflow.model.components.Branch;
 import org.folio.rest.workflow.model.components.MultiInstance;
+import org.folio.rest.workflow.model.has.HasAsync;
 
 @Entity
-public class Subprocess extends Node implements Branch, MultiInstance {
+public class Subprocess extends Node implements Branch, HasAsync, MultiInstance {
 
   @NotNull
   @Column(nullable = false)

--- a/components/src/test/java/org/folio/rest/workflow/TestApplication.java
+++ b/components/src/test/java/org/folio/rest/workflow/TestApplication.java
@@ -1,0 +1,18 @@
+package org.folio.rest.workflow;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
+
+public class TestApplication extends SpringBootServletInitializer {
+
+  @Override
+  protected SpringApplicationBuilder configure(SpringApplicationBuilder application) {
+    return application.sources(TestApplication.class);
+  }
+
+  public static void main(String[] args) {
+    SpringApplication.run(TestApplication.class, args);
+  }
+
+}

--- a/components/src/test/java/org/folio/rest/workflow/model/AbstractGatewayTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/AbstractGatewayTest.java
@@ -1,0 +1,126 @@
+package org.folio.rest.workflow.model;
+
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.folio.rest.workflow.enums.Direction;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AbstractGatewayTest {
+
+  @Mock
+  private Node node;
+
+  private List<Node> nodes;
+
+  private AbstractGateway abstractGateway;
+
+  @BeforeEach
+  void beforeEach() {
+    abstractGateway = new Impl();
+    nodes = new ArrayList<>();
+    nodes.add(node);
+  }
+
+  @Test
+  void getIdWorksTest() {
+    setField(abstractGateway, "id", VALUE);
+
+    assertEquals(VALUE, abstractGateway.getId());
+  }
+
+  @Test
+  void setIdWorksTest() {
+    setField(abstractGateway, "id", null);
+
+    abstractGateway.setId(VALUE);
+    assertEquals(VALUE, getField(abstractGateway, "id"));
+  }
+
+  @Test
+  void getNameWorksTest() {
+    setField(abstractGateway, "name", VALUE);
+
+    assertEquals(VALUE, abstractGateway.getName());
+  }
+
+  @Test
+  void setNameWorksTest() {
+    setField(abstractGateway, "name", null);
+
+    abstractGateway.setName(VALUE);
+    assertEquals(VALUE, getField(abstractGateway, "name"));
+  }
+
+  @Test
+  void getDescriptionWorksTest() {
+    setField(abstractGateway, "description", VALUE);
+
+    assertEquals(VALUE, abstractGateway.getDescription());
+  }
+
+  @Test
+  void setDescriptionWorksTest() {
+    setField(abstractGateway, "description", null);
+
+    abstractGateway.setDescription(VALUE);
+    assertEquals(VALUE, getField(abstractGateway, "description"));
+  }
+
+  @Test
+  void getDeserializeAsWorksTest() {
+    setField(abstractGateway, "deserializeAs", VALUE);
+
+    assertEquals(VALUE, abstractGateway.getDeserializeAs());
+  }
+
+  @Test
+  void setDeserializeAsWorksTest() {
+    setField(abstractGateway, "deserializeAs", null);
+
+    abstractGateway.setDeserializeAs(VALUE);
+    assertEquals(VALUE, getField(abstractGateway, "deserializeAs"));
+  }
+
+  @Test
+  void getDirectionWorksTest() {
+    setField(abstractGateway, "direction", Direction.CONVERGING);
+
+    assertEquals(Direction.CONVERGING, abstractGateway.getDirection());
+  }
+
+  @Test
+  void setDirectionWorksTest() {
+    setField(abstractGateway, "direction", null);
+
+    abstractGateway.setDirection(Direction.CONVERGING);
+    assertEquals(Direction.CONVERGING, getField(abstractGateway, "direction"));
+  }
+
+  @Test
+  void getNodesWorksTest() {
+    setField(abstractGateway, "nodes", nodes);
+
+    assertEquals(nodes, abstractGateway.getNodes());
+  }
+
+  @Test
+  void setNodesWorksTest() {
+    setField(abstractGateway, "nodes", null);
+
+    abstractGateway.setNodes(nodes);
+    assertEquals(nodes, getField(abstractGateway, "nodes"));
+  }
+
+  private static class Impl extends AbstractGateway { };
+
+}

--- a/components/src/test/java/org/folio/rest/workflow/model/CompressFileTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/CompressFileTest.java
@@ -1,0 +1,215 @@
+package org.folio.rest.workflow.model;
+
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.folio.rest.workflow.enums.CompressFileContainer;
+import org.folio.rest.workflow.enums.CompressFileFormat;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CompressFileTest {
+
+  @Mock
+  private EmbeddedVariable embeddedVariable;
+
+  private Set<EmbeddedVariable> inputVariables;
+
+  private CompressFileTask compressFileTask;
+
+  @BeforeEach
+  void beforeEach() {
+    compressFileTask = new CompressFileTask();
+    inputVariables = new HashSet<>();
+    inputVariables.add(embeddedVariable);
+  }
+
+  @Test
+  void getIdWorksTest() {
+    setField(compressFileTask, "id", VALUE);
+
+    assertEquals(VALUE, compressFileTask.getId());
+  }
+
+  @Test
+  void setIdWorksTest() {
+    setField(compressFileTask, "id", null);
+
+    compressFileTask.setId(VALUE);
+    assertEquals(VALUE, getField(compressFileTask, "id"));
+  }
+
+  @Test
+  void getNameWorksTest() {
+    setField(compressFileTask, "name", VALUE);
+
+    assertEquals(VALUE, compressFileTask.getName());
+  }
+
+  @Test
+  void setNameWorksTest() {
+    setField(compressFileTask, "name", null);
+
+    compressFileTask.setName(VALUE);
+    assertEquals(VALUE, getField(compressFileTask, "name"));
+  }
+
+  @Test
+  void getDescriptionWorksTest() {
+    setField(compressFileTask, "description", VALUE);
+
+    assertEquals(VALUE, compressFileTask.getDescription());
+  }
+
+  @Test
+  void setDescriptionWorksTest() {
+    setField(compressFileTask, "description", null);
+
+    compressFileTask.setDescription(VALUE);
+    assertEquals(VALUE, getField(compressFileTask, "description"));
+  }
+
+  @Test
+  void getDeserializeAsWorksTest() {
+    setField(compressFileTask, "deserializeAs", VALUE);
+
+    assertEquals(VALUE, compressFileTask.getDeserializeAs());
+  }
+
+  @Test
+  void setDeserializeAsWorksTest() {
+    setField(compressFileTask, "deserializeAs", null);
+
+    compressFileTask.setDeserializeAs(VALUE);
+    assertEquals(VALUE, getField(compressFileTask, "deserializeAs"));
+  }
+
+  @Test
+  void getInputVariablesWorksTest() {
+    setField(compressFileTask, "inputVariables", inputVariables);
+
+    assertEquals(inputVariables, compressFileTask.getInputVariables());
+  }
+
+  @Test
+  void setInputVariablesWorksTest() {
+    setField(compressFileTask, "inputVariables", null);
+
+    compressFileTask.setInputVariables(inputVariables);
+    assertEquals(inputVariables, getField(compressFileTask, "inputVariables"));
+  }
+
+  @Test
+  void getOutputVariableWorksTest() {
+    setField(compressFileTask, "outputVariable", embeddedVariable);
+
+    assertEquals(embeddedVariable, compressFileTask.getOutputVariable());
+  }
+
+  @Test
+  void setOutputVariableWorksTest() {
+    setField(compressFileTask, "outputVariable", null);
+
+    compressFileTask.setOutputVariable(embeddedVariable);
+    assertEquals(embeddedVariable, getField(compressFileTask, "outputVariable"));
+  }
+
+  @Test
+  void getAsyncBeforeWorksTest() {
+    setField(compressFileTask, "asyncBefore", true);
+
+    assertEquals(true, compressFileTask.isAsyncBefore());
+  }
+
+  @Test
+  void setAsyncBeforeWorksTest() {
+    setField(compressFileTask, "asyncBefore", false);
+
+    compressFileTask.setAsyncBefore(true);
+    assertEquals(true, getField(compressFileTask, "asyncBefore"));
+  }
+
+  @Test
+  void getAsyncAfterWorksTest() {
+    setField(compressFileTask, "asyncAfter", true);
+
+    assertEquals(true, compressFileTask.isAsyncAfter());
+  }
+
+  @Test
+  void setAsyncAfterWorksTest() {
+    setField(compressFileTask, "asyncAfter", false);
+
+    compressFileTask.setAsyncAfter(true);
+    assertEquals(true, getField(compressFileTask, "asyncAfter"));
+  }
+
+  @Test
+  void getSourceWorksTest() {
+    setField(compressFileTask, "source", VALUE);
+
+    assertEquals(VALUE, compressFileTask.getSource());
+  }
+
+  @Test
+  void setSourceWorksTest() {
+    setField(compressFileTask, "source", null);
+
+    compressFileTask.setSource(VALUE);
+    assertEquals(VALUE, getField(compressFileTask, "source"));
+  }
+
+  @Test
+  void getDestinationWorksTest() {
+    setField(compressFileTask, "destination", VALUE);
+
+    assertEquals(VALUE, compressFileTask.getDestination());
+  }
+
+  @Test
+  void setDestinationWorksTest() {
+    setField(compressFileTask, "destination", null);
+
+    compressFileTask.setDestination(VALUE);
+    assertEquals(VALUE, getField(compressFileTask, "destination"));
+  }
+
+  @Test
+  void getFormatWorksTest() {
+    setField(compressFileTask, "format", CompressFileFormat.BZIP2);
+
+    assertEquals(CompressFileFormat.BZIP2, compressFileTask.getFormat());
+  }
+
+  @Test
+  void setFormatWorksTest() {
+    setField(compressFileTask, "format", null);
+
+    compressFileTask.setFormat(CompressFileFormat.BZIP2);
+    assertEquals(CompressFileFormat.BZIP2, getField(compressFileTask, "format"));
+  }
+
+  @Test
+  void getContainerWorksTest() {
+    setField(compressFileTask, "container", CompressFileContainer.TAR);
+
+    assertEquals(CompressFileContainer.TAR, compressFileTask.getContainer());
+  }
+
+  @Test
+  void setContainerWorksTest() {
+    setField(compressFileTask, "container", null);
+
+    compressFileTask.setContainer(CompressFileContainer.TAR);
+    assertEquals(CompressFileContainer.TAR, getField(compressFileTask, "container"));
+  }
+
+}

--- a/components/src/test/java/org/folio/rest/workflow/model/ConditionTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/ConditionTest.java
@@ -1,0 +1,110 @@
+package org.folio.rest.workflow.model;
+
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ConditionTest {
+
+  private Condition condition;
+
+  @BeforeEach
+  void beforeEach() {
+    condition = new Condition();
+  }
+
+  @Test
+  void getIdWorksTest() {
+    setField(condition, "id", VALUE);
+
+    assertEquals(VALUE, condition.getId());
+  }
+
+  @Test
+  void setIdWorksTest() {
+    setField(condition, "id", null);
+
+    condition.setId(VALUE);
+    assertEquals(VALUE, getField(condition, "id"));
+  }
+
+  @Test
+  void getNameWorksTest() {
+    setField(condition, "name", VALUE);
+
+    assertEquals(VALUE, condition.getName());
+  }
+
+  @Test
+  void setNameWorksTest() {
+    setField(condition, "name", null);
+
+    condition.setName(VALUE);
+    assertEquals(VALUE, getField(condition, "name"));
+  }
+
+  @Test
+  void getDescriptionWorksTest() {
+    setField(condition, "description", VALUE);
+
+    assertEquals(VALUE, condition.getDescription());
+  }
+
+  @Test
+  void setDescriptionWorksTest() {
+    setField(condition, "description", null);
+
+    condition.setDescription(VALUE);
+    assertEquals(VALUE, getField(condition, "description"));
+  }
+
+  @Test
+  void getDeserializeAsWorksTest() {
+    setField(condition, "deserializeAs", VALUE);
+
+    assertEquals(VALUE, condition.getDeserializeAs());
+  }
+
+  @Test
+  void setDeserializeAsWorksTest() {
+    setField(condition, "deserializeAs", null);
+
+    condition.setDeserializeAs(VALUE);
+    assertEquals(VALUE, getField(condition, "deserializeAs"));
+  }
+
+  @Test
+  void getExpressionWorksTest() {
+    setField(condition, "expression", VALUE);
+
+    assertEquals(VALUE, condition.getExpression());
+  }
+
+  @Test
+  void setExpressionWorksTest() {
+    setField(condition, "expression", null);
+
+    condition.setExpression(VALUE);
+    assertEquals(VALUE, getField(condition, "expression"));
+  }
+
+  @Test
+  void getAnswerWorksTest() {
+    setField(condition, "answer", VALUE);
+
+    assertEquals(VALUE, condition.getAnswer());
+  }
+
+  @Test
+  void setAnswerWorksTest() {
+    setField(condition, "answer", null);
+
+    condition.setAnswer(VALUE);
+    assertEquals(VALUE, getField(condition, "answer"));
+  }
+
+}

--- a/components/src/test/java/org/folio/rest/workflow/model/ConnectToTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/ConnectToTest.java
@@ -1,0 +1,95 @@
+package org.folio.rest.workflow.model;
+
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ConnectToTest {
+
+  private ConnectTo connectTo;
+
+  @BeforeEach
+  void beforeEach() {
+    connectTo = new ConnectTo();
+  }
+
+  @Test
+  void getIdWorksTest() {
+    setField(connectTo, "id", VALUE);
+
+    assertEquals(VALUE, connectTo.getId());
+  }
+
+  @Test
+  void setIdWorksTest() {
+    setField(connectTo, "id", null);
+
+    connectTo.setId(VALUE);
+    assertEquals(VALUE, getField(connectTo, "id"));
+  }
+
+  @Test
+  void getNameWorksTest() {
+    setField(connectTo, "name", VALUE);
+
+    assertEquals(VALUE, connectTo.getName());
+  }
+
+  @Test
+  void setNameWorksTest() {
+    setField(connectTo, "name", null);
+
+    connectTo.setName(VALUE);
+    assertEquals(VALUE, getField(connectTo, "name"));
+  }
+
+  @Test
+  void getDescriptionWorksTest() {
+    setField(connectTo, "description", VALUE);
+
+    assertEquals(VALUE, connectTo.getDescription());
+  }
+
+  @Test
+  void setDescriptionWorksTest() {
+    setField(connectTo, "description", null);
+
+    connectTo.setDescription(VALUE);
+    assertEquals(VALUE, getField(connectTo, "description"));
+  }
+
+  @Test
+  void getDeserializeAsWorksTest() {
+    setField(connectTo, "deserializeAs", VALUE);
+
+    assertEquals(VALUE, connectTo.getDeserializeAs());
+  }
+
+  @Test
+  void setDeserializeAsWorksTest() {
+    setField(connectTo, "deserializeAs", null);
+
+    connectTo.setDeserializeAs(VALUE);
+    assertEquals(VALUE, getField(connectTo, "deserializeAs"));
+  }
+
+  @Test
+  void getNodeIdWorksTest() {
+    setField(connectTo, "nodeId", VALUE);
+
+    assertEquals(VALUE, connectTo.getNodeId());
+  }
+
+  @Test
+  void setNodeIdWorksTest() {
+    setField(connectTo, "nodeId", null);
+
+    connectTo.setNodeId(VALUE);
+    assertEquals(VALUE, getField(connectTo, "nodeId"));
+  }
+
+}

--- a/components/src/test/java/org/folio/rest/workflow/model/DatabaseConnectionTaskTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/DatabaseConnectionTaskTest.java
@@ -1,0 +1,213 @@
+package org.folio.rest.workflow.model;
+
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DatabaseConnectionTaskTest {
+
+  @Mock
+  private EmbeddedVariable embeddedVariable;
+
+  private Set<EmbeddedVariable> inputVariables;
+
+  private DatabaseConnectionTask databaseConnectionTask;
+
+  @BeforeEach
+  void beforeEach() {
+    databaseConnectionTask = new DatabaseConnectionTask();
+    inputVariables = new HashSet<>();
+    inputVariables.add(embeddedVariable);
+  }
+
+  @Test
+  void getIdWorksTest() {
+    setField(databaseConnectionTask, "id", VALUE);
+
+    assertEquals(VALUE, databaseConnectionTask.getId());
+  }
+
+  @Test
+  void setIdWorksTest() {
+    setField(databaseConnectionTask, "id", null);
+
+    databaseConnectionTask.setId(VALUE);
+    assertEquals(VALUE, getField(databaseConnectionTask, "id"));
+  }
+
+  @Test
+  void getNameWorksTest() {
+    setField(databaseConnectionTask, "name", VALUE);
+
+    assertEquals(VALUE, databaseConnectionTask.getName());
+  }
+
+  @Test
+  void setNameWorksTest() {
+    setField(databaseConnectionTask, "name", null);
+
+    databaseConnectionTask.setName(VALUE);
+    assertEquals(VALUE, getField(databaseConnectionTask, "name"));
+  }
+
+  @Test
+  void getDescriptionWorksTest() {
+    setField(databaseConnectionTask, "description", VALUE);
+
+    assertEquals(VALUE, databaseConnectionTask.getDescription());
+  }
+
+  @Test
+  void setDescriptionWorksTest() {
+    setField(databaseConnectionTask, "description", null);
+
+    databaseConnectionTask.setDescription(VALUE);
+    assertEquals(VALUE, getField(databaseConnectionTask, "description"));
+  }
+
+  @Test
+  void getDeserializeAsWorksTest() {
+    setField(databaseConnectionTask, "deserializeAs", VALUE);
+
+    assertEquals(VALUE, databaseConnectionTask.getDeserializeAs());
+  }
+
+  @Test
+  void setDeserializeAsWorksTest() {
+    setField(databaseConnectionTask, "deserializeAs", null);
+
+    databaseConnectionTask.setDeserializeAs(VALUE);
+    assertEquals(VALUE, getField(databaseConnectionTask, "deserializeAs"));
+  }
+
+  @Test
+  void getInputVariablesWorksTest() {
+    setField(databaseConnectionTask, "inputVariables", inputVariables);
+
+    assertEquals(inputVariables, databaseConnectionTask.getInputVariables());
+  }
+
+  @Test
+  void setInputVariablesWorksTest() {
+    setField(databaseConnectionTask, "inputVariables", null);
+
+    databaseConnectionTask.setInputVariables(inputVariables);
+    assertEquals(inputVariables, getField(databaseConnectionTask, "inputVariables"));
+  }
+
+  @Test
+  void getOutputVariableWorksTest() {
+    setField(databaseConnectionTask, "outputVariable", embeddedVariable);
+
+    assertEquals(embeddedVariable, databaseConnectionTask.getOutputVariable());
+  }
+
+  @Test
+  void setOutputVariableWorksTest() {
+    setField(databaseConnectionTask, "outputVariable", null);
+
+    databaseConnectionTask.setOutputVariable(embeddedVariable);
+    assertEquals(embeddedVariable, getField(databaseConnectionTask, "outputVariable"));
+  }
+
+  @Test
+  void getAsyncBeforeWorksTest() {
+    setField(databaseConnectionTask, "asyncBefore", true);
+
+    assertEquals(true, databaseConnectionTask.isAsyncBefore());
+  }
+
+  @Test
+  void setAsyncBeforeWorksTest() {
+    setField(databaseConnectionTask, "asyncBefore", false);
+
+    databaseConnectionTask.setAsyncBefore(true);
+    assertEquals(true, getField(databaseConnectionTask, "asyncBefore"));
+  }
+
+  @Test
+  void getAsyncAfterWorksTest() {
+    setField(databaseConnectionTask, "asyncAfter", true);
+
+    assertEquals(true, databaseConnectionTask.isAsyncAfter());
+  }
+
+  @Test
+  void setAsyncAfterWorksTest() {
+    setField(databaseConnectionTask, "asyncAfter", false);
+
+    databaseConnectionTask.setAsyncAfter(true);
+    assertEquals(true, getField(databaseConnectionTask, "asyncAfter"));
+  }
+
+  @Test
+  void getDesignationWorksTest() {
+    setField(databaseConnectionTask, "designation", VALUE);
+
+    assertEquals(VALUE, databaseConnectionTask.getDesignation());
+  }
+
+  @Test
+  void setDesignationWorksTest() {
+    setField(databaseConnectionTask, "designation", null);
+
+    databaseConnectionTask.setDesignation(VALUE);
+    assertEquals(VALUE, getField(databaseConnectionTask, "designation"));
+  }
+
+  @Test
+  void getUrlWorksTest() {
+    setField(databaseConnectionTask, "url", VALUE);
+
+    assertEquals(VALUE, databaseConnectionTask.getUrl());
+  }
+
+  @Test
+  void setUrlWorksTest() {
+    setField(databaseConnectionTask, "url", null);
+
+    databaseConnectionTask.setUrl(VALUE);
+    assertEquals(VALUE, getField(databaseConnectionTask, "url"));
+  }
+
+  @Test
+  void getUsernameWorksTest() {
+    setField(databaseConnectionTask, "username", VALUE);
+
+    assertEquals(VALUE, databaseConnectionTask.getUsername());
+  }
+
+  @Test
+  void setUsernameWorksTest() {
+    setField(databaseConnectionTask, "username", null);
+
+    databaseConnectionTask.setUsername(VALUE);
+    assertEquals(VALUE, getField(databaseConnectionTask, "username"));
+  }
+
+  @Test
+  void getPasswordWorksTest() {
+    setField(databaseConnectionTask, "password", VALUE);
+
+    assertEquals(VALUE, databaseConnectionTask.getPassword());
+  }
+
+  @Test
+  void setPasswordWorksTest() {
+    setField(databaseConnectionTask, "password", null);
+
+    databaseConnectionTask.setPassword(VALUE);
+    assertEquals(VALUE, getField(databaseConnectionTask, "password"));
+  }
+
+}

--- a/components/src/test/java/org/folio/rest/workflow/model/DatabaseDisconnectTaskTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/DatabaseDisconnectTaskTest.java
@@ -1,0 +1,168 @@
+package org.folio.rest.workflow.model;
+
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DatabaseDisconnectTaskTest {
+
+  @Mock
+  private EmbeddedVariable embeddedVariable;
+
+  private Set<EmbeddedVariable> inputVariables;
+
+  private DatabaseDisconnectTask databaseDisconnectTask;
+
+  @BeforeEach
+  void beforeEach() {
+    databaseDisconnectTask = new DatabaseDisconnectTask();
+    inputVariables = new HashSet<>();
+    inputVariables.add(embeddedVariable);
+  }
+
+  @Test
+  void getIdWorksTest() {
+    setField(databaseDisconnectTask, "id", VALUE);
+
+    assertEquals(VALUE, databaseDisconnectTask.getId());
+  }
+
+  @Test
+  void setIdWorksTest() {
+    setField(databaseDisconnectTask, "id", null);
+
+    databaseDisconnectTask.setId(VALUE);
+    assertEquals(VALUE, getField(databaseDisconnectTask, "id"));
+  }
+
+  @Test
+  void getNameWorksTest() {
+    setField(databaseDisconnectTask, "name", VALUE);
+
+    assertEquals(VALUE, databaseDisconnectTask.getName());
+  }
+
+  @Test
+  void setNameWorksTest() {
+    setField(databaseDisconnectTask, "name", null);
+
+    databaseDisconnectTask.setName(VALUE);
+    assertEquals(VALUE, getField(databaseDisconnectTask, "name"));
+  }
+
+  @Test
+  void getDescriptionWorksTest() {
+    setField(databaseDisconnectTask, "description", VALUE);
+
+    assertEquals(VALUE, databaseDisconnectTask.getDescription());
+  }
+
+  @Test
+  void setDescriptionWorksTest() {
+    setField(databaseDisconnectTask, "description", null);
+
+    databaseDisconnectTask.setDescription(VALUE);
+    assertEquals(VALUE, getField(databaseDisconnectTask, "description"));
+  }
+
+  @Test
+  void getDeserializeAsWorksTest() {
+    setField(databaseDisconnectTask, "deserializeAs", VALUE);
+
+    assertEquals(VALUE, databaseDisconnectTask.getDeserializeAs());
+  }
+
+  @Test
+  void setDeserializeAsWorksTest() {
+    setField(databaseDisconnectTask, "deserializeAs", null);
+
+    databaseDisconnectTask.setDeserializeAs(VALUE);
+    assertEquals(VALUE, getField(databaseDisconnectTask, "deserializeAs"));
+  }
+
+  @Test
+  void getInputVariablesWorksTest() {
+    setField(databaseDisconnectTask, "inputVariables", inputVariables);
+
+    assertEquals(inputVariables, databaseDisconnectTask.getInputVariables());
+  }
+
+  @Test
+  void setInputVariablesWorksTest() {
+    setField(databaseDisconnectTask, "inputVariables", null);
+
+    databaseDisconnectTask.setInputVariables(inputVariables);
+    assertEquals(inputVariables, getField(databaseDisconnectTask, "inputVariables"));
+  }
+
+  @Test
+  void getOutputVariableWorksTest() {
+    setField(databaseDisconnectTask, "outputVariable", embeddedVariable);
+
+    assertEquals(embeddedVariable, databaseDisconnectTask.getOutputVariable());
+  }
+
+  @Test
+  void setOutputVariableWorksTest() {
+    setField(databaseDisconnectTask, "outputVariable", null);
+
+    databaseDisconnectTask.setOutputVariable(embeddedVariable);
+    assertEquals(embeddedVariable, getField(databaseDisconnectTask, "outputVariable"));
+  }
+
+  @Test
+  void getAsyncBeforeWorksTest() {
+    setField(databaseDisconnectTask, "asyncBefore", true);
+
+    assertEquals(true, databaseDisconnectTask.isAsyncBefore());
+  }
+
+  @Test
+  void setAsyncBeforeWorksTest() {
+    setField(databaseDisconnectTask, "asyncBefore", false);
+
+    databaseDisconnectTask.setAsyncBefore(true);
+    assertEquals(true, getField(databaseDisconnectTask, "asyncBefore"));
+  }
+
+  @Test
+  void getAsyncAfterWorksTest() {
+    setField(databaseDisconnectTask, "asyncAfter", true);
+
+    assertEquals(true, databaseDisconnectTask.isAsyncAfter());
+  }
+
+  @Test
+  void setAsyncAfterWorksTest() {
+    setField(databaseDisconnectTask, "asyncAfter", false);
+
+    databaseDisconnectTask.setAsyncAfter(true);
+    assertEquals(true, getField(databaseDisconnectTask, "asyncAfter"));
+  }
+
+  @Test
+  void getDesignationWorksTest() {
+    setField(databaseDisconnectTask, "designation", VALUE);
+
+    assertEquals(VALUE, databaseDisconnectTask.getDesignation());
+  }
+
+  @Test
+  void setDesignationWorksTest() {
+    setField(databaseDisconnectTask, "designation", null);
+
+    databaseDisconnectTask.setDesignation(VALUE);
+    assertEquals(VALUE, getField(databaseDisconnectTask, "designation"));
+  }
+
+}

--- a/components/src/test/java/org/folio/rest/workflow/model/DatabaseQueryTaskTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/DatabaseQueryTaskTest.java
@@ -1,0 +1,229 @@
+package org.folio.rest.workflow.model;
+
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.folio.rest.workflow.enums.DatabaseResultType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DatabaseQueryTaskTest {
+
+  @Mock
+  private EmbeddedVariable embeddedVariable;
+
+  private Set<EmbeddedVariable> inputVariables;
+
+  private DatabaseQueryTask databaseQueryTask;
+
+  @BeforeEach
+  void beforeEach() {
+    databaseQueryTask = new DatabaseQueryTask();
+    inputVariables = new HashSet<>();
+    inputVariables.add(embeddedVariable);
+  }
+
+  @Test
+  void getIdWorksTest() {
+    setField(databaseQueryTask, "id", VALUE);
+
+    assertEquals(VALUE, databaseQueryTask.getId());
+  }
+
+  @Test
+  void setIdWorksTest() {
+    setField(databaseQueryTask, "id", null);
+
+    databaseQueryTask.setId(VALUE);
+    assertEquals(VALUE, getField(databaseQueryTask, "id"));
+  }
+
+  @Test
+  void getNameWorksTest() {
+    setField(databaseQueryTask, "name", VALUE);
+
+    assertEquals(VALUE, databaseQueryTask.getName());
+  }
+
+  @Test
+  void setNameWorksTest() {
+    setField(databaseQueryTask, "name", null);
+
+    databaseQueryTask.setName(VALUE);
+    assertEquals(VALUE, getField(databaseQueryTask, "name"));
+  }
+
+  @Test
+  void getDescriptionWorksTest() {
+    setField(databaseQueryTask, "description", VALUE);
+
+    assertEquals(VALUE, databaseQueryTask.getDescription());
+  }
+
+  @Test
+  void setDescriptionWorksTest() {
+    setField(databaseQueryTask, "description", null);
+
+    databaseQueryTask.setDescription(VALUE);
+    assertEquals(VALUE, getField(databaseQueryTask, "description"));
+  }
+
+  @Test
+  void getDeserializeAsWorksTest() {
+    setField(databaseQueryTask, "deserializeAs", VALUE);
+
+    assertEquals(VALUE, databaseQueryTask.getDeserializeAs());
+  }
+
+  @Test
+  void setDeserializeAsWorksTest() {
+    setField(databaseQueryTask, "deserializeAs", null);
+
+    databaseQueryTask.setDeserializeAs(VALUE);
+    assertEquals(VALUE, getField(databaseQueryTask, "deserializeAs"));
+  }
+
+  @Test
+  void getInputVariablesWorksTest() {
+    setField(databaseQueryTask, "inputVariables", inputVariables);
+
+    assertEquals(inputVariables, databaseQueryTask.getInputVariables());
+  }
+
+  @Test
+  void setInputVariablesWorksTest() {
+    setField(databaseQueryTask, "inputVariables", null);
+
+    databaseQueryTask.setInputVariables(inputVariables);
+    assertEquals(inputVariables, getField(databaseQueryTask, "inputVariables"));
+  }
+
+  @Test
+  void getOutputVariableWorksTest() {
+    setField(databaseQueryTask, "outputVariable", embeddedVariable);
+
+    assertEquals(embeddedVariable, databaseQueryTask.getOutputVariable());
+  }
+
+  @Test
+  void setOutputVariableWorksTest() {
+    setField(databaseQueryTask, "outputVariable", null);
+
+    databaseQueryTask.setOutputVariable(embeddedVariable);
+    assertEquals(embeddedVariable, getField(databaseQueryTask, "outputVariable"));
+  }
+
+  @Test
+  void getAsyncBeforeWorksTest() {
+    setField(databaseQueryTask, "asyncBefore", true);
+
+    assertEquals(true, databaseQueryTask.isAsyncBefore());
+  }
+
+  @Test
+  void setAsyncBeforeWorksTest() {
+    setField(databaseQueryTask, "asyncBefore", false);
+
+    databaseQueryTask.setAsyncBefore(true);
+    assertEquals(true, getField(databaseQueryTask, "asyncBefore"));
+  }
+
+  @Test
+  void getAsyncAfterWorksTest() {
+    setField(databaseQueryTask, "asyncAfter", true);
+
+    assertEquals(true, databaseQueryTask.isAsyncAfter());
+  }
+
+  @Test
+  void setAsyncAfterWorksTest() {
+    setField(databaseQueryTask, "asyncAfter", false);
+
+    databaseQueryTask.setAsyncAfter(true);
+    assertEquals(true, getField(databaseQueryTask, "asyncAfter"));
+  }
+
+  @Test
+  void getDesignationWorksTest() {
+    setField(databaseQueryTask, "designation", VALUE);
+
+    assertEquals(VALUE, databaseQueryTask.getDesignation());
+  }
+
+  @Test
+  void setDesignationWorksTest() {
+    setField(databaseQueryTask, "designation", null);
+
+    databaseQueryTask.setDesignation(VALUE);
+    assertEquals(VALUE, getField(databaseQueryTask, "designation"));
+  }
+
+  @Test
+  void getOutputPathWorksTest() {
+    setField(databaseQueryTask, "outputPath", VALUE);
+
+    assertEquals(VALUE, databaseQueryTask.getOutputPath());
+  }
+
+  @Test
+  void setOutputPathWorksTest() {
+    setField(databaseQueryTask, "outputPath", null);
+
+    databaseQueryTask.setOutputPath(VALUE);
+    assertEquals(VALUE, getField(databaseQueryTask, "outputPath"));
+  }
+
+  @Test
+  void getQueryWorksTest() {
+    setField(databaseQueryTask, "query", VALUE);
+
+    assertEquals(VALUE, databaseQueryTask.getQuery());
+  }
+
+  @Test
+  void setQueryWorksTest() {
+    setField(databaseQueryTask, "query", null);
+
+    databaseQueryTask.setQuery(VALUE);
+    assertEquals(VALUE, getField(databaseQueryTask, "query"));
+  }
+
+  @Test
+  void getResultTypeWorksTest() {
+    setField(databaseQueryTask, "resultType", DatabaseResultType.CSV);
+
+    assertEquals(DatabaseResultType.CSV, databaseQueryTask.getResultType());
+  }
+
+  @Test
+  void setResultTypeWorksTest() {
+    setField(databaseQueryTask, "resultType", null);
+
+    databaseQueryTask.setResultType(DatabaseResultType.CSV);
+    assertEquals(DatabaseResultType.CSV, getField(databaseQueryTask, "resultType"));
+  }
+
+  @Test
+  void getIncludeHeaderWorksTest() {
+    setField(databaseQueryTask, "includeHeader", true);
+
+    assertEquals(true, databaseQueryTask.getIncludeHeader());
+  }
+
+  @Test
+  void setIncludeHeaderWorksTest() {
+    setField(databaseQueryTask, "includeHeader", null);
+
+    databaseQueryTask.setIncludeHeader(true);
+    assertEquals(true, getField(databaseQueryTask, "includeHeader"));
+  }
+
+}

--- a/components/src/test/java/org/folio/rest/workflow/model/EmailTaskTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/EmailTaskTest.java
@@ -1,0 +1,288 @@
+package org.folio.rest.workflow.model;
+
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EmailTaskTest {
+
+  @Mock
+  private EmbeddedVariable embeddedVariable;
+
+  private Set<EmbeddedVariable> inputVariables;
+
+  private EmailTask emailTask;
+
+  @BeforeEach
+  void beforeEach() {
+    emailTask = new EmailTask();
+    inputVariables = new HashSet<>();
+    inputVariables.add(embeddedVariable);
+  }
+
+  @Test
+  void getIdWorksTest() {
+    setField(emailTask, "id", VALUE);
+
+    assertEquals(VALUE, emailTask.getId());
+  }
+
+  @Test
+  void setIdWorksTest() {
+    setField(emailTask, "id", null);
+
+    emailTask.setId(VALUE);
+    assertEquals(VALUE, getField(emailTask, "id"));
+  }
+
+  @Test
+  void getNameWorksTest() {
+    setField(emailTask, "name", VALUE);
+
+    assertEquals(VALUE, emailTask.getName());
+  }
+
+  @Test
+  void setNameWorksTest() {
+    setField(emailTask, "name", null);
+
+    emailTask.setName(VALUE);
+    assertEquals(VALUE, getField(emailTask, "name"));
+  }
+
+  @Test
+  void getDescriptionWorksTest() {
+    setField(emailTask, "description", VALUE);
+
+    assertEquals(VALUE, emailTask.getDescription());
+  }
+
+  @Test
+  void setDescriptionWorksTest() {
+    setField(emailTask, "description", null);
+
+    emailTask.setDescription(VALUE);
+    assertEquals(VALUE, getField(emailTask, "description"));
+  }
+
+  @Test
+  void getDeserializeAsWorksTest() {
+    setField(emailTask, "deserializeAs", VALUE);
+
+    assertEquals(VALUE, emailTask.getDeserializeAs());
+  }
+
+  @Test
+  void setDeserializeAsWorksTest() {
+    setField(emailTask, "deserializeAs", null);
+
+    emailTask.setDeserializeAs(VALUE);
+    assertEquals(VALUE, getField(emailTask, "deserializeAs"));
+  }
+
+  @Test
+  void getInputVariablesWorksTest() {
+    setField(emailTask, "inputVariables", inputVariables);
+
+    assertEquals(inputVariables, emailTask.getInputVariables());
+  }
+
+  @Test
+  void setInputVariablesWorksTest() {
+    setField(emailTask, "inputVariables", null);
+
+    emailTask.setInputVariables(inputVariables);
+    assertEquals(inputVariables, getField(emailTask, "inputVariables"));
+  }
+
+  @Test
+  void getOutputVariableWorksTest() {
+    setField(emailTask, "outputVariable", embeddedVariable);
+
+    assertEquals(embeddedVariable, emailTask.getOutputVariable());
+  }
+
+  @Test
+  void setOutputVariableWorksTest() {
+    setField(emailTask, "outputVariable", null);
+
+    emailTask.setOutputVariable(embeddedVariable);
+    assertEquals(embeddedVariable, getField(emailTask, "outputVariable"));
+  }
+
+  @Test
+  void getAsyncBeforeWorksTest() {
+    setField(emailTask, "asyncBefore", true);
+
+    assertEquals(true, emailTask.isAsyncBefore());
+  }
+
+  @Test
+  void setAsyncBeforeWorksTest() {
+    setField(emailTask, "asyncBefore", false);
+
+    emailTask.setAsyncBefore(true);
+    assertEquals(true, getField(emailTask, "asyncBefore"));
+  }
+
+  @Test
+  void getAsyncAfterWorksTest() {
+    setField(emailTask, "asyncAfter", true);
+
+    assertEquals(true, emailTask.isAsyncAfter());
+  }
+
+  @Test
+  void setAsyncAfterWorksTest() {
+    setField(emailTask, "asyncAfter", false);
+
+    emailTask.setAsyncAfter(true);
+    assertEquals(true, getField(emailTask, "asyncAfter"));
+  }
+
+  @Test
+  void getMailToWorksTest() {
+    setField(emailTask, "mailTo", VALUE);
+
+    assertEquals(VALUE, emailTask.getMailTo());
+  }
+
+  @Test
+  void setMailToWorksTest() {
+    setField(emailTask, "mailTo", null);
+
+    emailTask.setMailTo(VALUE);
+    assertEquals(VALUE, getField(emailTask, "mailTo"));
+  }
+
+  @Test
+  void getMailCcWorksTest() {
+    setField(emailTask, "mailCc", VALUE);
+
+    assertEquals(VALUE, emailTask.getMailCc());
+  }
+
+  @Test
+  void setMailCcWorksTest() {
+    setField(emailTask, "mailCc", null);
+
+    emailTask.setMailCc(VALUE);
+    assertEquals(VALUE, getField(emailTask, "mailCc"));
+  }
+
+  @Test
+  void getMailBccWorksTest() {
+    setField(emailTask, "mailBcc", VALUE);
+
+    assertEquals(VALUE, emailTask.getMailBcc());
+  }
+
+  @Test
+  void setMailBccWorksTest() {
+    setField(emailTask, "mailBcc", null);
+
+    emailTask.setMailBcc(VALUE);
+    assertEquals(VALUE, getField(emailTask, "mailBcc"));
+  }
+
+  @Test
+  void getMailFromWorksTest() {
+    setField(emailTask, "mailFrom", VALUE);
+
+    assertEquals(VALUE, emailTask.getMailFrom());
+  }
+
+  @Test
+  void setMailFromWorksTest() {
+    setField(emailTask, "mailFrom", null);
+
+    emailTask.setMailFrom(VALUE);
+    assertEquals(VALUE, getField(emailTask, "mailFrom"));
+  }
+
+  @Test
+  void getMailSubjectWorksTest() {
+    setField(emailTask, "mailSubject", VALUE);
+
+    assertEquals(VALUE, emailTask.getMailSubject());
+  }
+
+  @Test
+  void setMailSubjectWorksTest() {
+    setField(emailTask, "mailSubject", null);
+
+    emailTask.setMailSubject(VALUE);
+    assertEquals(VALUE, getField(emailTask, "mailSubject"));
+  }
+
+  @Test
+  void getMailTextWorksTest() {
+    setField(emailTask, "mailText", VALUE);
+
+    assertEquals(VALUE, emailTask.getMailText());
+  }
+
+  @Test
+  void setMailTextWorksTest() {
+    setField(emailTask, "mailText", null);
+
+    emailTask.setMailText(VALUE);
+    assertEquals(VALUE, getField(emailTask, "mailText"));
+  }
+
+  @Test
+  void getMailMarkupWorksTest() {
+    setField(emailTask, "mailMarkup", VALUE);
+
+    assertEquals(VALUE, emailTask.getMailMarkup());
+  }
+
+  @Test
+  void setMailMarkupWorksTest() {
+    setField(emailTask, "mailMarkup", null);
+
+    emailTask.setMailMarkup(VALUE);
+    assertEquals(VALUE, getField(emailTask, "mailMarkup"));
+  }
+
+  @Test
+  void getAttachmentPathWorksTest() {
+    setField(emailTask, "attachmentPath", VALUE);
+
+    assertEquals(VALUE, emailTask.getAttachmentPath());
+  }
+
+  @Test
+  void setAttachmentPathWorksTest() {
+    setField(emailTask, "attachmentPath", null);
+
+    emailTask.setAttachmentPath(VALUE);
+    assertEquals(VALUE, getField(emailTask, "attachmentPath"));
+  }
+
+  @Test
+  void getIncludeAttachmentWorksTest() {
+    setField(emailTask, "includeAttachment", VALUE);
+
+    assertEquals(VALUE, emailTask.getIncludeAttachment());
+  }
+
+  @Test
+  void setIncludeAttachmentWorksTest() {
+    setField(emailTask, "includeAttachment", null);
+
+    emailTask.setIncludeAttachment(VALUE);
+    assertEquals(VALUE, getField(emailTask, "includeAttachment"));
+  }
+
+}

--- a/components/src/test/java/org/folio/rest/workflow/model/EmbeddedLoopReferenceTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/EmbeddedLoopReferenceTest.java
@@ -1,0 +1,95 @@
+package org.folio.rest.workflow.model;
+
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class EmbeddedLoopReferenceTest {
+
+  private EmbeddedLoopReference embeddedLoopReference;
+
+  @BeforeEach
+  void beforeEach() {
+    embeddedLoopReference = new EmbeddedLoopReference();
+  }
+
+  @Test
+  void getCardinalityExpressionWorksTest() {
+    setField(embeddedLoopReference, "cardinalityExpression", VALUE);
+
+    assertEquals(VALUE, embeddedLoopReference.getCardinalityExpression());
+  }
+
+  @Test
+  void setCardinalityExpressionWorksTest() {
+    setField(embeddedLoopReference, "cardinalityExpression", null);
+
+    embeddedLoopReference.setCardinalityExpression(VALUE);
+    assertEquals(VALUE, getField(embeddedLoopReference, "cardinalityExpression"));
+  }
+
+  @Test
+  void getDataInputRefExpressionWorksTest() {
+    setField(embeddedLoopReference, "dataInputRefExpression", VALUE);
+
+    assertEquals(VALUE, embeddedLoopReference.getDataInputRefExpression());
+  }
+
+  @Test
+  void setDataInputRefExpressionWorksTest() {
+    setField(embeddedLoopReference, "dataInputRefExpression", null);
+
+    embeddedLoopReference.setDataInputRefExpression(VALUE);
+    assertEquals(VALUE, getField(embeddedLoopReference, "dataInputRefExpression"));
+  }
+
+  @Test
+  void getInputDataNameWorksTest() {
+    setField(embeddedLoopReference, "inputDataName", VALUE);
+
+    assertEquals(VALUE, embeddedLoopReference.getInputDataName());
+  }
+
+  @Test
+  void setInputDataNameWorksTest() {
+    setField(embeddedLoopReference, "inputDataName", null);
+
+    embeddedLoopReference.setInputDataName(VALUE);
+    assertEquals(VALUE, getField(embeddedLoopReference, "inputDataName"));
+  }
+
+  @Test
+  void getCompleteConditionExpressionWorksTest() {
+    setField(embeddedLoopReference, "completeConditionExpression", VALUE);
+
+    assertEquals(VALUE, embeddedLoopReference.getCompleteConditionExpression());
+  }
+
+  @Test
+  void setCompleteConditionExpressionWorksTest() {
+    setField(embeddedLoopReference, "completeConditionExpression", null);
+
+    embeddedLoopReference.setCompleteConditionExpression(VALUE);
+    assertEquals(VALUE, getField(embeddedLoopReference, "completeConditionExpression"));
+  }
+
+  @Test
+  void getParallelWorksTest() {
+    setField(embeddedLoopReference, "parallel", true);
+
+    assertEquals(true, embeddedLoopReference.isParallel());
+  }
+
+  @Test
+  void setParallelWorksTest() {
+    setField(embeddedLoopReference, "parallel", false);
+
+    embeddedLoopReference.setParallel(true);
+    assertEquals(true, getField(embeddedLoopReference, "parallel"));
+  }
+
+}

--- a/components/src/test/java/org/folio/rest/workflow/model/EmbeddedProcessorTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/EmbeddedProcessorTest.java
@@ -1,0 +1,96 @@
+package org.folio.rest.workflow.model;
+
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import org.folio.rest.workflow.enums.ScriptType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class EmbeddedProcessorTest {
+
+  private EmbeddedProcessor embeddedProcessor;
+
+  @BeforeEach
+  void beforeEach() {
+    embeddedProcessor = new EmbeddedProcessor();
+  }
+
+  @Test
+  void getScriptTypeWorksTest() {
+    setField(embeddedProcessor, "scriptType", ScriptType.GROOVY);
+
+    assertEquals(ScriptType.GROOVY, embeddedProcessor.getScriptType());
+  }
+
+  @Test
+  void setScriptTypeWorksTest() {
+    setField(embeddedProcessor, "scriptType", null);
+
+    embeddedProcessor.setScriptType(ScriptType.GROOVY);
+    assertEquals(ScriptType.GROOVY, getField(embeddedProcessor, "scriptType"));
+  }
+
+  @Test
+  void getFunctionNameWorksTest() {
+    setField(embeddedProcessor, "functionName", VALUE);
+
+    assertEquals(VALUE, embeddedProcessor.getFunctionName());
+  }
+
+  @Test
+  void setFunctionNameWorksTest() {
+    setField(embeddedProcessor, "functionName", null);
+
+    embeddedProcessor.setFunctionName(VALUE);
+    assertEquals(VALUE, getField(embeddedProcessor, "functionName"));
+  }
+
+  @Test
+  void getCodeWorksTest() {
+    setField(embeddedProcessor, "code", VALUE);
+
+    assertEquals(VALUE, embeddedProcessor.getCode());
+  }
+
+  @Test
+  void setCodeWorksTest() {
+    setField(embeddedProcessor, "code", null);
+
+    embeddedProcessor.setCode(VALUE);
+    assertEquals(VALUE, getField(embeddedProcessor, "code"));
+  }
+
+  @Test
+  void getBufferWorksTest() {
+    setField(embeddedProcessor, "buffer", 1);
+
+    assertEquals(1, embeddedProcessor.getBuffer());
+  }
+
+  @Test
+  void setBufferWorksTest() {
+    setField(embeddedProcessor, "buffer", 0);
+
+    embeddedProcessor.setBuffer(1);
+    assertEquals(1, getField(embeddedProcessor, "buffer"));
+  }
+
+  @Test
+  void getDelayWorksTest() {
+    setField(embeddedProcessor, "delay", 1);
+
+    assertEquals(1, embeddedProcessor.getDelay());
+  }
+
+  @Test
+  void setDelayWorksTest() {
+    setField(embeddedProcessor, "delay", 0);
+
+    embeddedProcessor.setDelay(1);
+    assertEquals(1, getField(embeddedProcessor, "delay"));
+  }
+
+}

--- a/components/src/test/java/org/folio/rest/workflow/model/EmbeddedRequestTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/EmbeddedRequestTest.java
@@ -1,0 +1,126 @@
+package org.folio.rest.workflow.model;
+
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import org.folio.rest.workflow.enums.HttpMethod;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class EmbeddedRequestTest {
+
+  private EmbeddedRequest embeddedRequest;
+
+  @BeforeEach
+  void beforeEach() {
+    embeddedRequest = new EmbeddedRequest();
+  }
+
+  @Test
+  void getUrlWorksTest() {
+    setField(embeddedRequest, "url", VALUE);
+
+    assertEquals(VALUE, embeddedRequest.getUrl());
+  }
+
+  @Test
+  void setUrlWorksTest() {
+    setField(embeddedRequest, "url", null);
+
+    embeddedRequest.setUrl(VALUE);
+    assertEquals(VALUE, getField(embeddedRequest, "url"));
+  }
+
+  @Test
+  void getMethodWorksTest() {
+    setField(embeddedRequest, "method", HttpMethod.DELETE);
+
+    assertEquals(HttpMethod.DELETE, embeddedRequest.getMethod());
+  }
+
+  @Test
+  void setMethodWorksTest() {
+    setField(embeddedRequest, "method", null);
+
+    embeddedRequest.setMethod(HttpMethod.DELETE);
+    assertEquals(HttpMethod.DELETE, getField(embeddedRequest, "method"));
+  }
+
+  @Test
+  void getContentTypeWorksTest() {
+    setField(embeddedRequest, "contentType", VALUE);
+
+    assertEquals(VALUE, embeddedRequest.getContentType());
+  }
+
+  @Test
+  void setContentTypeWorksTest() {
+    setField(embeddedRequest, "contentType", null);
+
+    embeddedRequest.setContentType(VALUE);
+    assertEquals(VALUE, getField(embeddedRequest, "contentType"));
+  }
+
+  @Test
+  void getAcceptWorksTest() {
+    setField(embeddedRequest, "accept", VALUE);
+
+    assertEquals(VALUE, embeddedRequest.getAccept());
+  }
+
+  @Test
+  void setAcceptWorksTest() {
+    setField(embeddedRequest, "accept", null);
+
+    embeddedRequest.setAccept(VALUE);
+    assertEquals(VALUE, getField(embeddedRequest, "accept"));
+  }
+
+  @Test
+  void getBodyTemplateWorksTest() {
+    setField(embeddedRequest, "bodyTemplate", VALUE);
+
+    assertEquals(VALUE, embeddedRequest.getBodyTemplate());
+  }
+
+  @Test
+  void setBodyTemplateWorksTest() {
+    setField(embeddedRequest, "bodyTemplate", null);
+
+    embeddedRequest.setBodyTemplate(VALUE);
+    assertEquals(VALUE, getField(embeddedRequest, "bodyTemplate"));
+  }
+
+  @Test
+  void getIterableWorksTest() {
+    setField(embeddedRequest, "iterable", true);
+
+    assertEquals(true, embeddedRequest.isIterable());
+  }
+
+  @Test
+  void setIterableWorksTest() {
+    setField(embeddedRequest, "iterable", false);
+
+    embeddedRequest.setIterable(true);
+    assertEquals(true, getField(embeddedRequest, "iterable"));
+  }
+
+  @Test
+  void getResponseKeyWorksTest() {
+    setField(embeddedRequest, "responseKey", VALUE);
+
+    assertEquals(VALUE, embeddedRequest.getResponseKey());
+  }
+
+  @Test
+  void setResponseKeyWorksTest() {
+    setField(embeddedRequest, "responseKey", null);
+
+    embeddedRequest.setResponseKey(VALUE);
+    assertEquals(VALUE, getField(embeddedRequest, "responseKey"));
+  }
+
+}

--- a/components/src/test/java/org/folio/rest/workflow/model/EmbeddedVariableTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/EmbeddedVariableTest.java
@@ -1,0 +1,96 @@
+package org.folio.rest.workflow.model;
+
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import org.folio.rest.workflow.enums.VariableType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class EmbeddedVariableTest {
+
+  private EmbeddedVariable embeddedVariable;
+
+  @BeforeEach
+  void beforeEach() {
+    embeddedVariable = new EmbeddedVariable();
+  }
+
+  @Test
+  void getKeyWorksTest() {
+    setField(embeddedVariable, "key", VALUE);
+
+    assertEquals(VALUE, embeddedVariable.getKey());
+  }
+
+  @Test
+  void setKeyWorksTest() {
+    setField(embeddedVariable, "key", null);
+
+    embeddedVariable.setKey(VALUE);
+    assertEquals(VALUE, getField(embeddedVariable, "key"));
+  }
+
+  @Test
+  void getTypeWorksTest() {
+    setField(embeddedVariable, "type", VariableType.PROCESS);
+
+    assertEquals(VariableType.PROCESS, embeddedVariable.getType());
+  }
+
+  @Test
+  void setTypeWorksTest() {
+    setField(embeddedVariable, "type", null);
+
+    embeddedVariable.setType(VariableType.PROCESS);
+    assertEquals(VariableType.PROCESS, getField(embeddedVariable, "type"));
+  }
+
+  @Test
+  void getSpinWorksTest() {
+    setField(embeddedVariable, "spin", true);
+
+    assertEquals(true, embeddedVariable.isSpin());
+  }
+
+  @Test
+  void setSpinWorksTest() {
+    setField(embeddedVariable, "spin", false);
+
+    embeddedVariable.setSpin(true);
+    assertEquals(true, getField(embeddedVariable, "spin"));
+  }
+
+  @Test
+  void getAsJsonWorksTest() {
+    setField(embeddedVariable, "asJson", true);
+
+    assertEquals(true, embeddedVariable.getAsJson());
+  }
+
+  @Test
+  void setAsJsonWorksTest() {
+    setField(embeddedVariable, "asJson", null);
+
+    embeddedVariable.setAsJson(true);
+    assertEquals(true, getField(embeddedVariable, "asJson"));
+  }
+
+  @Test
+  void getAsTransientWorksTest() {
+    setField(embeddedVariable, "asTransient", true);
+
+    assertEquals(true, embeddedVariable.getAsTransient());
+  }
+
+  @Test
+  void setAsTransientWorksTest() {
+    setField(embeddedVariable, "asTransient", null);
+
+    embeddedVariable.setAsTransient(true);
+    assertEquals(true, getField(embeddedVariable, "asTransient"));
+  }
+
+}

--- a/components/src/test/java/org/folio/rest/workflow/model/EndEventTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/EndEventTest.java
@@ -1,0 +1,82 @@
+package org.folio.rest.workflow.model;
+
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class EndEventTest {
+
+  private EndEvent endEvent;
+
+  @BeforeEach
+  void beforeEach() {
+    endEvent = new Impl();
+  }
+
+  @Test
+  void getIdWorksTest() {
+    setField(endEvent, "id", VALUE);
+
+    assertEquals(VALUE, endEvent.getId());
+  }
+
+  @Test
+  void setIdWorksTest() {
+    setField(endEvent, "id", null);
+
+    endEvent.setId(VALUE);
+    assertEquals(VALUE, getField(endEvent, "id"));
+  }
+
+  @Test
+  void getNameWorksTest() {
+    setField(endEvent, "name", VALUE);
+
+    assertEquals(VALUE, endEvent.getName());
+  }
+
+  @Test
+  void setNameWorksTest() {
+    setField(endEvent, "name", null);
+
+    endEvent.setName(VALUE);
+    assertEquals(VALUE, getField(endEvent, "name"));
+  }
+
+  @Test
+  void getDescriptionWorksTest() {
+    setField(endEvent, "description", VALUE);
+
+    assertEquals(VALUE, endEvent.getDescription());
+  }
+
+  @Test
+  void setDescriptionWorksTest() {
+    setField(endEvent, "description", null);
+
+    endEvent.setDescription(VALUE);
+    assertEquals(VALUE, getField(endEvent, "description"));
+  }
+
+  @Test
+  void getDeserializeAsWorksTest() {
+    setField(endEvent, "deserializeAs", VALUE);
+
+    assertEquals(VALUE, endEvent.getDeserializeAs());
+  }
+
+  @Test
+  void setDeserializeAsWorksTest() {
+    setField(endEvent, "deserializeAs", null);
+
+    endEvent.setDeserializeAs(VALUE);
+    assertEquals(VALUE, getField(endEvent, "deserializeAs"));
+  }
+
+  private static class Impl extends EndEvent { };
+
+}

--- a/components/src/test/java/org/folio/rest/workflow/model/EventSubprocessTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/EventSubprocessTest.java
@@ -1,0 +1,138 @@
+package org.folio.rest.workflow.model;
+
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EventSubprocessTest {
+
+  @Mock
+  private Node node;
+
+  private List<Node> nodes;
+
+  private EventSubprocess eventSubprocess;
+
+  @BeforeEach
+  void beforeEach() {
+    eventSubprocess = new EventSubprocess();
+    nodes = new ArrayList<>();
+    nodes.add(node);
+  }
+
+  @Test
+  void getIdWorksTest() {
+    setField(eventSubprocess, "id", VALUE);
+
+    assertEquals(VALUE, eventSubprocess.getId());
+  }
+
+  @Test
+  void setIdWorksTest() {
+    setField(eventSubprocess, "id", null);
+
+    eventSubprocess.setId(VALUE);
+    assertEquals(VALUE, getField(eventSubprocess, "id"));
+  }
+
+  @Test
+  void getNameWorksTest() {
+    setField(eventSubprocess, "name", VALUE);
+
+    assertEquals(VALUE, eventSubprocess.getName());
+  }
+
+  @Test
+  void setNameWorksTest() {
+    setField(eventSubprocess, "name", null);
+
+    eventSubprocess.setName(VALUE);
+    assertEquals(VALUE, getField(eventSubprocess, "name"));
+  }
+
+  @Test
+  void getDescriptionWorksTest() {
+    setField(eventSubprocess, "description", VALUE);
+
+    assertEquals(VALUE, eventSubprocess.getDescription());
+  }
+
+  @Test
+  void setDescriptionWorksTest() {
+    setField(eventSubprocess, "description", null);
+
+    eventSubprocess.setDescription(VALUE);
+    assertEquals(VALUE, getField(eventSubprocess, "description"));
+  }
+
+  @Test
+  void getDeserializeAsWorksTest() {
+    setField(eventSubprocess, "deserializeAs", VALUE);
+
+    assertEquals(VALUE, eventSubprocess.getDeserializeAs());
+  }
+
+  @Test
+  void setDeserializeAsWorksTest() {
+    setField(eventSubprocess, "deserializeAs", null);
+
+    eventSubprocess.setDeserializeAs(VALUE);
+    assertEquals(VALUE, getField(eventSubprocess, "deserializeAs"));
+  }
+
+  @Test
+  void getAsyncBeforeWorksTest() {
+    setField(eventSubprocess, "asyncBefore", true);
+
+    assertEquals(true, eventSubprocess.isAsyncBefore());
+  }
+
+  @Test
+  void setAsyncBeforeWorksTest() {
+    setField(eventSubprocess, "asyncBefore", false);
+
+    eventSubprocess.setAsyncBefore(true);
+    assertEquals(true, getField(eventSubprocess, "asyncBefore"));
+  }
+
+  @Test
+  void getAsyncAfterWorksTest() {
+    setField(eventSubprocess, "asyncAfter", true);
+
+    assertEquals(true, eventSubprocess.isAsyncAfter());
+  }
+
+  @Test
+  void setAsyncAfterWorksTest() {
+    setField(eventSubprocess, "asyncAfter", false);
+
+    eventSubprocess.setAsyncAfter(true);
+    assertEquals(true, getField(eventSubprocess, "asyncAfter"));
+  }
+
+  @Test
+  void getNodesWorksTest() {
+    setField(eventSubprocess, "nodes", nodes);
+
+    assertEquals(nodes, eventSubprocess.getNodes());
+  }
+
+  @Test
+  void setNodesWorksTest() {
+    setField(eventSubprocess, "nodes", null);
+
+    eventSubprocess.setNodes(nodes);
+    assertEquals(nodes, getField(eventSubprocess, "nodes"));
+  }
+
+}

--- a/components/src/test/java/org/folio/rest/workflow/model/ExclusiveGatewayTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/ExclusiveGatewayTest.java
@@ -1,0 +1,124 @@
+package org.folio.rest.workflow.model;
+
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.folio.rest.workflow.enums.Direction;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ExclusiveGatewayTest {
+
+  @Mock
+  private Node node;
+
+  private List<Node> nodes;
+
+  private ExclusiveGateway exclusiveGateway;
+
+  @BeforeEach
+  void beforeEach() {
+    exclusiveGateway = new ExclusiveGateway();
+    nodes = new ArrayList<>();
+    nodes.add(node);
+  }
+
+  @Test
+  void getIdWorksTest() {
+    setField(exclusiveGateway, "id", VALUE);
+
+    assertEquals(VALUE, exclusiveGateway.getId());
+  }
+
+  @Test
+  void setIdWorksTest() {
+    setField(exclusiveGateway, "id", null);
+
+    exclusiveGateway.setId(VALUE);
+    assertEquals(VALUE, getField(exclusiveGateway, "id"));
+  }
+
+  @Test
+  void getNameWorksTest() {
+    setField(exclusiveGateway, "name", VALUE);
+
+    assertEquals(VALUE, exclusiveGateway.getName());
+  }
+
+  @Test
+  void setNameWorksTest() {
+    setField(exclusiveGateway, "name", null);
+
+    exclusiveGateway.setName(VALUE);
+    assertEquals(VALUE, getField(exclusiveGateway, "name"));
+  }
+
+  @Test
+  void getDescriptionWorksTest() {
+    setField(exclusiveGateway, "description", VALUE);
+
+    assertEquals(VALUE, exclusiveGateway.getDescription());
+  }
+
+  @Test
+  void setDescriptionWorksTest() {
+    setField(exclusiveGateway, "description", null);
+
+    exclusiveGateway.setDescription(VALUE);
+    assertEquals(VALUE, getField(exclusiveGateway, "description"));
+  }
+
+  @Test
+  void getDeserializeAsWorksTest() {
+    setField(exclusiveGateway, "deserializeAs", VALUE);
+
+    assertEquals(VALUE, exclusiveGateway.getDeserializeAs());
+  }
+
+  @Test
+  void setDeserializeAsWorksTest() {
+    setField(exclusiveGateway, "deserializeAs", null);
+
+    exclusiveGateway.setDeserializeAs(VALUE);
+    assertEquals(VALUE, getField(exclusiveGateway, "deserializeAs"));
+  }
+
+  @Test
+  void getDirectionWorksTest() {
+    setField(exclusiveGateway, "direction", Direction.CONVERGING);
+
+    assertEquals(Direction.CONVERGING, exclusiveGateway.getDirection());
+  }
+
+  @Test
+  void setDirectionWorksTest() {
+    setField(exclusiveGateway, "direction", null);
+
+    exclusiveGateway.setDirection(Direction.CONVERGING);
+    assertEquals(Direction.CONVERGING, getField(exclusiveGateway, "direction"));
+  }
+
+  @Test
+  void getNodesWorksTest() {
+    setField(exclusiveGateway, "nodes", nodes);
+
+    assertEquals(nodes, exclusiveGateway.getNodes());
+  }
+
+  @Test
+  void setNodesWorksTest() {
+    setField(exclusiveGateway, "nodes", null);
+
+    exclusiveGateway.setNodes(nodes);
+    assertEquals(nodes, getField(exclusiveGateway, "nodes"));
+  }
+
+}

--- a/components/src/test/java/org/folio/rest/workflow/model/FileTaskTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/FileTaskTest.java
@@ -1,0 +1,214 @@
+package org.folio.rest.workflow.model;
+
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.folio.rest.workflow.enums.FileOp;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FileTaskTest {
+
+  @Mock
+  private EmbeddedVariable embeddedVariable;
+
+  private Set<EmbeddedVariable> inputVariables;
+
+  private FileTask fileTask;
+
+  @BeforeEach
+  void beforeEach() {
+    fileTask = new FileTask();
+    inputVariables = new HashSet<>();
+    inputVariables.add(embeddedVariable);
+  }
+
+  @Test
+  void getIdWorksTest() {
+    setField(fileTask, "id", VALUE);
+
+    assertEquals(VALUE, fileTask.getId());
+  }
+
+  @Test
+  void setIdWorksTest() {
+    setField(fileTask, "id", null);
+
+    fileTask.setId(VALUE);
+    assertEquals(VALUE, getField(fileTask, "id"));
+  }
+
+  @Test
+  void getNameWorksTest() {
+    setField(fileTask, "name", VALUE);
+
+    assertEquals(VALUE, fileTask.getName());
+  }
+
+  @Test
+  void setNameWorksTest() {
+    setField(fileTask, "name", null);
+
+    fileTask.setName(VALUE);
+    assertEquals(VALUE, getField(fileTask, "name"));
+  }
+
+  @Test
+  void getDescriptionWorksTest() {
+    setField(fileTask, "description", VALUE);
+
+    assertEquals(VALUE, fileTask.getDescription());
+  }
+
+  @Test
+  void setDescriptionWorksTest() {
+    setField(fileTask, "description", null);
+
+    fileTask.setDescription(VALUE);
+    assertEquals(VALUE, getField(fileTask, "description"));
+  }
+
+  @Test
+  void getDeserializeAsWorksTest() {
+    setField(fileTask, "deserializeAs", VALUE);
+
+    assertEquals(VALUE, fileTask.getDeserializeAs());
+  }
+
+  @Test
+  void setDeserializeAsWorksTest() {
+    setField(fileTask, "deserializeAs", null);
+
+    fileTask.setDeserializeAs(VALUE);
+    assertEquals(VALUE, getField(fileTask, "deserializeAs"));
+  }
+
+  @Test
+  void getInputVariablesWorksTest() {
+    setField(fileTask, "inputVariables", inputVariables);
+
+    assertEquals(inputVariables, fileTask.getInputVariables());
+  }
+
+  @Test
+  void setInputVariablesWorksTest() {
+    setField(fileTask, "inputVariables", null);
+
+    fileTask.setInputVariables(inputVariables);
+    assertEquals(inputVariables, getField(fileTask, "inputVariables"));
+  }
+
+  @Test
+  void getOutputVariableWorksTest() {
+    setField(fileTask, "outputVariable", embeddedVariable);
+
+    assertEquals(embeddedVariable, fileTask.getOutputVariable());
+  }
+
+  @Test
+  void setOutputVariableWorksTest() {
+    setField(fileTask, "outputVariable", null);
+
+    fileTask.setOutputVariable(embeddedVariable);
+    assertEquals(embeddedVariable, getField(fileTask, "outputVariable"));
+  }
+
+  @Test
+  void getAsyncBeforeWorksTest() {
+    setField(fileTask, "asyncBefore", true);
+
+    assertEquals(true, fileTask.isAsyncBefore());
+  }
+
+  @Test
+  void setAsyncBeforeWorksTest() {
+    setField(fileTask, "asyncBefore", false);
+
+    fileTask.setAsyncBefore(true);
+    assertEquals(true, getField(fileTask, "asyncBefore"));
+  }
+
+  @Test
+  void getAsyncAfterWorksTest() {
+    setField(fileTask, "asyncAfter", true);
+
+    assertEquals(true, fileTask.isAsyncAfter());
+  }
+
+  @Test
+  void setAsyncAfterWorksTest() {
+    setField(fileTask, "asyncAfter", false);
+
+    fileTask.setAsyncAfter(true);
+    assertEquals(true, getField(fileTask, "asyncAfter"));
+  }
+
+  @Test
+  void getOpWorksTest() {
+    setField(fileTask, "op", FileOp.DELETE);
+
+    assertEquals(FileOp.DELETE, fileTask.getOp());
+  }
+
+  @Test
+  void setOpWorksTest() {
+    setField(fileTask, "op", null);
+
+    fileTask.setOp(FileOp.DELETE);
+    assertEquals(FileOp.DELETE, getField(fileTask, "op"));
+  }
+
+  @Test
+  void getPathWorksTest() {
+    setField(fileTask, "path", VALUE);
+
+    assertEquals(VALUE, fileTask.getPath());
+  }
+
+  @Test
+  void setPathWorksTest() {
+    setField(fileTask, "path", null);
+
+    fileTask.setPath(VALUE);
+    assertEquals(VALUE, getField(fileTask, "path"));
+  }
+
+  @Test
+  void getTargetWorksTest() {
+    setField(fileTask, "target", VALUE);
+
+    assertEquals(VALUE, fileTask.getTarget());
+  }
+
+  @Test
+  void setTargetWorksTest() {
+    setField(fileTask, "target", null);
+
+    fileTask.setTarget(VALUE);
+    assertEquals(VALUE, getField(fileTask, "target"));
+  }
+
+  @Test
+  void getLineWorksTest() {
+    setField(fileTask, "line", VALUE);
+
+    assertEquals(VALUE, fileTask.getLine());
+  }
+
+  @Test
+  void setLineWorksTest() {
+    setField(fileTask, "line", null);
+
+    fileTask.setLine(VALUE);
+    assertEquals(VALUE, getField(fileTask, "line"));
+  }
+
+}

--- a/components/src/test/java/org/folio/rest/workflow/model/FtpTaskTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/FtpTaskTest.java
@@ -1,0 +1,274 @@
+package org.folio.rest.workflow.model;
+
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.folio.rest.workflow.enums.SftpOp;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FtpTaskTest {
+
+  @Mock
+  private EmbeddedVariable embeddedVariable;
+
+  private Set<EmbeddedVariable> inputVariables;
+
+  private FtpTask ftpTask;
+
+  @BeforeEach
+  void beforeEach() {
+    ftpTask = new FtpTask();
+    inputVariables = new HashSet<>();
+    inputVariables.add(embeddedVariable);
+  }
+
+  @Test
+  void getIdWorksTest() {
+    setField(ftpTask, "id", VALUE);
+
+    assertEquals(VALUE, ftpTask.getId());
+  }
+
+  @Test
+  void setIdWorksTest() {
+    setField(ftpTask, "id", null);
+
+    ftpTask.setId(VALUE);
+    assertEquals(VALUE, getField(ftpTask, "id"));
+  }
+
+  @Test
+  void getNameWorksTest() {
+    setField(ftpTask, "name", VALUE);
+
+    assertEquals(VALUE, ftpTask.getName());
+  }
+
+  @Test
+  void setNameWorksTest() {
+    setField(ftpTask, "name", null);
+
+    ftpTask.setName(VALUE);
+    assertEquals(VALUE, getField(ftpTask, "name"));
+  }
+
+  @Test
+  void getDescriptionWorksTest() {
+    setField(ftpTask, "description", VALUE);
+
+    assertEquals(VALUE, ftpTask.getDescription());
+  }
+
+  @Test
+  void setDescriptionWorksTest() {
+    setField(ftpTask, "description", null);
+
+    ftpTask.setDescription(VALUE);
+    assertEquals(VALUE, getField(ftpTask, "description"));
+  }
+
+  @Test
+  void getDeserializeAsWorksTest() {
+    setField(ftpTask, "deserializeAs", VALUE);
+
+    assertEquals(VALUE, ftpTask.getDeserializeAs());
+  }
+
+  @Test
+  void setDeserializeAsWorksTest() {
+    setField(ftpTask, "deserializeAs", null);
+
+    ftpTask.setDeserializeAs(VALUE);
+    assertEquals(VALUE, getField(ftpTask, "deserializeAs"));
+  }
+
+  @Test
+  void getInputVariablesWorksTest() {
+    setField(ftpTask, "inputVariables", inputVariables);
+
+    assertEquals(inputVariables, ftpTask.getInputVariables());
+  }
+
+  @Test
+  void setInputVariablesWorksTest() {
+    setField(ftpTask, "inputVariables", null);
+
+    ftpTask.setInputVariables(inputVariables);
+    assertEquals(inputVariables, getField(ftpTask, "inputVariables"));
+  }
+
+  @Test
+  void getOutputVariableWorksTest() {
+    setField(ftpTask, "outputVariable", embeddedVariable);
+
+    assertEquals(embeddedVariable, ftpTask.getOutputVariable());
+  }
+
+  @Test
+  void setOutputVariableWorksTest() {
+    setField(ftpTask, "outputVariable", null);
+
+    ftpTask.setOutputVariable(embeddedVariable);
+    assertEquals(embeddedVariable, getField(ftpTask, "outputVariable"));
+  }
+
+  @Test
+  void getAsyncBeforeWorksTest() {
+    setField(ftpTask, "asyncBefore", true);
+
+    assertEquals(true, ftpTask.isAsyncBefore());
+  }
+
+  @Test
+  void setAsyncBeforeWorksTest() {
+    setField(ftpTask, "asyncBefore", false);
+
+    ftpTask.setAsyncBefore(true);
+    assertEquals(true, getField(ftpTask, "asyncBefore"));
+  }
+
+  @Test
+  void getAsyncAfterWorksTest() {
+    setField(ftpTask, "asyncAfter", true);
+
+    assertEquals(true, ftpTask.isAsyncAfter());
+  }
+
+  @Test
+  void setAsyncAfterWorksTest() {
+    setField(ftpTask, "asyncAfter", false);
+
+    ftpTask.setAsyncAfter(true);
+    assertEquals(true, getField(ftpTask, "asyncAfter"));
+  }
+
+  @Test
+  void getOriginPathWorksTest() {
+    setField(ftpTask, "originPath", VALUE);
+
+    assertEquals(VALUE, ftpTask.getOriginPath());
+  }
+
+  @Test
+  void setOriginPathWorksTest() {
+    setField(ftpTask, "originPath", null);
+
+    ftpTask.setOriginPath(VALUE);
+    assertEquals(VALUE, getField(ftpTask, "originPath"));
+  }
+
+  @Test
+  void getDestinationPathWorksTest() {
+    setField(ftpTask, "destinationPath", VALUE);
+
+    assertEquals(VALUE, ftpTask.getDestinationPath());
+  }
+
+  @Test
+  void setDestinationPathWorksTest() {
+    setField(ftpTask, "destinationPath", null);
+
+    ftpTask.setDestinationPath(VALUE);
+    assertEquals(VALUE, getField(ftpTask, "destinationPath"));
+  }
+
+  @Test
+  void getOpWorksTest() {
+    setField(ftpTask, "op", SftpOp.GET);
+
+    assertEquals(SftpOp.GET, ftpTask.getOp());
+  }
+
+  @Test
+  void setOpWorksTest() {
+    setField(ftpTask, "op", null);
+
+    ftpTask.setOp(SftpOp.GET);
+    assertEquals(SftpOp.GET, getField(ftpTask, "op"));
+  }
+
+  @Test
+  void getSchemeWorksTest() {
+    setField(ftpTask, "scheme", VALUE);
+
+    assertEquals(VALUE, ftpTask.getScheme());
+  }
+
+  @Test
+  void setSchemeWorksTest() {
+    setField(ftpTask, "scheme", null);
+
+    ftpTask.setScheme(VALUE);
+    assertEquals(VALUE, getField(ftpTask, "scheme"));
+  }
+
+  @Test
+  void getHostWorksTest() {
+    setField(ftpTask, "host", VALUE);
+
+    assertEquals(VALUE, ftpTask.getHost());
+  }
+
+  @Test
+  void setHostWorksTest() {
+    setField(ftpTask, "host", null);
+
+    ftpTask.setHost(VALUE);
+    assertEquals(VALUE, getField(ftpTask, "host"));
+  }
+
+  @Test
+  void getPortWorksTest() {
+    setField(ftpTask, "port", 1);
+
+    assertEquals(1, ftpTask.getPort());
+  }
+
+  @Test
+  void setPortWorksTest() {
+    setField(ftpTask, "port", 0);
+
+    ftpTask.setPort(1);
+    assertEquals(1, getField(ftpTask, "port"));
+  }
+
+  @Test
+  void getUsernameWorksTest() {
+    setField(ftpTask, "username", VALUE);
+
+    assertEquals(VALUE, ftpTask.getUsername());
+  }
+
+  @Test
+  void setUsernameWorksTest() {
+    setField(ftpTask, "username", null);
+
+    ftpTask.setUsername(VALUE);
+    assertEquals(VALUE, getField(ftpTask, "username"));
+  }
+
+  @Test
+  void getPasswordWorksTest() {
+    setField(ftpTask, "password", VALUE);
+
+    assertEquals(VALUE, ftpTask.getPassword());
+  }
+
+  @Test
+  void setPasswordWorksTest() {
+    setField(ftpTask, "password", null);
+
+    ftpTask.setPassword(VALUE);
+    assertEquals(VALUE, getField(ftpTask, "password"));
+  }
+
+}

--- a/components/src/test/java/org/folio/rest/workflow/model/InclusiveGatewayTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/InclusiveGatewayTest.java
@@ -1,0 +1,124 @@
+package org.folio.rest.workflow.model;
+
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.folio.rest.workflow.enums.Direction;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class InclusiveGatewayTest {
+
+  @Mock
+  private Node node;
+
+  private List<Node> nodes;
+
+  private InclusiveGateway abstractGateway;
+
+  @BeforeEach
+  void beforeEach() {
+    abstractGateway = new InclusiveGateway();
+    nodes = new ArrayList<>();
+    nodes.add(node);
+  }
+
+  @Test
+  void getIdWorksTest() {
+    setField(abstractGateway, "id", VALUE);
+
+    assertEquals(VALUE, abstractGateway.getId());
+  }
+
+  @Test
+  void setIdWorksTest() {
+    setField(abstractGateway, "id", null);
+
+    abstractGateway.setId(VALUE);
+    assertEquals(VALUE, getField(abstractGateway, "id"));
+  }
+
+  @Test
+  void getNameWorksTest() {
+    setField(abstractGateway, "name", VALUE);
+
+    assertEquals(VALUE, abstractGateway.getName());
+  }
+
+  @Test
+  void setNameWorksTest() {
+    setField(abstractGateway, "name", null);
+
+    abstractGateway.setName(VALUE);
+    assertEquals(VALUE, getField(abstractGateway, "name"));
+  }
+
+  @Test
+  void getDescriptionWorksTest() {
+    setField(abstractGateway, "description", VALUE);
+
+    assertEquals(VALUE, abstractGateway.getDescription());
+  }
+
+  @Test
+  void setDescriptionWorksTest() {
+    setField(abstractGateway, "description", null);
+
+    abstractGateway.setDescription(VALUE);
+    assertEquals(VALUE, getField(abstractGateway, "description"));
+  }
+
+  @Test
+  void getDeserializeAsWorksTest() {
+    setField(abstractGateway, "deserializeAs", VALUE);
+
+    assertEquals(VALUE, abstractGateway.getDeserializeAs());
+  }
+
+  @Test
+  void setDeserializeAsWorksTest() {
+    setField(abstractGateway, "deserializeAs", null);
+
+    abstractGateway.setDeserializeAs(VALUE);
+    assertEquals(VALUE, getField(abstractGateway, "deserializeAs"));
+  }
+
+  @Test
+  void getDirectionWorksTest() {
+    setField(abstractGateway, "direction", Direction.CONVERGING);
+
+    assertEquals(Direction.CONVERGING, abstractGateway.getDirection());
+  }
+
+  @Test
+  void setDirectionWorksTest() {
+    setField(abstractGateway, "direction", null);
+
+    abstractGateway.setDirection(Direction.CONVERGING);
+    assertEquals(Direction.CONVERGING, getField(abstractGateway, "direction"));
+  }
+
+  @Test
+  void getNodesWorksTest() {
+    setField(abstractGateway, "nodes", nodes);
+
+    assertEquals(nodes, abstractGateway.getNodes());
+  }
+
+  @Test
+  void setNodesWorksTest() {
+    setField(abstractGateway, "nodes", null);
+
+    abstractGateway.setNodes(nodes);
+    assertEquals(nodes, getField(abstractGateway, "nodes"));
+  }
+
+}

--- a/components/src/test/java/org/folio/rest/workflow/model/MoveToLastGatewayTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/MoveToLastGatewayTest.java
@@ -1,0 +1,124 @@
+package org.folio.rest.workflow.model;
+
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.folio.rest.workflow.enums.Direction;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MoveToLastGatewayTest {
+
+  @Mock
+  private Node node;
+
+  private List<Node> nodes;
+
+  private MoveToLastGateway moveToLastGateway;
+
+  @BeforeEach
+  void beforeEach() {
+    moveToLastGateway = new MoveToLastGateway();
+    nodes = new ArrayList<>();
+    nodes.add(node);
+  }
+
+  @Test
+  void getIdWorksTest() {
+    setField(moveToLastGateway, "id", VALUE);
+
+    assertEquals(VALUE, moveToLastGateway.getId());
+  }
+
+  @Test
+  void setIdWorksTest() {
+    setField(moveToLastGateway, "id", null);
+
+    moveToLastGateway.setId(VALUE);
+    assertEquals(VALUE, getField(moveToLastGateway, "id"));
+  }
+
+  @Test
+  void getNameWorksTest() {
+    setField(moveToLastGateway, "name", VALUE);
+
+    assertEquals(VALUE, moveToLastGateway.getName());
+  }
+
+  @Test
+  void setNameWorksTest() {
+    setField(moveToLastGateway, "name", null);
+
+    moveToLastGateway.setName(VALUE);
+    assertEquals(VALUE, getField(moveToLastGateway, "name"));
+  }
+
+  @Test
+  void getDescriptionWorksTest() {
+    setField(moveToLastGateway, "description", VALUE);
+
+    assertEquals(VALUE, moveToLastGateway.getDescription());
+  }
+
+  @Test
+  void setDescriptionWorksTest() {
+    setField(moveToLastGateway, "description", null);
+
+    moveToLastGateway.setDescription(VALUE);
+    assertEquals(VALUE, getField(moveToLastGateway, "description"));
+  }
+
+  @Test
+  void getDeserializeAsWorksTest() {
+    setField(moveToLastGateway, "deserializeAs", VALUE);
+
+    assertEquals(VALUE, moveToLastGateway.getDeserializeAs());
+  }
+
+  @Test
+  void setDeserializeAsWorksTest() {
+    setField(moveToLastGateway, "deserializeAs", null);
+
+    moveToLastGateway.setDeserializeAs(VALUE);
+    assertEquals(VALUE, getField(moveToLastGateway, "deserializeAs"));
+  }
+
+  @Test
+  void getDirectionWorksTest() {
+    setField(moveToLastGateway, "direction", Direction.CONVERGING);
+
+    assertEquals(Direction.CONVERGING, moveToLastGateway.getDirection());
+  }
+
+  @Test
+  void setDirectionWorksTest() {
+    setField(moveToLastGateway, "direction", null);
+
+    moveToLastGateway.setDirection(Direction.CONVERGING);
+    assertEquals(Direction.CONVERGING, getField(moveToLastGateway, "direction"));
+  }
+
+  @Test
+  void getNodesWorksTest() {
+    setField(moveToLastGateway, "nodes", nodes);
+
+    assertEquals(nodes, moveToLastGateway.getNodes());
+  }
+
+  @Test
+  void setNodesWorksTest() {
+    setField(moveToLastGateway, "nodes", null);
+
+    moveToLastGateway.setNodes(nodes);
+    assertEquals(nodes, getField(moveToLastGateway, "nodes"));
+  }
+
+}

--- a/components/src/test/java/org/folio/rest/workflow/model/MoveToNodeTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/MoveToNodeTest.java
@@ -1,0 +1,123 @@
+package org.folio.rest.workflow.model;
+
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MoveToNodeTest {
+
+  @Mock
+  private Node node;
+
+  private List<Node> nodes;
+
+  private MoveToNode moveToNode;
+
+  @BeforeEach
+  void beforeEach() {
+    moveToNode = new MoveToNode();
+    nodes = new ArrayList<>();
+    nodes.add(node);
+  }
+
+  @Test
+  void getIdWorksTest() {
+    setField(moveToNode, "id", VALUE);
+
+    assertEquals(VALUE, moveToNode.getId());
+  }
+
+  @Test
+  void setIdWorksTest() {
+    setField(moveToNode, "id", null);
+
+    moveToNode.setId(VALUE);
+    assertEquals(VALUE, getField(moveToNode, "id"));
+  }
+
+  @Test
+  void getNameWorksTest() {
+    setField(moveToNode, "name", VALUE);
+
+    assertEquals(VALUE, moveToNode.getName());
+  }
+
+  @Test
+  void setNameWorksTest() {
+    setField(moveToNode, "name", null);
+
+    moveToNode.setName(VALUE);
+    assertEquals(VALUE, getField(moveToNode, "name"));
+  }
+
+  @Test
+  void getDescriptionWorksTest() {
+    setField(moveToNode, "description", VALUE);
+
+    assertEquals(VALUE, moveToNode.getDescription());
+  }
+
+  @Test
+  void setDescriptionWorksTest() {
+    setField(moveToNode, "description", null);
+
+    moveToNode.setDescription(VALUE);
+    assertEquals(VALUE, getField(moveToNode, "description"));
+  }
+
+  @Test
+  void getDeserializeAsWorksTest() {
+    setField(moveToNode, "deserializeAs", VALUE);
+
+    assertEquals(VALUE, moveToNode.getDeserializeAs());
+  }
+
+  @Test
+  void setDeserializeAsWorksTest() {
+    setField(moveToNode, "deserializeAs", null);
+
+    moveToNode.setDeserializeAs(VALUE);
+    assertEquals(VALUE, getField(moveToNode, "deserializeAs"));
+  }
+
+  @Test
+  void getGatewayIdWorksTest() {
+    setField(moveToNode, "gatewayId", VALUE);
+
+    assertEquals(VALUE, moveToNode.getGatewayId());
+  }
+
+  @Test
+  void setGatewayIdWorksTest() {
+    setField(moveToNode, "gatewayId", null);
+
+    moveToNode.setGatewayId(VALUE);
+    assertEquals(VALUE, getField(moveToNode, "gatewayId"));
+  }
+
+  @Test
+  void getNodesWorksTest() {
+    setField(moveToNode, "nodes", nodes);
+
+    assertEquals(nodes, moveToNode.getNodes());
+  }
+
+  @Test
+  void setNodesWorksTest() {
+    setField(moveToNode, "nodes", null);
+
+    moveToNode.setNodes(nodes);
+    assertEquals(nodes, getField(moveToNode, "nodes"));
+  }
+
+}

--- a/components/src/test/java/org/folio/rest/workflow/model/NodeTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/NodeTest.java
@@ -1,0 +1,82 @@
+package org.folio.rest.workflow.model;
+
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class NodeTest {
+
+  private Node node;
+
+  @BeforeEach
+  void beforeEach() {
+    node = new Impl();
+  }
+
+  @Test
+  void getIdWorksTest() {
+    setField(node, "id", VALUE);
+
+    assertEquals(VALUE, node.getId());
+  }
+
+  @Test
+  void setIdWorksTest() {
+    setField(node, "id", null);
+
+    node.setId(VALUE);
+    assertEquals(VALUE, getField(node, "id"));
+  }
+
+  @Test
+  void getNameWorksTest() {
+    setField(node, "name", VALUE);
+
+    assertEquals(VALUE, node.getName());
+  }
+
+  @Test
+  void setNameWorksTest() {
+    setField(node, "name", null);
+
+    node.setName(VALUE);
+    assertEquals(VALUE, getField(node, "name"));
+  }
+
+  @Test
+  void getDescriptionWorksTest() {
+    setField(node, "description", VALUE);
+
+    assertEquals(VALUE, node.getDescription());
+  }
+
+  @Test
+  void setDescriptionWorksTest() {
+    setField(node, "description", null);
+
+    node.setDescription(VALUE);
+    assertEquals(VALUE, getField(node, "description"));
+  }
+
+  @Test
+  void getDeserializeAsWorksTest() {
+    setField(node, "deserializeAs", VALUE);
+
+    assertEquals(VALUE, node.getDeserializeAs());
+  }
+
+  @Test
+  void setDeserializeAsWorksTest() {
+    setField(node, "deserializeAs", null);
+
+    node.setDeserializeAs(VALUE);
+    assertEquals(VALUE, getField(node, "deserializeAs"));
+  }
+
+  private static class Impl extends Node { };
+
+}

--- a/components/src/test/java/org/folio/rest/workflow/model/ParallelGatewayTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/ParallelGatewayTest.java
@@ -1,0 +1,124 @@
+package org.folio.rest.workflow.model;
+
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.folio.rest.workflow.enums.Direction;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ParallelGatewayTest {
+
+  @Mock
+  private Node node;
+
+  private List<Node> nodes;
+
+  private ParallelGateway parallelGateway;
+
+  @BeforeEach
+  void beforeEach() {
+    parallelGateway = new ParallelGateway();
+    nodes = new ArrayList<>();
+    nodes.add(node);
+  }
+
+  @Test
+  void getIdWorksTest() {
+    setField(parallelGateway, "id", VALUE);
+
+    assertEquals(VALUE, parallelGateway.getId());
+  }
+
+  @Test
+  void setIdWorksTest() {
+    setField(parallelGateway, "id", null);
+
+    parallelGateway.setId(VALUE);
+    assertEquals(VALUE, getField(parallelGateway, "id"));
+  }
+
+  @Test
+  void getNameWorksTest() {
+    setField(parallelGateway, "name", VALUE);
+
+    assertEquals(VALUE, parallelGateway.getName());
+  }
+
+  @Test
+  void setNameWorksTest() {
+    setField(parallelGateway, "name", null);
+
+    parallelGateway.setName(VALUE);
+    assertEquals(VALUE, getField(parallelGateway, "name"));
+  }
+
+  @Test
+  void getDescriptionWorksTest() {
+    setField(parallelGateway, "description", VALUE);
+
+    assertEquals(VALUE, parallelGateway.getDescription());
+  }
+
+  @Test
+  void setDescriptionWorksTest() {
+    setField(parallelGateway, "description", null);
+
+    parallelGateway.setDescription(VALUE);
+    assertEquals(VALUE, getField(parallelGateway, "description"));
+  }
+
+  @Test
+  void getDeserializeAsWorksTest() {
+    setField(parallelGateway, "deserializeAs", VALUE);
+
+    assertEquals(VALUE, parallelGateway.getDeserializeAs());
+  }
+
+  @Test
+  void setDeserializeAsWorksTest() {
+    setField(parallelGateway, "deserializeAs", null);
+
+    parallelGateway.setDeserializeAs(VALUE);
+    assertEquals(VALUE, getField(parallelGateway, "deserializeAs"));
+  }
+
+  @Test
+  void getDirectionWorksTest() {
+    setField(parallelGateway, "direction", Direction.CONVERGING);
+
+    assertEquals(Direction.CONVERGING, parallelGateway.getDirection());
+  }
+
+  @Test
+  void setDirectionWorksTest() {
+    setField(parallelGateway, "direction", null);
+
+    parallelGateway.setDirection(Direction.CONVERGING);
+    assertEquals(Direction.CONVERGING, getField(parallelGateway, "direction"));
+  }
+
+  @Test
+  void getNodesWorksTest() {
+    setField(parallelGateway, "nodes", nodes);
+
+    assertEquals(nodes, parallelGateway.getNodes());
+  }
+
+  @Test
+  void setNodesWorksTest() {
+    setField(parallelGateway, "nodes", null);
+
+    parallelGateway.setNodes(nodes);
+    assertEquals(nodes, getField(parallelGateway, "nodes"));
+  }
+
+}

--- a/components/src/test/java/org/folio/rest/workflow/model/ProcessorTaskTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/ProcessorTaskTest.java
@@ -1,0 +1,171 @@
+package org.folio.rest.workflow.model;
+
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProcessorTaskTest {
+
+  @Mock
+  private EmbeddedVariable embeddedVariable;
+
+  @Mock
+  private EmbeddedProcessor embeddedProcessor;
+
+  private Set<EmbeddedVariable> inputVariables;
+
+  private ProcessorTask processorTask;
+
+  @BeforeEach
+  void beforeEach() {
+    processorTask = new ProcessorTask();
+    inputVariables = new HashSet<>();
+    inputVariables.add(embeddedVariable);
+  }
+
+  @Test
+  void getIdWorksTest() {
+    setField(processorTask, "id", VALUE);
+
+    assertEquals(VALUE, processorTask.getId());
+  }
+
+  @Test
+  void setIdWorksTest() {
+    setField(processorTask, "id", null);
+
+    processorTask.setId(VALUE);
+    assertEquals(VALUE, getField(processorTask, "id"));
+  }
+
+  @Test
+  void getNameWorksTest() {
+    setField(processorTask, "name", VALUE);
+
+    assertEquals(VALUE, processorTask.getName());
+  }
+
+  @Test
+  void setNameWorksTest() {
+    setField(processorTask, "name", null);
+
+    processorTask.setName(VALUE);
+    assertEquals(VALUE, getField(processorTask, "name"));
+  }
+
+  @Test
+  void getDescriptionWorksTest() {
+    setField(processorTask, "description", VALUE);
+
+    assertEquals(VALUE, processorTask.getDescription());
+  }
+
+  @Test
+  void setDescriptionWorksTest() {
+    setField(processorTask, "description", null);
+
+    processorTask.setDescription(VALUE);
+    assertEquals(VALUE, getField(processorTask, "description"));
+  }
+
+  @Test
+  void getDeserializeAsWorksTest() {
+    setField(processorTask, "deserializeAs", VALUE);
+
+    assertEquals(VALUE, processorTask.getDeserializeAs());
+  }
+
+  @Test
+  void setDeserializeAsWorksTest() {
+    setField(processorTask, "deserializeAs", null);
+
+    processorTask.setDeserializeAs(VALUE);
+    assertEquals(VALUE, getField(processorTask, "deserializeAs"));
+  }
+
+  @Test
+  void getInputVariablesWorksTest() {
+    setField(processorTask, "inputVariables", inputVariables);
+
+    assertEquals(inputVariables, processorTask.getInputVariables());
+  }
+
+  @Test
+  void setInputVariablesWorksTest() {
+    setField(processorTask, "inputVariables", null);
+
+    processorTask.setInputVariables(inputVariables);
+    assertEquals(inputVariables, getField(processorTask, "inputVariables"));
+  }
+
+  @Test
+  void getOutputVariableWorksTest() {
+    setField(processorTask, "outputVariable", embeddedVariable);
+
+    assertEquals(embeddedVariable, processorTask.getOutputVariable());
+  }
+
+  @Test
+  void setOutputVariableWorksTest() {
+    setField(processorTask, "outputVariable", null);
+
+    processorTask.setOutputVariable(embeddedVariable);
+    assertEquals(embeddedVariable, getField(processorTask, "outputVariable"));
+  }
+
+  @Test
+  void getAsyncBeforeWorksTest() {
+    setField(processorTask, "asyncBefore", true);
+
+    assertEquals(true, processorTask.isAsyncBefore());
+  }
+
+  @Test
+  void setAsyncBeforeWorksTest() {
+    setField(processorTask, "asyncBefore", false);
+
+    processorTask.setAsyncBefore(true);
+    assertEquals(true, getField(processorTask, "asyncBefore"));
+  }
+
+  @Test
+  void getAsyncAfterWorksTest() {
+    setField(processorTask, "asyncAfter", true);
+
+    assertEquals(true, processorTask.isAsyncAfter());
+  }
+
+  @Test
+  void setAsyncAfterWorksTest() {
+    setField(processorTask, "asyncAfter", false);
+
+    processorTask.setAsyncAfter(true);
+    assertEquals(true, getField(processorTask, "asyncAfter"));
+  }
+
+  @Test
+  void getProcessorWorksTest() {
+    setField(processorTask, "processor", embeddedProcessor);
+
+    assertEquals(embeddedProcessor, processorTask.getProcessor());
+  }
+
+  @Test
+  void setProcessorWorksTest() {
+    setField(processorTask, "processor", null);
+
+    processorTask.setProcessor(embeddedProcessor);
+    assertEquals(embeddedProcessor, getField(processorTask, "processor"));
+  }
+
+}

--- a/components/src/test/java/org/folio/rest/workflow/model/ReceiveTaskTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/ReceiveTaskTest.java
@@ -1,0 +1,128 @@
+package org.folio.rest.workflow.model;
+
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ReceiveTaskTest {
+
+  private ReceiveTask receiveTask;
+
+  @BeforeEach
+  void beforeEach() {
+    receiveTask = new ReceiveTask();
+  }
+
+  @Test
+  void getIdWorksTest() {
+    setField(receiveTask, "id", VALUE);
+
+    assertEquals(VALUE, receiveTask.getId());
+  }
+
+  @Test
+  void setIdWorksTest() {
+    setField(receiveTask, "id", null);
+
+    receiveTask.setId(VALUE);
+    assertEquals(VALUE, getField(receiveTask, "id"));
+  }
+
+  @Test
+  void getNameWorksTest() {
+    setField(receiveTask, "name", VALUE);
+
+    assertEquals(VALUE, receiveTask.getName());
+  }
+
+  @Test
+  void setNameWorksTest() {
+    setField(receiveTask, "name", null);
+
+    receiveTask.setName(VALUE);
+    assertEquals(VALUE, getField(receiveTask, "name"));
+  }
+
+  @Test
+  void getDescriptionWorksTest() {
+    setField(receiveTask, "description", VALUE);
+
+    assertEquals(VALUE, receiveTask.getDescription());
+  }
+
+  @Test
+  void setDescriptionWorksTest() {
+    setField(receiveTask, "description", null);
+
+    receiveTask.setDescription(VALUE);
+    assertEquals(VALUE, getField(receiveTask, "description"));
+  }
+
+  @Test
+  void getDeserializeAsWorksTest() {
+    setField(receiveTask, "deserializeAs", VALUE);
+
+    assertEquals(VALUE, receiveTask.getDeserializeAs());
+  }
+
+  @Test
+  void setDeserializeAsWorksTest() {
+    setField(receiveTask, "deserializeAs", null);
+
+    receiveTask.setDeserializeAs(VALUE);
+    assertEquals(VALUE, getField(receiveTask, "deserializeAs"));
+  }
+
+  @Test
+  void getAsyncBeforeWorksTest() {
+    setField(receiveTask, "asyncBefore", true);
+
+    assertEquals(true, receiveTask.isAsyncBefore());
+  }
+
+  @Test
+  void setAsyncBeforeWorksTest() {
+    setField(receiveTask, "asyncBefore", false);
+
+    receiveTask.setAsyncBefore(true);
+    assertEquals(true, getField(receiveTask, "asyncBefore"));
+  }
+
+  @Test
+  void getAsyncAfterWorksTest() {
+    setField(receiveTask, "asyncAfter", true);
+
+    assertEquals(true, receiveTask.isAsyncAfter());
+  }
+
+  @Test
+  void setAsyncAfterWorksTest() {
+    setField(receiveTask, "asyncAfter", false);
+
+    receiveTask.setAsyncAfter(true);
+    assertEquals(true, getField(receiveTask, "asyncAfter"));
+  }
+
+  @Test
+  void getMessageWorksTest() {
+    setField(receiveTask, "message", VALUE);
+
+    assertEquals(VALUE, receiveTask.getMessage());
+  }
+
+  @Test
+  void setMessageWorksTest() {
+    setField(receiveTask, "message", null);
+
+    receiveTask.setMessage(VALUE);
+    assertEquals(VALUE, getField(receiveTask, "message"));
+  }
+
+}

--- a/components/src/test/java/org/folio/rest/workflow/model/RequestTaskTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/RequestTaskTest.java
@@ -1,0 +1,186 @@
+package org.folio.rest.workflow.model;
+
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RequestTaskTest {
+
+  @Mock
+  private EmbeddedVariable embeddedVariable;
+
+  @Mock
+  private EmbeddedRequest embeddedRequest;
+
+  private Set<EmbeddedVariable> inputVariables;
+
+  private RequestTask requestTask;
+
+  @BeforeEach
+  void beforeEach() {
+    requestTask = new RequestTask();
+    inputVariables = new HashSet<>();
+    inputVariables.add(embeddedVariable);
+  }
+
+  @Test
+  void getIdWorksTest() {
+    setField(requestTask, "id", VALUE);
+
+    assertEquals(VALUE, requestTask.getId());
+  }
+
+  @Test
+  void setIdWorksTest() {
+    setField(requestTask, "id", null);
+
+    requestTask.setId(VALUE);
+    assertEquals(VALUE, getField(requestTask, "id"));
+  }
+
+  @Test
+  void getNameWorksTest() {
+    setField(requestTask, "name", VALUE);
+
+    assertEquals(VALUE, requestTask.getName());
+  }
+
+  @Test
+  void setNameWorksTest() {
+    setField(requestTask, "name", null);
+
+    requestTask.setName(VALUE);
+    assertEquals(VALUE, getField(requestTask, "name"));
+  }
+
+  @Test
+  void getDescriptionWorksTest() {
+    setField(requestTask, "description", VALUE);
+
+    assertEquals(VALUE, requestTask.getDescription());
+  }
+
+  @Test
+  void setDescriptionWorksTest() {
+    setField(requestTask, "description", null);
+
+    requestTask.setDescription(VALUE);
+    assertEquals(VALUE, getField(requestTask, "description"));
+  }
+
+  @Test
+  void getDeserializeAsWorksTest() {
+    setField(requestTask, "deserializeAs", VALUE);
+
+    assertEquals(VALUE, requestTask.getDeserializeAs());
+  }
+
+  @Test
+  void setDeserializeAsWorksTest() {
+    setField(requestTask, "deserializeAs", null);
+
+    requestTask.setDeserializeAs(VALUE);
+    assertEquals(VALUE, getField(requestTask, "deserializeAs"));
+  }
+
+  @Test
+  void getInputVariablesWorksTest() {
+    setField(requestTask, "inputVariables", inputVariables);
+
+    assertEquals(inputVariables, requestTask.getInputVariables());
+  }
+
+  @Test
+  void setInputVariablesWorksTest() {
+    setField(requestTask, "inputVariables", null);
+
+    requestTask.setInputVariables(inputVariables);
+    assertEquals(inputVariables, getField(requestTask, "inputVariables"));
+  }
+
+  @Test
+  void getOutputVariableWorksTest() {
+    setField(requestTask, "outputVariable", embeddedVariable);
+
+    assertEquals(embeddedVariable, requestTask.getOutputVariable());
+  }
+
+  @Test
+  void setOutputVariableWorksTest() {
+    setField(requestTask, "outputVariable", null);
+
+    requestTask.setOutputVariable(embeddedVariable);
+    assertEquals(embeddedVariable, getField(requestTask, "outputVariable"));
+  }
+
+  @Test
+  void getAsyncBeforeWorksTest() {
+    setField(requestTask, "asyncBefore", true);
+
+    assertEquals(true, requestTask.isAsyncBefore());
+  }
+
+  @Test
+  void setAsyncBeforeWorksTest() {
+    setField(requestTask, "asyncBefore", false);
+
+    requestTask.setAsyncBefore(true);
+    assertEquals(true, getField(requestTask, "asyncBefore"));
+  }
+
+  @Test
+  void getAsyncAfterWorksTest() {
+    setField(requestTask, "asyncAfter", true);
+
+    assertEquals(true, requestTask.isAsyncAfter());
+  }
+
+  @Test
+  void setAsyncAfterWorksTest() {
+    setField(requestTask, "asyncAfter", false);
+
+    requestTask.setAsyncAfter(true);
+    assertEquals(true, getField(requestTask, "asyncAfter"));
+  }
+
+  @Test
+  void getHeaderOutputVariablesWorksTest() {
+    setField(requestTask, "headerOutputVariables", inputVariables);
+
+    assertEquals(inputVariables, requestTask.getHeaderOutputVariables());
+  }
+
+  @Test
+  void setHeaderOutputVariablesWorksTest() {
+    setField(requestTask, "headerOutputVariables", null);
+
+    requestTask.setHeaderOutputVariables(inputVariables);
+    assertEquals(inputVariables, getField(requestTask, "headerOutputVariables"));
+  }
+
+  @Test
+  void getRequestWorksTest() {
+    setField(requestTask, "request", embeddedRequest);
+
+    assertEquals(embeddedRequest, requestTask.getRequest());
+  }
+
+  @Test
+  void setRequestWorksTest() {
+    setField(requestTask, "request", null);
+
+    requestTask.setRequest(embeddedRequest);
+    assertEquals(embeddedRequest, getField(requestTask, "request"));
+  }
+
+}

--- a/components/src/test/java/org/folio/rest/workflow/model/ScriptTaskTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/ScriptTaskTest.java
@@ -1,0 +1,155 @@
+package org.folio.rest.workflow.model;
+
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ScriptTaskTest {
+
+  private ScriptTask scriptTask;
+
+  @BeforeEach
+  void beforeEach() {
+    scriptTask = new ScriptTask();
+  }
+
+  @Test
+  void getIdWorksTest() {
+    setField(scriptTask, "id", VALUE);
+
+    assertEquals(VALUE, scriptTask.getId());
+  }
+
+  @Test
+  void setIdWorksTest() {
+    setField(scriptTask, "id", null);
+
+    scriptTask.setId(VALUE);
+    assertEquals(VALUE, getField(scriptTask, "id"));
+  }
+
+  @Test
+  void getNameWorksTest() {
+    setField(scriptTask, "name", VALUE);
+
+    assertEquals(VALUE, scriptTask.getName());
+  }
+
+  @Test
+  void setNameWorksTest() {
+    setField(scriptTask, "name", null);
+
+    scriptTask.setName(VALUE);
+    assertEquals(VALUE, getField(scriptTask, "name"));
+  }
+
+  @Test
+  void getDescriptionWorksTest() {
+    setField(scriptTask, "description", VALUE);
+
+    assertEquals(VALUE, scriptTask.getDescription());
+  }
+
+  @Test
+  void setDescriptionWorksTest() {
+    setField(scriptTask, "description", null);
+
+    scriptTask.setDescription(VALUE);
+    assertEquals(VALUE, getField(scriptTask, "description"));
+  }
+
+  @Test
+  void getDeserializeAsWorksTest() {
+    setField(scriptTask, "deserializeAs", VALUE);
+
+    assertEquals(VALUE, scriptTask.getDeserializeAs());
+  }
+
+  @Test
+  void setDeserializeAsWorksTest() {
+    setField(scriptTask, "deserializeAs", null);
+
+    scriptTask.setDeserializeAs(VALUE);
+    assertEquals(VALUE, getField(scriptTask, "deserializeAs"));
+  }
+
+  @Test
+  void getAsyncBeforeWorksTest() {
+    setField(scriptTask, "asyncBefore", true);
+
+    assertEquals(true, scriptTask.isAsyncBefore());
+  }
+
+  @Test
+  void setAsyncBeforeWorksTest() {
+    setField(scriptTask, "asyncBefore", false);
+
+    scriptTask.setAsyncBefore(true);
+    assertEquals(true, getField(scriptTask, "asyncBefore"));
+  }
+
+  @Test
+  void getAsyncAfterWorksTest() {
+    setField(scriptTask, "asyncAfter", true);
+
+    assertEquals(true, scriptTask.isAsyncAfter());
+  }
+
+  @Test
+  void setAsyncAfterWorksTest() {
+    setField(scriptTask, "asyncAfter", false);
+
+    scriptTask.setAsyncAfter(true);
+    assertEquals(true, getField(scriptTask, "asyncAfter"));
+  }
+
+  @Test
+  void getScriptFormatWorksTest() {
+    setField(scriptTask, "scriptFormat", VALUE);
+
+    assertEquals(VALUE, scriptTask.getScriptFormat());
+  }
+
+  @Test
+  void setScriptFormatWorksTest() {
+    setField(scriptTask, "scriptFormat", null);
+
+    scriptTask.setScriptFormat(VALUE);
+    assertEquals(VALUE, getField(scriptTask, "scriptFormat"));
+  }
+
+  @Test
+  void getCodeWorksTest() {
+    setField(scriptTask, "code", VALUE);
+
+    assertEquals(VALUE, scriptTask.getCode());
+  }
+
+  @Test
+  void setCodeWorksTest() {
+    setField(scriptTask, "code", null);
+
+    scriptTask.setCode(VALUE);
+    assertEquals(VALUE, getField(scriptTask, "code"));
+  }
+
+  @Test
+  void getResultVariableWorksTest() {
+    setField(scriptTask, "resultVariable", VALUE);
+
+    assertEquals(VALUE, scriptTask.getResultVariable());
+  }
+
+  @Test
+  void setResultVariableWorksTest() {
+    setField(scriptTask, "resultVariable", null);
+
+    scriptTask.setResultVariable(VALUE);
+    assertEquals(VALUE, getField(scriptTask, "resultVariable"));
+  }
+
+}

--- a/components/src/test/java/org/folio/rest/workflow/model/SetupTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/SetupTest.java
@@ -1,0 +1,49 @@
+package org.folio.rest.workflow.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SetupTest {
+
+  private Setup setup;
+
+  @BeforeEach
+  void beforeEach() {
+    setup = new Setup();
+  }
+
+  @Test
+  void getAsyncBeforeWorksTest() {
+    setField(setup, "asyncBefore", true);
+
+    assertEquals(true, setup.isAsyncBefore());
+  }
+
+  @Test
+  void setAsyncBeforeWorksTest() {
+    setField(setup, "asyncBefore", false);
+
+    setup.setAsyncBefore(true);
+    assertEquals(true, getField(setup, "asyncBefore"));
+  }
+
+  @Test
+  void getAsyncAfterWorksTest() {
+    setField(setup, "asyncAfter", true);
+
+    assertEquals(true, setup.isAsyncAfter());
+  }
+
+  @Test
+  void setAsyncAfterWorksTest() {
+    setField(setup, "asyncAfter", false);
+
+    setup.setAsyncAfter(true);
+    assertEquals(true, getField(setup, "asyncAfter"));
+  }
+
+}

--- a/components/src/test/java/org/folio/rest/workflow/model/StartEventTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/StartEventTest.java
@@ -1,0 +1,143 @@
+package org.folio.rest.workflow.model;
+
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import org.folio.rest.workflow.enums.StartEventType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class StartEventTest {
+
+  private StartEvent startEvent;
+
+  @BeforeEach
+  void beforeEach() {
+    startEvent = new Impl();
+  }
+
+  @Test
+  void getIdWorksTest() {
+    setField(startEvent, "id", VALUE);
+
+    assertEquals(VALUE, startEvent.getId());
+  }
+
+  @Test
+  void setIdWorksTest() {
+    setField(startEvent, "id", null);
+
+    startEvent.setId(VALUE);
+    assertEquals(VALUE, getField(startEvent, "id"));
+  }
+
+  @Test
+  void getNameWorksTest() {
+    setField(startEvent, "name", VALUE);
+
+    assertEquals(VALUE, startEvent.getName());
+  }
+
+  @Test
+  void setNameWorksTest() {
+    setField(startEvent, "name", null);
+
+    startEvent.setName(VALUE);
+    assertEquals(VALUE, getField(startEvent, "name"));
+  }
+
+  @Test
+  void getDescriptionWorksTest() {
+    setField(startEvent, "description", VALUE);
+
+    assertEquals(VALUE, startEvent.getDescription());
+  }
+
+  @Test
+  void setDescriptionWorksTest() {
+    setField(startEvent, "description", null);
+
+    startEvent.setDescription(VALUE);
+    assertEquals(VALUE, getField(startEvent, "description"));
+  }
+
+  @Test
+  void getDeserializeAsWorksTest() {
+    setField(startEvent, "deserializeAs", VALUE);
+
+    assertEquals(VALUE, startEvent.getDeserializeAs());
+  }
+
+  @Test
+  void setDeserializeAsWorksTest() {
+    setField(startEvent, "deserializeAs", null);
+
+    startEvent.setDeserializeAs(VALUE);
+    assertEquals(VALUE, getField(startEvent, "deserializeAs"));
+  }
+
+  @Test
+  void getTypeWorksTest() {
+    setField(startEvent, "type", StartEventType.MESSAGE_CORRELATION);
+
+    assertEquals(StartEventType.MESSAGE_CORRELATION, startEvent.getType());
+  }
+
+  @Test
+  void setTypeWorksTest() {
+    setField(startEvent, "type", null);
+
+    startEvent.setType(StartEventType.MESSAGE_CORRELATION);
+    assertEquals(StartEventType.MESSAGE_CORRELATION, getField(startEvent, "type"));
+  }
+
+  @Test
+  void getExpressionWorksTest() {
+    setField(startEvent, "expression", VALUE);
+
+    assertEquals(VALUE, startEvent.getExpression());
+  }
+
+  @Test
+  void setExpressionWorksTest() {
+    setField(startEvent, "expression", null);
+
+    startEvent.setExpression(VALUE);
+    assertEquals(VALUE, getField(startEvent, "expression"));
+  }
+
+  @Test
+  void getInterruptingWorksTest() {
+    setField(startEvent, "interrupting", true);
+
+    assertEquals(true, startEvent.isInterrupting());
+  }
+
+  @Test
+  void setInterruptingWorksTest() {
+    setField(startEvent, "interrupting", false);
+
+    startEvent.setInterrupting(true);
+    assertEquals(true, getField(startEvent, "interrupting"));
+  }
+
+  @Test
+  void getAsyncBeforeWorksTest() {
+    setField(startEvent, "asyncBefore", true);
+
+    assertEquals(true, startEvent.isAsyncBefore());
+  }
+
+  @Test
+  void setAsyncBeforeWorksTest() {
+    setField(startEvent, "asyncBefore", false);
+
+    startEvent.setAsyncBefore(true);
+    assertEquals(true, getField(startEvent, "asyncBefore"));
+  }
+
+  private static class Impl extends StartEvent { };
+
+}

--- a/components/src/test/java/org/folio/rest/workflow/model/SubprocessTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/SubprocessTest.java
@@ -1,0 +1,172 @@
+package org.folio.rest.workflow.model;
+
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.folio.rest.workflow.enums.SubprocessType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SubprocessTest {
+
+  @Mock
+  private EmbeddedLoopReference embeddedLoopReference;
+
+  @Mock
+  private Node node;
+
+  private List<Node> nodes;
+
+  private Subprocess subprocess;
+
+  @BeforeEach
+  void beforeEach() {
+    subprocess = new Subprocess();
+    nodes = new ArrayList<>();
+    nodes.add(node);
+  }
+
+  @Test
+  void getIdWorksTest() {
+    setField(subprocess, "id", VALUE);
+
+    assertEquals(VALUE, subprocess.getId());
+  }
+
+  @Test
+  void setIdWorksTest() {
+    setField(subprocess, "id", null);
+
+    subprocess.setId(VALUE);
+    assertEquals(VALUE, getField(subprocess, "id"));
+  }
+
+  @Test
+  void getNameWorksTest() {
+    setField(subprocess, "name", VALUE);
+
+    assertEquals(VALUE, subprocess.getName());
+  }
+
+  @Test
+  void setNameWorksTest() {
+    setField(subprocess, "name", null);
+
+    subprocess.setName(VALUE);
+    assertEquals(VALUE, getField(subprocess, "name"));
+  }
+
+  @Test
+  void getDescriptionWorksTest() {
+    setField(subprocess, "description", VALUE);
+
+    assertEquals(VALUE, subprocess.getDescription());
+  }
+
+  @Test
+  void setDescriptionWorksTest() {
+    setField(subprocess, "description", null);
+
+    subprocess.setDescription(VALUE);
+    assertEquals(VALUE, getField(subprocess, "description"));
+  }
+
+  @Test
+  void getDeserializeAsWorksTest() {
+    setField(subprocess, "deserializeAs", VALUE);
+
+    assertEquals(VALUE, subprocess.getDeserializeAs());
+  }
+
+  @Test
+  void setDeserializeAsWorksTest() {
+    setField(subprocess, "deserializeAs", null);
+
+    subprocess.setDeserializeAs(VALUE);
+    assertEquals(VALUE, getField(subprocess, "deserializeAs"));
+  }
+
+  @Test
+  void getAsyncBeforeWorksTest() {
+    setField(subprocess, "asyncBefore", true);
+
+    assertEquals(true, subprocess.isAsyncBefore());
+  }
+
+  @Test
+  void setAsyncBeforeWorksTest() {
+    setField(subprocess, "asyncBefore", false);
+
+    subprocess.setAsyncBefore(true);
+    assertEquals(true, getField(subprocess, "asyncBefore"));
+  }
+
+  @Test
+  void getAsyncAfterWorksTest() {
+    setField(subprocess, "asyncAfter", true);
+
+    assertEquals(true, subprocess.isAsyncAfter());
+  }
+
+  @Test
+  void setAsyncAfterWorksTest() {
+    setField(subprocess, "asyncAfter", false);
+
+    subprocess.setAsyncAfter(true);
+    assertEquals(true, getField(subprocess, "asyncAfter"));
+  }
+
+  @Test
+  void getNodesWorksTest() {
+    setField(subprocess, "nodes", nodes);
+
+    assertEquals(nodes, subprocess.getNodes());
+  }
+
+  @Test
+  void setNodesWorksTest() {
+    setField(subprocess, "nodes", null);
+
+    subprocess.setNodes(nodes);
+    assertEquals(nodes, getField(subprocess, "nodes"));
+  }
+
+  @Test
+  void getTypeWorksTest() {
+    setField(subprocess, "type", SubprocessType.EMBEDDED);
+
+    assertEquals(SubprocessType.EMBEDDED, subprocess.getType());
+  }
+
+  @Test
+  void setTypeWorksTest() {
+    setField(subprocess, "type", null);
+
+    subprocess.setType(SubprocessType.EMBEDDED);
+    assertEquals(SubprocessType.EMBEDDED, getField(subprocess, "type"));
+  }
+
+  @Test
+  void getLoopRefWorksTest() {
+    setField(subprocess, "loopRef", embeddedLoopReference);
+
+    assertEquals(embeddedLoopReference, subprocess.getLoopRef());
+  }
+
+  @Test
+  void setLoopRefWorksTest() {
+    setField(subprocess, "loopRef", null);
+
+    subprocess.setLoopRef(embeddedLoopReference);
+    assertEquals(embeddedLoopReference, getField(subprocess, "loopRef"));
+  }
+
+}

--- a/components/src/test/java/org/folio/rest/workflow/model/WorkflowTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/WorkflowTest.java
@@ -1,0 +1,171 @@
+package org.folio.rest.workflow.model;
+
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class WorkflowTest {
+
+  @Mock
+  private Setup setup;
+
+  @Mock
+  private Node node;
+
+  private List<Node> nodes;
+
+  private Workflow workflow;
+
+  @BeforeEach
+  void beforeEach() {
+    workflow = new Workflow();
+    nodes = new ArrayList<>();
+    nodes.add(node);
+  }
+
+  @Test
+  void getIdWorksTest() {
+    setField(workflow, "id", VALUE);
+
+    assertEquals(VALUE, workflow.getId());
+  }
+
+  @Test
+  void setIdWorksTest() {
+    setField(workflow, "id", null);
+
+    workflow.setId(VALUE);
+    assertEquals(VALUE, getField(workflow, "id"));
+  }
+
+  @Test
+  void getNameWorksTest() {
+    setField(workflow, "name", VALUE);
+
+    assertEquals(VALUE, workflow.getName());
+  }
+
+  @Test
+  void setNameWorksTest() {
+    setField(workflow, "name", null);
+
+    workflow.setName(VALUE);
+    assertEquals(VALUE, getField(workflow, "name"));
+  }
+
+  @Test
+  void getDescriptionWorksTest() {
+    setField(workflow, "description", VALUE);
+
+    assertEquals(VALUE, workflow.getDescription());
+  }
+
+  @Test
+  void setDescriptionWorksTest() {
+    setField(workflow, "description", null);
+
+    workflow.setDescription(VALUE);
+    assertEquals(VALUE, getField(workflow, "description"));
+  }
+
+  @Test
+  void getNodesWorksTest() {
+    setField(workflow, "nodes", nodes);
+
+    assertEquals(nodes, workflow.getNodes());
+  }
+
+  @Test
+  void setNodesWorksTest() {
+    setField(workflow, "nodes", null);
+
+    workflow.setNodes(nodes);
+    assertEquals(nodes, getField(workflow, "nodes"));
+  }
+
+  @Test
+  void getVersionTagWorksTest() {
+    setField(workflow, "versionTag", VALUE);
+
+    assertEquals(VALUE, workflow.getVersionTag());
+  }
+
+  @Test
+  void setVersionTagWorksTest() {
+    setField(workflow, "versionTag", null);
+
+    workflow.setVersionTag(VALUE);
+    assertEquals(VALUE, getField(workflow, "versionTag"));
+  }
+
+  @Test
+  void getHistoryTimeToLiveWorksTest() {
+    setField(workflow, "historyTimeToLive", 1);
+
+    assertEquals(1, workflow.getHistoryTimeToLive());
+  }
+
+  @Test
+  void setHistoryTimeToLiveWorksTest() {
+    setField(workflow, "historyTimeToLive", null);
+
+    workflow.setHistoryTimeToLive(1);
+    assertEquals(1, getField(workflow, "historyTimeToLive"));
+  }
+
+  @Test
+  void getActiveWorksTest() {
+    setField(workflow, "active", true);
+
+    assertEquals(true, workflow.isActive());
+  }
+
+  @Test
+  void setActiveWorksTest() {
+    setField(workflow, "active", false);
+
+    workflow.setActive(true);
+    assertEquals(true, getField(workflow, "active"));
+  }
+
+  @Test
+  void getDeploymentIdWorksTest() {
+    setField(workflow, "deploymentId", VALUE);
+
+    assertEquals(VALUE, workflow.getDeploymentId());
+  }
+
+  @Test
+  void setDeploymentIdWorksTest() {
+    setField(workflow, "deploymentId", null);
+
+    workflow.setDeploymentId(VALUE);
+    assertEquals(VALUE, getField(workflow, "deploymentId"));
+  }
+
+  @Test
+  void getSetupWorksTest() {
+    setField(workflow, "setup", setup);
+
+    assertEquals(setup, workflow.getSetup());
+  }
+
+  @Test
+  void setSetupWorksTest() {
+    setField(workflow, "setup", null);
+
+    workflow.setSetup(setup);
+    assertEquals(setup, getField(workflow, "setup"));
+  }
+
+}

--- a/service/src/main/java/org/folio/rest/workflow/controller/WorkflowController.java
+++ b/service/src/main/java/org/folio/rest/workflow/controller/WorkflowController.java
@@ -57,7 +57,7 @@ public class WorkflowController {
   }
 
   @DeleteMapping(value = {"/{id}/delete", "/{id}/delete/"})
-  public ResponseEntity deleteWorkflow(
+  public ResponseEntity<Object> deleteWorkflow(
     @PathVariable String id,
     @TenantHeader String tenant,
     @TokenHeader String token

--- a/service/src/main/java/org/folio/rest/workflow/controller/WorkflowController.java
+++ b/service/src/main/java/org/folio/rest/workflow/controller/WorkflowController.java
@@ -57,7 +57,7 @@ public class WorkflowController {
   }
 
   @DeleteMapping(value = {"/{id}/delete", "/{id}/delete/"})
-  public ResponseEntity<?> deleteWorkflow(
+  public ResponseEntity deleteWorkflow(
     @PathVariable String id,
     @TenantHeader String tenant,
     @TokenHeader String token

--- a/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
@@ -240,7 +240,7 @@ public class WorkflowEngineService {
   private Workflow sendWorkflowRequest(WorkflowDto workflow, String requestPath, String tenant, String token)
       throws WorkflowEngineServiceException {
 
-    HttpEntity<WorkflowDto> entity = new HttpEntity<WorkflowDto>(workflow, headers(tenant, token));
+    HttpEntity<WorkflowDto> entity = new HttpEntity<>(workflow, headers(tenant, token));
     String url = String.format(requestPath, okapiUrl, basePath);
 
     try {


### PR DESCRIPTION
This helps resolve [MODWRKFLOW-18](https://folio-org.atlassian.net/browse/MODWRKFLOW-18).

The `spring-test` dependency is now added to the components pom.

The `maven-surefire-plugin` is now enabled for the components so that tests are actually run.

The unit tests exposed that several of the models are missing the `HasAsync` interface. This adds the `HasAsync` to the missing models and this change should not break anything.

Add all of the components model unit tests.