### PR TITLE
MODWRKFLOW-22: Add import end point that accepts FWZ format.

### DIFF
--- a/components/src/main/java/org/folio/rest/workflow/utility/CompressFileMagic.java
+++ b/components/src/main/java/org/folio/rest/workflow/utility/CompressFileMagic.java
@@ -1,0 +1,164 @@
+package org.folio.rest.workflow.utility;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import org.folio.rest.workflow.enums.CompressFileFormat;
+
+/**
+ * Provide functionality to detect file mime-types based on the magic headers.
+ *
+ * This approach is more reliable than detecting via file-extensions.
+ *
+ * @see <a href="https://en.wikipedia.org/wiki/List_of_file_signatures">(Wikipedia) List of Magic Headers</a>
+ */
+public class CompressFileMagic {
+
+  /**
+   * A minimum header size needed to perform the magic checks.
+   */
+  public static final int HEADER_SIZE = 4;
+
+  /**
+   * Magic header for the BZIP2 format.
+   */
+  public static final byte[] MAGIC_BZIP2 = { 0x42, 0x5A, 0x68 };
+
+  /**
+   * Magic header for the GZIP format.
+   */
+  public static final byte[] MAGIC_GZIP = { 0x1F, (byte) 0x8B };
+
+  /**
+   * Magic header for the ZIP format.
+   */
+  public static final byte[] MAGIC_ZIP = { 0x50, 0x4B, 0x03, 0x04 };
+
+  /**
+   * Magic header for the ZIP format that is empty.
+   */
+  public static final byte[] MAGIC_ZIP_EMPTY = { 0x50, 0x4B, 0x05, 0x06 };
+
+  /**
+   * Magic header for the ZIP format that is spanned.
+   */
+  public static final byte[] MAGIC_ZIP_SPAN = { 0x50, 0x4B, 0x07, 0x08 };
+
+  /**
+   * Detect if a string represents a BZIP2 format.
+   *
+   * @param input The string representing some of the initial bytes of a file.
+   *
+   * @return TRUE if the string represents the format and FALSE otherwise.
+   */
+  public static boolean isBzip2(byte[] input) {
+    if (input == null) {
+      return false;
+    }
+
+    return matchBytes(input, MAGIC_BZIP2);
+  }
+
+  /**
+   * Detect if a string represents a GZIP format.
+   *
+   * @param input The string representing some of the initial bytes of a file.
+   *
+   * @return TRUE if the string represents the format and FALSE otherwise.
+   */
+  public static boolean isGzip(byte[] input) {
+    if (input == null) {
+      return false;
+    }
+
+    return matchBytes(input, MAGIC_GZIP);
+  }
+
+  /**
+   * Detect if a string represents a ZIP format.
+   *
+   * @param input The string representing some of the initial bytes of a file.
+   *
+   * @return TRUE if the string represents the format and FALSE otherwise.
+   */
+  public static boolean isZip(byte[] input) {
+    if (input == null) {
+      return false;
+    }
+
+    if (matchBytes(input, MAGIC_ZIP)) {
+      return true;
+    }
+
+    if (matchBytes(input, MAGIC_ZIP_EMPTY)) {
+      return true;
+    }
+
+    if (matchBytes(input, MAGIC_ZIP_SPAN)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Detect a supported format from the file header.
+   *
+   * @param file The file being detected.
+   *
+   * @return A supported type on a successfull match and NULL otherwise.
+   *
+   * @throws IOException On error reading the file stream.
+   */
+  public static CompressFileFormat detectFormat(File file) throws IOException {
+    try (FileInputStream fis = new FileInputStream(file)) {
+      return detectFormat(fis);
+    }
+  }
+
+  /**
+   * Detect a supported format from the file header.
+   *
+   * @param inputStream A stream of the file being detected.
+   *
+   * @return A supported type on a successfull match and NULL otherwise.
+   *
+   * @throws IOException On error reading the file stream.
+   */
+  public static CompressFileFormat detectFormat(InputStream inputStream) throws IOException {
+    byte[] header = inputStream.readNBytes(HEADER_SIZE);
+
+    if (CompressFileMagic.isBzip2(header)) {
+      return CompressFileFormat.BZIP2;
+    }
+
+    if (CompressFileMagic.isGzip(header)) {
+      return CompressFileFormat.GZIP;
+    }
+
+    if (CompressFileMagic.isZip(header)) {
+      return CompressFileFormat.ZIP;
+    }
+
+    return null;
+  }
+
+  /**
+   * Determine if a byte sequence matches another.
+   *
+   * @param input The string representing some of the initial bytes of a file.
+   *
+   * @return TRUE if the string represents the format and FALSE otherwise.
+   */
+  private static boolean matchBytes(byte[] input, byte[] match) {
+    if (input.length < match.length) return false;
+
+    for (int i = 0; i < match.length; i++) {
+      if (input[i] != match[i]) return false;
+    }
+
+    return true;
+  }
+
+}

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -113,6 +113,12 @@
       <artifactId>lombok</artifactId>
       <scope>provided</scope>
     </dependency>
+
+    <dependency>
+       <groupId>org.apache.commons</groupId>
+       <artifactId>commons-compress</artifactId>
+       <version>1.26.1</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/service/src/main/java/org/folio/rest/workflow/SpringOkapiModule.java
+++ b/service/src/main/java/org/folio/rest/workflow/SpringOkapiModule.java
@@ -16,5 +16,4 @@ public class SpringOkapiModule extends SpringBootServletInitializer {
   public static void main(String[] args) {
     SpringApplication.run(SpringOkapiModule.class, args);
   }
-
 }

--- a/service/src/main/java/org/folio/rest/workflow/controller/WorkflowController.java
+++ b/service/src/main/java/org/folio/rest/workflow/controller/WorkflowController.java
@@ -1,11 +1,18 @@
 package org.folio.rest.workflow.controller;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.compress.archivers.ArchiveException;
+import org.apache.commons.compress.compressors.CompressorException;
 import org.folio.rest.workflow.exception.WorkflowEngineServiceException;
+import org.folio.rest.workflow.exception.WorkflowImportException;
 import org.folio.rest.workflow.model.Workflow;
 import org.folio.rest.workflow.service.WorkflowCqlService;
 import org.folio.rest.workflow.service.WorkflowEngineService;
+import org.folio.rest.workflow.service.WorkflowImportService;
 import org.folio.spring.tenant.annotation.TenantHeader;
 import org.folio.spring.web.annotation.TokenHeader;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,7 +26,9 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @RestController
@@ -30,10 +39,13 @@ public class WorkflowController {
 
   private WorkflowCqlService workflowCqlService;
 
+  private WorkflowImportService workflowImportService;
+
   @Autowired
-  public WorkflowController(WorkflowEngineService workflowEngineService, WorkflowCqlService workflowCqlService) {
+  public WorkflowController(WorkflowEngineService workflowEngineService, WorkflowCqlService workflowCqlService, WorkflowImportService workflowImportService) {
     this.workflowEngineService = workflowEngineService;
     this.workflowCqlService = workflowCqlService;
+    this.workflowImportService = workflowImportService;
   }
 
   @PutMapping(value = {"/{id}/activate", "/{id}/activate/"}, produces = { MediaType.APPLICATION_JSON_VALUE })
@@ -99,6 +111,21 @@ public class WorkflowController {
   ) {
     log.debug("Performing CQL search: {}, offset, limit", query, offset, limit);
     return workflowCqlService.findByCql(query, offset, limit);
+  }
+
+  @PostMapping(value = { "/import", "/import/" }, produces = { MediaType.APPLICATION_JSON_VALUE }, consumes = { MediaType.MULTIPART_FORM_DATA_VALUE })
+  public ResponseEntity<Object> importWorkflow(
+      @RequestPart(name = "file") MultipartFile fwz,
+      @TenantHeader String tenant,
+      @TokenHeader String token
+    ) throws URISyntaxException, IOException, CompressorException, ArchiveException, WorkflowImportException {
+
+    log.debug("Importing FWZ");
+
+    Workflow workflow = workflowImportService.importFile(fwz.getResource());
+    URI location = new URI(String.format("/workflows/%s", workflow.getId()));
+
+    return ResponseEntity.created(location).body(workflow);
   }
 
 }

--- a/service/src/main/java/org/folio/rest/workflow/exception/WorkflowImportAlreadyImported.java
+++ b/service/src/main/java/org/folio/rest/workflow/exception/WorkflowImportAlreadyImported.java
@@ -1,0 +1,17 @@
+package org.folio.rest.workflow.exception;
+
+public class WorkflowImportAlreadyImported extends WorkflowImportException {
+
+  private static final long serialVersionUID = -703730144353588622L;
+
+  private static final String MESSAGE = "The workflow cannot be imported because workflow '%s' is already imported.";
+
+  public WorkflowImportAlreadyImported(String id) {
+    super(String.format(MESSAGE, id));
+  }
+
+  public WorkflowImportAlreadyImported(String id, Exception e) {
+    super(String.format(MESSAGE, id), e);
+  }
+
+}

--- a/service/src/main/java/org/folio/rest/workflow/exception/WorkflowImportException.java
+++ b/service/src/main/java/org/folio/rest/workflow/exception/WorkflowImportException.java
@@ -1,0 +1,15 @@
+package org.folio.rest.workflow.exception;
+
+public class WorkflowImportException extends Exception {
+
+  private static final long serialVersionUID = 1481933564332490082L;
+
+  public WorkflowImportException(String message) {
+    super(message);
+  }
+
+  public WorkflowImportException(String message, Exception e) {
+    super(message, e);
+  }
+
+}

--- a/service/src/main/java/org/folio/rest/workflow/exception/WorkflowImportInvalidOrMissingProperty.java
+++ b/service/src/main/java/org/folio/rest/workflow/exception/WorkflowImportInvalidOrMissingProperty.java
@@ -1,0 +1,17 @@
+package org.folio.rest.workflow.exception;
+
+public class WorkflowImportInvalidOrMissingProperty extends WorkflowImportException {
+
+  private static final long serialVersionUID = -703730144353588622L;
+
+  private static final String MESSAGE = "The workflow cannot be imported because '%s' has an invalid or a missing property '%s'.";
+
+  public WorkflowImportInvalidOrMissingProperty(String name, String property) {
+    super(String.format(MESSAGE, name, property));
+  }
+
+  public WorkflowImportInvalidOrMissingProperty(String name, String property, Exception e) {
+    super(String.format(MESSAGE, name, property), e);
+  }
+
+}

--- a/service/src/main/java/org/folio/rest/workflow/exception/WorkflowImportJsonFileIsDirectory.java
+++ b/service/src/main/java/org/folio/rest/workflow/exception/WorkflowImportJsonFileIsDirectory.java
@@ -1,0 +1,17 @@
+package org.folio.rest.workflow.exception;
+
+public class WorkflowImportJsonFileIsDirectory extends WorkflowImportException {
+
+  private static final long serialVersionUID = -1861735040910804859L;
+
+  private static final String MESSAGE = "The workflow cannot be imported because the JSON file '%s' is a directory.";
+
+  public WorkflowImportJsonFileIsDirectory(String name) {
+    super(String.format(MESSAGE, name));
+  }
+
+  public WorkflowImportJsonFileIsDirectory(String name, Exception e) {
+    super(String.format(MESSAGE, name), e);
+  }
+
+}

--- a/service/src/main/java/org/folio/rest/workflow/exception/WorkflowImportRequiredFileMissing.java
+++ b/service/src/main/java/org/folio/rest/workflow/exception/WorkflowImportRequiredFileMissing.java
@@ -1,0 +1,17 @@
+package org.folio.rest.workflow.exception;
+
+public class WorkflowImportRequiredFileMissing extends WorkflowImportException {
+
+  private static final long serialVersionUID = -8957979238753187195L;
+
+  private static final String MESSAGE = "The workflow cannot be imported because the required file '%s' is missing.";
+
+  public WorkflowImportRequiredFileMissing(String name) {
+    super(String.format(MESSAGE, name));
+  }
+
+  public WorkflowImportRequiredFileMissing(String name, Exception e) {
+    super(String.format(MESSAGE, name), e);
+  }
+
+}

--- a/service/src/main/java/org/folio/rest/workflow/model/ExtractedWorkflow.java
+++ b/service/src/main/java/org/folio/rest/workflow/model/ExtractedWorkflow.java
@@ -1,0 +1,129 @@
+package org.folio.rest.workflow.model;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import lombok.Getter;
+
+/**
+ * A collection of Workflow Nodes for use during import.
+ */
+@Getter
+public class ExtractedWorkflow {
+
+  /**
+   * A string representing the "code" key.
+   */
+  public static final String CODE = "code";
+
+  /**
+   * A string representing the "deserializeAs" key.
+   */
+  public static final String DESERIALIZE_AS = "deserializeAs";
+
+  /**
+   * The name of the FWZ JSON file within the archive.
+   */
+  public static final String FWZ_JSON = "fwz.json";
+
+  /**
+   * A string representing the "id" key.
+   */
+  public static final String ID = "id";
+
+  /**
+   * The JavaScript type.
+   */
+  public static final String JAVASCRIPT = "javascript";
+
+  /**
+   * The JavaScript extension name.
+   */
+  public static final String JAVASCRIPT_EXT_NAME = "js";
+
+  /**
+   * The JSON extension.
+   */
+  public static final String JSON_EXT = ".json";
+
+  /**
+   * A string representing the "nodes" key.
+   */
+  public static final String NODES = "nodes";
+
+  /**
+   * The Python type.
+   */
+  public static final String PYTHON = "python";
+
+  /**
+   * The Python extension name.
+   */
+  public static final String PYTHON_EXT_NAME = "py";
+
+  /**
+   * The Ruby type.
+   */
+  public static final String RUBY = "ruby";
+
+  /**
+   * The Ruby extension name.
+   */
+  public static final String RUBY_EXT_NAME = "rb";
+
+  /**
+   * A string representing the "scriptFormat" key.
+   */
+  public static final String SCRIPT_FORMAT = "scriptFormat";
+
+  /**
+   * A string representing the "ScriptTask" Node type.
+   */
+  public static final String SCRIPT_TASK = "ScriptTask";
+
+  /**
+   * The name of the setup JSON file within the archive.
+   */
+  public static final String SETUP_JSON = "setup.json";
+
+  /**
+   * A string representing the "triggers" directory.
+   */
+  public static final String TRIGGERS = "triggers";
+
+  /**
+   * A string representing the "version" key.
+   */
+  public static final String VERSION = "version";
+
+  /**
+   * The version regex pattern supporting 1.0.* versions.
+   */
+  public static final Pattern VERSION_PATTERN_1_0 = Pattern.compile("^1\\.0(|\\.\\d+.*)$");
+
+  /**
+   * The name of the workflow JSON file within the archive.
+   */
+  public static final String WORKFLOW_JSON = "workflow.json";
+
+  private List<String> expanded;
+
+  private Map<String, JsonNode> required;
+
+  private Map<String, JsonNode> nodes;
+
+  private Map<String, JsonNode> triggers;
+
+  private Map<String, String> scripts;
+
+  public ExtractedWorkflow() {
+    expanded = new ArrayList<>();
+    required = new HashMap<>();
+    nodes = new HashMap<>();
+    triggers = new HashMap<>();
+    scripts = new HashMap<>();
+  }
+}

--- a/service/src/main/java/org/folio/rest/workflow/model/repo/NodeRepo.java
+++ b/service/src/main/java/org/folio/rest/workflow/model/repo/NodeRepo.java
@@ -5,6 +5,5 @@ import org.folio.spring.cql.JpaCqlRepository;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 @RepositoryRestResource
-public interface TaskRepo extends JpaCqlRepository<Node, String> {
-
+public interface NodeRepo extends JpaCqlRepository<Node, String> {
 }

--- a/service/src/main/java/org/folio/rest/workflow/model/repo/WorkflowRepo.java
+++ b/service/src/main/java/org/folio/rest/workflow/model/repo/WorkflowRepo.java
@@ -12,5 +12,9 @@ public interface WorkflowRepo extends JpaCqlRepository<Workflow, String> {
 
   @Override
   @RestResource(exported = false)
+  public boolean existsById(String id);
+
+  @Override
+  @RestResource(exported = false)
   public void deleteById(String id);
 }

--- a/service/src/main/java/org/folio/rest/workflow/service/WorkflowImportService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/WorkflowImportService.java
@@ -1,0 +1,537 @@
+package org.folio.rest.workflow.service;
+
+import static org.folio.rest.workflow.model.ExtractedWorkflow.CODE;
+import static org.folio.rest.workflow.model.ExtractedWorkflow.DESERIALIZE_AS;
+import static org.folio.rest.workflow.model.ExtractedWorkflow.FWZ_JSON;
+import static org.folio.rest.workflow.model.ExtractedWorkflow.ID;
+import static org.folio.rest.workflow.model.ExtractedWorkflow.JAVASCRIPT;
+import static org.folio.rest.workflow.model.ExtractedWorkflow.JAVASCRIPT_EXT_NAME;
+import static org.folio.rest.workflow.model.ExtractedWorkflow.JSON_EXT;
+import static org.folio.rest.workflow.model.ExtractedWorkflow.NODES;
+import static org.folio.rest.workflow.model.ExtractedWorkflow.PYTHON;
+import static org.folio.rest.workflow.model.ExtractedWorkflow.PYTHON_EXT_NAME;
+import static org.folio.rest.workflow.model.ExtractedWorkflow.RUBY;
+import static org.folio.rest.workflow.model.ExtractedWorkflow.RUBY_EXT_NAME;
+import static org.folio.rest.workflow.model.ExtractedWorkflow.SCRIPT_FORMAT;
+import static org.folio.rest.workflow.model.ExtractedWorkflow.SCRIPT_TASK;
+import static org.folio.rest.workflow.model.ExtractedWorkflow.SETUP_JSON;
+import static org.folio.rest.workflow.model.ExtractedWorkflow.TRIGGERS;
+import static org.folio.rest.workflow.model.ExtractedWorkflow.VERSION;
+import static org.folio.rest.workflow.model.ExtractedWorkflow.VERSION_PATTERN_1_0;
+import static org.folio.rest.workflow.model.ExtractedWorkflow.WORKFLOW_JSON;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.github.jknack.handlebars.internal.Files;
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.compress.archivers.ArchiveException;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarFile;
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipFile;
+import org.apache.commons.compress.compressors.CompressorException;
+import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+import org.apache.commons.compress.utils.SeekableInMemoryByteChannel;
+import org.folio.rest.workflow.enums.CompressFileFormat;
+import org.folio.rest.workflow.exception.WorkflowImportAlreadyImported;
+import org.folio.rest.workflow.exception.WorkflowImportException;
+import org.folio.rest.workflow.exception.WorkflowImportInvalidOrMissingProperty;
+import org.folio.rest.workflow.exception.WorkflowImportJsonFileIsDirectory;
+import org.folio.rest.workflow.exception.WorkflowImportRequiredFileMissing;
+import org.folio.rest.workflow.model.ExtractedWorkflow;
+import org.folio.rest.workflow.model.Node;
+import org.folio.rest.workflow.model.Trigger;
+import org.folio.rest.workflow.model.Workflow;
+import org.folio.rest.workflow.model.repo.NodeRepo;
+import org.folio.rest.workflow.model.repo.TriggerRepo;
+import org.folio.rest.workflow.model.repo.WorkflowRepo;
+import org.folio.rest.workflow.utility.CompressFileMagic;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class WorkflowImportService {
+
+  private ObjectMapper objectMapper;
+
+  private NodeRepo nodeRepo;
+
+  private TriggerRepo triggerRepo;
+
+  private WorkflowRepo workflowRepo;
+
+  @Autowired
+  public WorkflowImportService(ObjectMapper objectMapper, NodeRepo nodeRepo, TriggerRepo triggerRepo, WorkflowRepo workflowRepo) {
+    this.objectMapper = objectMapper;
+    this.nodeRepo = nodeRepo;
+    this.triggerRepo = triggerRepo;
+    this.workflowRepo = workflowRepo;
+  }
+
+  /**
+   * Import the given FWZ file, creating a new Workflow.
+   *
+   * Every format, except for the ZIP format, uses the TAR format as a container.
+   *
+   * @param fwz The file to import.
+   *
+   * @return The created Workflow.
+   *
+   * @throws ArchiveException On archive error.
+   * @throws CompressorException On compressor error.
+   * @throws IOException On error reading the file stream, extracting the JSON, or other such errors.
+   * @throws WorkflowImportException On import failure.
+   */
+  public Workflow importFile(Resource fwz) throws IOException, CompressorException, ArchiveException,
+      WorkflowImportException {
+
+    CompressFileFormat format = CompressFileMagic.detectFormat(fwz.getInputStream());
+
+    if (format != null) {
+      ExtractedWorkflow extracted = new ExtractedWorkflow();
+
+      switch (format) {
+        case BZIP2:
+          processTar(fwz, extracted, CompressFileFormat.BZIP2);
+          break;
+
+        case GZIP:
+          processTar(fwz, extracted, CompressFileFormat.GZIP);
+          break;
+
+        case ZIP:
+          processZip(fwz, extracted);
+          break;
+      }
+
+      if (!extracted.getRequired().containsKey(SETUP_JSON)) {
+        throw new WorkflowImportRequiredFileMissing(SETUP_JSON);
+      }
+
+      if (!extracted.getRequired().containsKey(WORKFLOW_JSON)) {
+        throw new WorkflowImportRequiredFileMissing(WORKFLOW_JSON);
+      }
+
+      collapseNodeScripts(extracted);
+      verifyExistence(extracted.getRequired().get(WORKFLOW_JSON));
+      expandWorkflow(extracted);
+      createTriggers(extracted.getTriggers());
+      createNodes(extracted.getNodes(), extracted.getExpanded());
+
+      return createWorkflow(extracted.getRequired().get(WORKFLOW_JSON));
+    }
+
+    throw new WorkflowImportException("Cannot import due to unknown FWZ compression format.");
+  }
+
+  /**
+   * Walk through each Node and merge any found scripts.
+   *
+   * @param extracted The extracted data.
+   *
+   * @throws WorkflowImportInvalidOrMissingProperty If a property is missing.
+   * @throws WorkflowImportRequiredFileMissing If the script file is not found.
+   * @throws JsonProcessingException On error processing the JSON.
+   */
+  private void collapseNodeScripts(ExtractedWorkflow extracted) throws WorkflowImportInvalidOrMissingProperty, WorkflowImportRequiredFileMissing, JsonProcessingException {
+    for (Entry<String, JsonNode> entry : extracted.getNodes().entrySet()) {
+      if (!entry.getValue().has(DESERIALIZE_AS)) {
+        continue;
+      }
+
+      if (entry.getValue().get(DESERIALIZE_AS).getNodeType() != JsonNodeType.STRING) {
+        throw new WorkflowImportInvalidOrMissingProperty(entry.getKey(), DESERIALIZE_AS);
+      }
+
+      String deserializeAs = entry.getValue().get(DESERIALIZE_AS).asText();
+      if (!SCRIPT_TASK.equalsIgnoreCase(deserializeAs)) {
+        continue;
+      }
+
+      if (!entry.getValue().has(SCRIPT_FORMAT) || entry.getValue().get(SCRIPT_FORMAT).getNodeType() != JsonNodeType.STRING) {
+        throw new WorkflowImportInvalidOrMissingProperty(entry.getKey(), SCRIPT_FORMAT);
+      }
+
+      if (!entry.getValue().has(CODE) || entry.getValue().get(CODE).getNodeType() != JsonNodeType.STRING) {
+        throw new WorkflowImportInvalidOrMissingProperty(entry.getKey(), CODE);
+      }
+
+      String scriptFormat = entry.getValue().get(SCRIPT_FORMAT).asText();
+      String fileName = entry.getValue().get(CODE).asText();
+      String extension = scriptFormat.toLowerCase().trim();
+
+      switch(scriptFormat) {
+        case JAVASCRIPT:
+          extension = JAVASCRIPT_EXT_NAME;
+          break;
+        case PYTHON:
+          extension = PYTHON_EXT_NAME;
+          break;
+        case RUBY:
+          extension = RUBY_EXT_NAME;
+          break;
+      }
+
+      String scriptPath = NODES + "/" + extension + "/" + fileName;
+      if (!extracted.getScripts().containsKey(scriptPath)) {
+        throw new WorkflowImportRequiredFileMissing(scriptPath);
+      }
+
+      String stringified = objectMapper.writeValueAsString(extracted.getScripts().get(scriptPath));
+
+      ((ObjectNode) entry.getValue()).put(CODE, stringified);
+    }
+  }
+
+  /**
+   * Create the Nodes in the database.
+   *
+   * @param nodes The Nodes to iterate over.
+   * @param expanded An array of IDs of nodes representing the top-down order of creation.
+   *
+   * @throws JsonProcessingException On JSON parse failure.
+   * @throws JsonMappingException On JSON mapping failure.
+   */
+  private void createNodes(Map<String, JsonNode> nodes, List<String> expanded) throws JsonMappingException, JsonProcessingException {
+    for (String uuid : expanded) {
+      Node node = objectMapper.readValue(nodes.get(uuid).toString(), Node.class);
+      nodeRepo.save(node);
+    }
+  }
+
+  /**
+   * Create the Triggers in the database.
+   *
+   * @param triggers The Triggers to iterate over.
+   *
+   * @throws JsonProcessingException On JSON parse failure.
+   * @throws JsonMappingException On JSON mapping failure.
+   */
+  private void createTriggers(Map<String, JsonNode> triggers) throws JsonMappingException, JsonProcessingException {
+    for (JsonNode triggerNode : triggers.values()) {
+      Trigger trigger = objectMapper.readValue(triggerNode.toString(), Trigger.class);
+      triggerRepo.save(trigger);
+    }
+  }
+
+  /**
+   * Create the Workflow in the database.
+   *
+   * @param workflowJson The Workflow JSON to save.
+   *
+   * @return The created Workflow.
+   *
+   * @throws JsonProcessingException On JSON parse failure.
+   * @throws JsonMappingException On JSON mapping failure.
+   */
+  private Workflow createWorkflow(JsonNode workflowJson) throws JsonMappingException, JsonProcessingException {
+    Workflow workflow = objectMapper.readValue(workflowJson.toString(), Workflow.class);
+    return workflowRepo.save(workflow);
+  }
+
+  /**
+   * Extract the Nodes and Scripts from the archive.
+   *
+   * @param name The file being processed.
+   * @param pathParts The array of path parts.
+   * @param inputStream The input stream to use.
+   * @param extracted The extracted data.
+   * @param isDirectory Designate the the entry is a directory.
+   *
+   * @throws IOException On error reading the file stream, extracting the JSON, or other such errors.
+   * @throws WorkflowImportException On import failure.
+   */
+  private void extractNodesAndScripts(String name, InputStream inputStream, ExtractedWorkflow extracted, boolean isDirectory) throws IOException, WorkflowImportException {
+    String[] pathParts = name.split("/", 4);
+
+    if (!verifyPathParts(name, pathParts)) {
+      return;
+    }
+
+    if (pathParts.length == 1 || pathParts.length == 2) {
+      if (pathParts[pathParts.length - 1].endsWith(JSON_EXT)) {
+        if (isDirectory) {
+          throw new WorkflowImportJsonFileIsDirectory(name);
+        }
+
+        if (pathParts.length == 1) {
+          if (FWZ_JSON.equalsIgnoreCase(name)) {
+            extracted.getRequired().put(FWZ_JSON, objectMapper.readTree(inputStream));
+
+            verifyVersion(extracted.getRequired().get(FWZ_JSON));
+          } else if (WORKFLOW_JSON.equalsIgnoreCase(name)) {
+            extracted.getRequired().put(WORKFLOW_JSON, objectMapper.readTree(inputStream));
+          } else if (SETUP_JSON.equalsIgnoreCase(name)) {
+            extracted.getRequired().put(SETUP_JSON, objectMapper.readTree(inputStream));
+          } else {
+            warnOnUnknownFileOrDir(name);
+          }
+        } else {
+          JsonNode json = objectMapper.readTree(inputStream);
+
+          if (!json.has(ID) || json.get(ID).getNodeType() != JsonNodeType.STRING) {
+            throw new WorkflowImportInvalidOrMissingProperty(name, ID);
+          }
+
+          if (!json.has(DESERIALIZE_AS) || json.get(DESERIALIZE_AS).getNodeType() != JsonNodeType.STRING) {
+            throw new WorkflowImportInvalidOrMissingProperty(name, DESERIALIZE_AS);
+          }
+
+          if (pathParts[0].equalsIgnoreCase(NODES)) {
+            extracted.getNodes().put(json.get(ID).asText(), json);
+          } else {
+            extracted.getTriggers().put(json.get(ID).asText(), json);
+          }
+        }
+      } else if (!isDirectory) {
+         warnOnUnknownFileOrDir(name);
+      }
+    } else {
+      if (pathParts[0].equalsIgnoreCase(NODES)) {
+        String script = Files.read(inputStream, StandardCharsets.UTF_8);
+        extracted.getScripts().put(name, script);
+      } else {
+        warnOnUnknownFileOrDir(name);
+      }
+    }
+  }
+
+  /**
+   * Replace the strings representing a Node with the actual Node for all Nodes.
+   *
+   * The expanded array effectively becomes a top-down dependency hierarchy order.
+   *
+   * @param extracted The extracted data.
+   *
+   * @throws JsonProcessingException On JSON parse failure.
+   * @throws JsonMappingException On JSON mapping failure.
+   * @throws WorkflowImportInvalidOrMissingProperty On invalid property.
+   */
+  private void expandWorkflow(ExtractedWorkflow extracted) throws JsonMappingException, JsonProcessingException, WorkflowImportInvalidOrMissingProperty {
+    for (JsonNode node : extracted.getNodes().values()) {
+      expandNode(extracted.getNodes(), node, extracted.getExpanded());
+    }
+
+    JsonNode workflowNode = extracted.getRequired().get(WORKFLOW_JSON);
+    String workflowId = workflowNode.get(ID).asText();
+
+    // The expandNode() method requires the Workflow to be on the getNodes(), so temporarily add it.
+    extracted.getNodes().put(workflowId, extracted.getRequired().get(WORKFLOW_JSON));
+
+    expandNode(extracted.getNodes(), extracted.getRequired().get(WORKFLOW_JSON), extracted.getExpanded());
+
+    extracted.getNodes().remove(workflowId);
+    extracted.getExpanded().remove(workflowId);
+  }
+
+  /**
+   * Replace the strings representing a Node with the actual Node for all Nodes.
+   *
+   * The expanded array effectively becomes a top-down dependency hierarchy order.
+   *
+   * @param nodes The collection of all known Nodes.
+   * @param node The node to process.
+   * @param expanded An array of IDs of nodes that have already been expanded.
+   *
+   * @throws JsonProcessingException On JSON parse failure.
+   * @throws JsonMappingException On JSON mapping failure.
+   * @throws WorkflowImportInvalidOrMissingProperty On invalid property.
+   */
+  private void expandNode(Map<String, JsonNode> nodes, JsonNode node, List<String> expanded) throws JsonMappingException, JsonProcessingException, WorkflowImportInvalidOrMissingProperty {
+    String nodeId = node.get(ID).asText();
+    if (expanded.contains(nodeId)) {
+      return;
+    }
+
+    if (node.has(NODES)) {
+      if (!node.get(NODES).isArray()) {
+        throw new WorkflowImportInvalidOrMissingProperty(nodeId, NODES);
+      }
+
+      ArrayNode expandedNodes = objectMapper.createArrayNode();
+      String[] values = objectMapper.readValue(node.get(NODES).toString(), String[].class);
+
+      for (String value : values) {
+        String[] parts = value.split("/");
+        if (parts.length == 0) {
+          throw new WorkflowImportInvalidOrMissingProperty(nodeId, NODES);
+        }
+
+        String uuid = parts[parts.length - 1];
+        expandNode(nodes, nodes.get(uuid), expanded);
+        expandedNodes.add(nodes.get(uuid));
+      }
+
+      ((ObjectNode) node).set(NODES, expandedNodes);
+    }
+
+    expanded.add(nodeId);
+  }
+
+  /**
+   * Get the compression input stream based on the given format for TAR containers.
+   *
+   * @param inputStream The stream to de-compress.
+   * @param format The compression format.
+   *
+   * @return An input stream based on the compression format.
+   *
+   * @throws IOException On failure to build the input stream.
+   * @throws WorkflowImportException On import failure.
+   */
+  private InputStream getCompressorInputStream(InputStream inputStream, CompressFileFormat format) throws IOException, WorkflowImportException {
+    if (CompressFileFormat.BZIP2.equals(format)) {
+      return new BZip2CompressorInputStream(inputStream);
+    }
+
+    if (CompressFileFormat.GZIP.equals(format)) {
+      return new GzipCompressorInputStream(inputStream);
+    }
+
+    throw new WorkflowImportException(String.format("Unknown compression format '%s'.", format));
+  }
+
+  /**
+   * Process the FWZ file for TAR formats.
+   *
+   * @param fwz The resource representing the FWZ JSON file.
+   * @param extracted The extracted data.
+   * @param format The compression format.
+   *
+   * @throws ArchiveException On archive error.
+   * @throws CompressorException On compressor error.
+   * @throws IOException On error reading the file stream, extracting the JSON, or other such errors.
+   * @throws WorkflowImportException On import failure.
+   */
+  private void processTar(Resource fwz, ExtractedWorkflow extracted, CompressFileFormat format) throws CompressorException, ArchiveException,
+      IOException, WorkflowImportException {
+
+    try (BufferedInputStream buffer = new BufferedInputStream(fwz.getInputStream());
+          InputStream compressed = getCompressorInputStream(buffer, format);
+          TarFile tarFile = new TarFile(compressed.readAllBytes());
+        ) {
+
+      for (TarArchiveEntry entry : tarFile.getEntries()) {
+        extractNodesAndScripts(entry.getName(), tarFile.getInputStream(entry), extracted, entry.isDirectory());
+      }
+    }
+  }
+
+  /**
+   * Process the FWZ file for a ZIP format.
+   *
+   * @param fwz The resource representing the FWZ file.
+   * @param extracted The extracted data.
+   *
+   * @throws IOException On error reading the file stream, extracting the JSON, or other such errors.
+   * @throws WorkflowImportException On import failure.
+   */
+  private void processZip(Resource fwz, ExtractedWorkflow extracted) throws IOException, WorkflowImportException {
+    try (SeekableInMemoryByteChannel channel = new SeekableInMemoryByteChannel(fwz.getInputStream().readAllBytes());
+          ZipFile zipFile = ZipFile.builder()
+            .setSeekableByteChannel(channel).get();
+        ) {
+
+      Enumeration<ZipArchiveEntry> entries = zipFile.getEntries();
+
+      while (entries.hasMoreElements()) {
+        ZipArchiveEntry entry = entries.nextElement();
+        extractNodesAndScripts(entry.getName(), zipFile.getInputStream(entry), extracted, entry.isDirectory());
+      }
+    }
+  }
+
+  /**
+   * Get the Workflow UUID and Verify the existence of the Workflow.
+   *
+   * @param json The JSON data representing the Workflow.
+   *
+   * @throws WorkflowImportException On import failure.
+   */
+  private void verifyExistence(JsonNode json) throws WorkflowImportException {
+    if (!json.has(ID) || json.get(ID) == null) {
+      throw new WorkflowImportInvalidOrMissingProperty(null, ID);
+    }
+
+    String id = json.get(ID).asText();
+
+    if (workflowRepo.existsById(id)) {
+      throw new WorkflowImportAlreadyImported(id);
+    }
+  }
+
+  /**
+   * Verify that the path parts are valid.
+   *
+   * @param name The file being processed.
+   * @param pathParts The array of path parts.
+   *
+   * @return TRUE if the paths are valid and FALSE otherwise.
+   */
+  private boolean verifyPathParts(String name, String[] pathParts) {
+    if (pathParts.length == 1) {
+      if (!FWZ_JSON.equalsIgnoreCase(pathParts[0]) && !SETUP_JSON.equalsIgnoreCase(pathParts[0]) && !WORKFLOW_JSON.equalsIgnoreCase(pathParts[0])) {
+        if (!pathParts[0].equalsIgnoreCase(NODES) && !pathParts[0].equalsIgnoreCase(TRIGGERS)) {
+          warnOnUnknownFileOrDir(name);
+        }
+
+        return false;
+      }
+    } else if (pathParts.length == 0) {
+      return false;
+    } else {
+      if (!pathParts[0].equalsIgnoreCase(NODES) && !pathParts[0].equalsIgnoreCase(TRIGGERS) || pathParts.length > 3) {
+        warnOnUnknownFileOrDir(name);
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Given fwz.json data, verify that the version is known.
+   *
+   * This only prints a warning for unknown versions.
+   * Future implementations of this may potentially throw exceptions.
+   *
+   * @param json The JSON data representing the Workflow.
+   */
+  private void verifyVersion(JsonNode json) {
+    if (json.has(VERSION)) {
+      String version = json.get(VERSION).asText();
+
+      if (!VERSION_PATTERN_1_0.matcher(version).matches()) {
+        log.warn("Unknown version '{}', attempting import anyway.", version);
+      }
+    } else {
+      log.warn("No version is specified, attempting import anyway.");
+    }
+  }
+
+  /**
+   * Print warning for unknown file or directory.
+   *
+   * @param name The name of the unknown file or directory.
+   */
+  private void warnOnUnknownFileOrDir(String name) {
+    log.warn("Ignoring unknown file or directory: '{}'.", name);
+  }
+
+}

--- a/service/src/test/java/org/folio/rest/workflow/controller/WorkflowControllerTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/controller/WorkflowControllerTest.java
@@ -37,6 +37,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
@@ -51,6 +52,7 @@ import java.util.stream.Stream;
 import org.folio.rest.workflow.model.Workflow;
 import org.folio.rest.workflow.service.WorkflowCqlService;
 import org.folio.rest.workflow.service.WorkflowEngineService;
+import org.folio.rest.workflow.service.WorkflowImportService;
 import org.folio.spring.tenant.properties.TenantProperties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -61,8 +63,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -78,6 +82,8 @@ class WorkflowControllerTest {
 
   private static final String PATH = "/workflows";
 
+  private static final String PATH_IMPORT = PATH + "/import";
+
   private static final String PATH_SEARCH = PATH + "/search";
 
   private static final String OFFSET = "offset";
@@ -87,6 +93,8 @@ class WorkflowControllerTest {
   private static final String LIMIT = "limit";
 
   private static final String LIMIT_VALUE = "100";
+
+  private static final String MULTIPART_FORM = MediaType.MULTIPART_FORM_DATA_VALUE;
 
   private static final String QUERY = "query";
 
@@ -152,6 +160,9 @@ class WorkflowControllerTest {
 
   @MockBean
   private WorkflowEngineService workflowEngineService;
+
+  @MockBean
+  private WorkflowImportService workflowImportService;
 
   @MockBean
   private TenantProperties tenantProperties;
@@ -325,6 +336,37 @@ class WorkflowControllerTest {
       .andDo(log()).andExpect(status().is(status));
   }
 
+  @ParameterizedTest
+  @MethodSource("provideHeadersBodyStatusForImportWorkflows")
+  void importWorkflowsTest(HttpHeaders headers, String contentType, String accept, MediaType mediaType, MultiValueMap<String, String> parameters, String body, int status) throws Exception {
+    Workflow workflow = new Workflow();
+    workflow.setId(UUID);
+
+    MockMultipartFile exampleFwz = new MockMultipartFile("file", "example.fwz", APP_JSON, JSON_OBJECT.getBytes());
+
+    lenient().when(workflowImportService.importFile(any(Resource.class))).thenReturn(workflow);
+
+    MockHttpServletRequestBuilder request = appendHeaders(multipart(PATH_IMPORT).file(exampleFwz), headers, contentType, accept);
+    request = appendParameters(request, parameters);
+
+    MvcResult result = mvc.perform(appendBody(request, body))
+      .andDo(log()).andExpect(status().is(status)).andReturn();
+
+    if (status == 200) {
+      MediaType responseType = MediaType.parseMediaType(result.getResponse().getContentType());
+
+      assertTrue(mediaType.isCompatibleWith(responseType));
+      assertEquals(workflow, result.getResponse().getContentAsString());
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideDeleteGetPatchPutForImportWorkflows")
+  void importWorkflowsFailsTest(Method method, HttpHeaders headers, String contentType, String accept, MediaType mediaType, MultiValueMap<String, String> parameters, String body, int status) throws Exception {
+    mvc.perform(invokeRequestBuilder(PATH_IMPORT, method, headers, contentType, accept, parameters, body))
+      .andDo(log()).andExpect(status().is(status));
+  }
+
   /**
    * Helper function for parameterized test providing DELETE, PATCH, POST, and PUT for search workflows end point.
    *
@@ -346,6 +388,29 @@ class WorkflowControllerTest {
     Object[] params = { NO_PARAM, LIM_PARAM, OFF_LIM_PARAM, OFF_PARAM };
 
     return buildHttpDeletePatchPostPut(OKAPI_HEAD_NO_URL, params);
+  }
+
+  /**
+   * Helper function for parameterized test providing DELETE, PATCH, POST, and PUT for search workflows end point.
+   *
+   * @return
+   *   The arguments array stream with the stream columns as:
+   *     - Method The (reflection) request method.
+   *     - HttpHeaders headers.
+   *     - String contentType (Content-Type request).
+   *     - String accept (ask for this Content-Type on response).
+   *       String mediaType (response Content-Type).
+   *     - MultiValueMap<String, String> parameters.
+   *     - String body (request body).
+   *     - int status (response HTTP status code).
+   *
+   * @throws NoSuchMethodException
+   * @throws SecurityException
+   */
+  private static Stream<Arguments> provideDeleteGetPatchPutForImportWorkflows() throws NoSuchMethodException, SecurityException {
+    Object[] params = { NO_PARAM };
+
+    return buildHttpDeleteGetPatchPut(OKAPI_HEAD_NO_URL, params);
   }
 
   /**
@@ -643,6 +708,54 @@ class WorkflowControllerTest {
 
     Stream<Arguments> stream2 = Stream.concat(stream1, buildAppJsonBodyStatus(OKAPI_HEAD_TOKEN, params));
     return Stream.concat(stream2, buildAppJsonBodyStatus(OKAPI_HEAD_TENANT, params));
+  }
+
+  /**
+   * Helper function for parameterized test providing tests with headers, body, and status for search workflows end point.
+   *
+   * This is intended to be used for when the correct HTTP method is being used in the request.
+   *
+   * @return
+   *   The arguments array stream with the stream columns as:
+   *     - HttpHeaders headers.
+   *     - String contentType (Content-Type request).
+   *     - String accept (ask for this Content-Type on response).
+   *       String mediaType (response Content-Type).
+   *     - MultiValueMap<String, String> parameters.
+   *     - String body (request body).
+   *     - int status (response HTTP status code).
+   */
+  private static Stream<Arguments> provideHeadersBodyStatusForImportWorkflows() {
+    return Stream.of(
+      Arguments.of(OKAPI_HEAD_TENANT, APP_JSON,       APP_SCHEMA, MT_APP_JSON, NO_PARAM, JSON_OBJECT, 415),
+      Arguments.of(OKAPI_HEAD_TENANT, APP_JSON,       APP_JSON,   MT_APP_JSON, NO_PARAM, JSON_OBJECT, 415),
+      Arguments.of(OKAPI_HEAD_TENANT, APP_JSON,       TEXT_PLAIN, MT_APP_JSON, NO_PARAM, JSON_OBJECT, 415),
+      Arguments.of(OKAPI_HEAD_TENANT, APP_JSON,       APP_STREAM, MT_APP_JSON, NO_PARAM, JSON_OBJECT, 415),
+      Arguments.of(OKAPI_HEAD_TENANT, APP_JSON,       NULL_STR,   MT_APP_JSON, NO_PARAM, JSON_OBJECT, 415),
+      Arguments.of(OKAPI_HEAD_TENANT, APP_JSON,       APP_STAR,   MT_APP_JSON, NO_PARAM, JSON_OBJECT, 415),
+      Arguments.of(OKAPI_HEAD_TENANT, APP_JSON,       STAR,       MT_APP_JSON, NO_PARAM, JSON_OBJECT, 415),
+      Arguments.of(OKAPI_HEAD_TENANT, TEXT_PLAIN,     APP_SCHEMA, MT_APP_JSON, NO_PARAM, PLAIN_BODY,  415),
+      Arguments.of(OKAPI_HEAD_TENANT, TEXT_PLAIN,     APP_JSON,   MT_APP_JSON, NO_PARAM, PLAIN_BODY,  415),
+      Arguments.of(OKAPI_HEAD_TENANT, TEXT_PLAIN,     TEXT_PLAIN, MT_APP_JSON, NO_PARAM, PLAIN_BODY,  415),
+      Arguments.of(OKAPI_HEAD_TENANT, TEXT_PLAIN,     APP_STREAM, MT_APP_JSON, NO_PARAM, PLAIN_BODY,  415),
+      Arguments.of(OKAPI_HEAD_TENANT, TEXT_PLAIN,     NULL_STR,   MT_APP_JSON, NO_PARAM, PLAIN_BODY,  415),
+      Arguments.of(OKAPI_HEAD_TENANT, TEXT_PLAIN,     STAR,       MT_APP_JSON, NO_PARAM, PLAIN_BODY,  415),
+      Arguments.of(OKAPI_HEAD_TENANT, TEXT_PLAIN,     APP_STAR,   MT_APP_JSON, NO_PARAM, PLAIN_BODY,  415),
+      Arguments.of(OKAPI_HEAD_TENANT, APP_STREAM,     APP_SCHEMA, MT_APP_JSON, NO_PARAM, JSON_OBJECT, 415),
+      Arguments.of(OKAPI_HEAD_TENANT, APP_STREAM,     APP_JSON,   MT_APP_JSON, NO_PARAM, JSON_OBJECT, 415),
+      Arguments.of(OKAPI_HEAD_TENANT, APP_STREAM,     TEXT_PLAIN, MT_APP_JSON, NO_PARAM, JSON_OBJECT, 415),
+      Arguments.of(OKAPI_HEAD_TENANT, APP_STREAM,     APP_STREAM, MT_APP_JSON, NO_PARAM, JSON_OBJECT, 415),
+      Arguments.of(OKAPI_HEAD_TENANT, APP_STREAM,     NULL_STR,   MT_APP_JSON, NO_PARAM, JSON_OBJECT, 415),
+      Arguments.of(OKAPI_HEAD_TENANT, APP_STREAM,     APP_STAR,   MT_APP_JSON, NO_PARAM, JSON_OBJECT, 415),
+      Arguments.of(OKAPI_HEAD_TENANT, APP_STREAM,     STAR,       MT_APP_JSON, NO_PARAM, JSON_OBJECT, 415),
+      Arguments.of(OKAPI_HEAD_TENANT, MULTIPART_FORM, APP_SCHEMA, MT_APP_JSON, NO_PARAM, JSON_OBJECT, 406),
+      Arguments.of(OKAPI_HEAD_TENANT, MULTIPART_FORM, APP_JSON,   MT_APP_JSON, NO_PARAM, JSON_OBJECT, 201),
+      Arguments.of(OKAPI_HEAD_TENANT, MULTIPART_FORM, TEXT_PLAIN, MT_APP_JSON, NO_PARAM, JSON_OBJECT, 406),
+      Arguments.of(OKAPI_HEAD_TENANT, MULTIPART_FORM, APP_STREAM, MT_APP_JSON, NO_PARAM, JSON_OBJECT, 406),
+      Arguments.of(OKAPI_HEAD_TENANT, MULTIPART_FORM, NULL_STR,   MT_APP_JSON, NO_PARAM, JSON_OBJECT, 201),
+      Arguments.of(OKAPI_HEAD_TENANT, MULTIPART_FORM, APP_STAR,   MT_APP_JSON, NO_PARAM, JSON_OBJECT, 201),
+      Arguments.of(OKAPI_HEAD_TENANT, MULTIPART_FORM, STAR,       MT_APP_JSON, NO_PARAM, JSON_OBJECT, 201)
+    );
   }
 
   /**

--- a/service/src/test/java/org/folio/rest/workflow/exception/WorkflowImportAlreadyImportedTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/exception/WorkflowImportAlreadyImportedTest.java
@@ -1,0 +1,33 @@
+package org.folio.rest.workflow.exception;
+
+import static org.folio.spring.test.mock.MockMvcConstant.UUID;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class WorkflowImportAlreadyImportedTest {
+
+  @Test
+  void workflowImportAlreadyImportedWorksTest() throws IOException {
+    WorkflowImportAlreadyImported exception = Assertions.assertThrows(WorkflowImportAlreadyImported.class, () -> {
+      throw new WorkflowImportAlreadyImported(UUID);
+    });
+
+    assertNotNull(exception);
+    assertTrue(exception.getMessage().contains(UUID));
+  }
+
+  @Test
+  void workflowImportAlreadyImportedWorksWithChildExceptionTest() throws IOException {
+    WorkflowImportAlreadyImported exception = Assertions.assertThrows(WorkflowImportAlreadyImported.class, () -> {
+      throw new WorkflowImportAlreadyImported(UUID, new RuntimeException("Additional Exception"));
+    });
+
+    assertNotNull(exception);
+    assertTrue(exception.getMessage().contains(UUID));
+  }
+
+}

--- a/service/src/test/java/org/folio/rest/workflow/exception/WorkflowImportExceptionTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/exception/WorkflowImportExceptionTest.java
@@ -1,0 +1,33 @@
+package org.folio.rest.workflow.exception;
+
+import static org.folio.spring.test.mock.MockMvcConstant.UUID;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class WorkflowImportExceptionTest {
+
+  @Test
+  void workflowImportExceptionWorksTest() throws IOException {
+    WorkflowImportException exception = Assertions.assertThrows(WorkflowImportException.class, () -> {
+      throw new WorkflowImportException(UUID);
+    });
+
+    assertNotNull(exception);
+    assertTrue(exception.getMessage().contains(UUID));
+  }
+
+  @Test
+  void workflowImportExceptionWorksWithChildExceptionTest() throws IOException {
+    WorkflowImportException exception = Assertions.assertThrows(WorkflowImportException.class, () -> {
+      throw new WorkflowImportException(UUID, new RuntimeException("Additional Exception"));
+    });
+
+    assertNotNull(exception);
+    assertTrue(exception.getMessage().contains(UUID));
+  }
+
+}

--- a/service/src/test/java/org/folio/rest/workflow/exception/WorkflowImportInvalidOrMissingPropertyTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/exception/WorkflowImportInvalidOrMissingPropertyTest.java
@@ -1,0 +1,36 @@
+package org.folio.rest.workflow.exception;
+
+import static org.folio.spring.test.mock.MockMvcConstant.URL;
+import static org.folio.spring.test.mock.MockMvcConstant.UUID;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class WorkflowImportInvalidOrMissingPropertyTest {
+
+  @Test
+  void workflowImportInvalidOrMissingPropertyWorksTest() throws IOException {
+    WorkflowImportInvalidOrMissingProperty exception = Assertions.assertThrows(WorkflowImportInvalidOrMissingProperty.class, () -> {
+      throw new WorkflowImportInvalidOrMissingProperty(UUID, URL);
+    });
+
+    assertNotNull(exception);
+    assertTrue(exception.getMessage().contains(UUID));
+    assertTrue(exception.getMessage().contains(URL));
+  }
+
+  @Test
+  void workflowImportInvalidOrMissingPropertyWorksWithChildExceptionTest() throws IOException {
+    WorkflowImportInvalidOrMissingProperty exception = Assertions.assertThrows(WorkflowImportInvalidOrMissingProperty.class, () -> {
+      throw new WorkflowImportInvalidOrMissingProperty(UUID, URL, new RuntimeException("Additional Exception"));
+    });
+
+    assertNotNull(exception);
+    assertTrue(exception.getMessage().contains(UUID));
+    assertTrue(exception.getMessage().contains(URL));
+  }
+
+}

--- a/service/src/test/java/org/folio/rest/workflow/exception/WorkflowImportJsonFileIsDirectoryTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/exception/WorkflowImportJsonFileIsDirectoryTest.java
@@ -1,0 +1,33 @@
+package org.folio.rest.workflow.exception;
+
+import static org.folio.spring.test.mock.MockMvcConstant.UUID;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class WorkflowImportJsonFileIsDirectoryTest {
+
+  @Test
+  void workflowImportJsonFileIsDirectoryWorksTest() throws IOException {
+    WorkflowImportJsonFileIsDirectory exception = Assertions.assertThrows(WorkflowImportJsonFileIsDirectory.class, () -> {
+      throw new WorkflowImportJsonFileIsDirectory(UUID);
+    });
+
+    assertNotNull(exception);
+    assertTrue(exception.getMessage().contains(UUID));
+  }
+
+  @Test
+  void workflowImportJsonFileIsDirectoryWorksWithChildExceptionTest() throws IOException {
+    WorkflowImportJsonFileIsDirectory exception = Assertions.assertThrows(WorkflowImportJsonFileIsDirectory.class, () -> {
+      throw new WorkflowImportJsonFileIsDirectory(UUID, new RuntimeException("Additional Exception"));
+    });
+
+    assertNotNull(exception);
+    assertTrue(exception.getMessage().contains(UUID));
+  }
+
+}

--- a/service/src/test/java/org/folio/rest/workflow/exception/WorkflowImportRequiredFileMissingTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/exception/WorkflowImportRequiredFileMissingTest.java
@@ -1,0 +1,33 @@
+package org.folio.rest.workflow.exception;
+
+import static org.folio.spring.test.mock.MockMvcConstant.UUID;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class WorkflowImportRequiredFileMissingTest {
+
+  @Test
+  void workflowImportRequiredFileMissingWorksTest() throws IOException {
+    WorkflowImportRequiredFileMissing exception = Assertions.assertThrows(WorkflowImportRequiredFileMissing.class, () -> {
+      throw new WorkflowImportRequiredFileMissing(UUID);
+    });
+
+    assertNotNull(exception);
+    assertTrue(exception.getMessage().contains(UUID));
+  }
+
+  @Test
+  void workflowImportRequiredFileMissingWorksWithChildExceptionTest() throws IOException {
+    WorkflowImportRequiredFileMissing exception = Assertions.assertThrows(WorkflowImportRequiredFileMissing.class, () -> {
+      throw new WorkflowImportRequiredFileMissing(UUID, new RuntimeException("Additional Exception"));
+    });
+
+    assertNotNull(exception);
+    assertTrue(exception.getMessage().contains(UUID));
+  }
+
+}


### PR DESCRIPTION
resolves [MODWRKFLOW-22](https://folio-org.atlassian.net/browse/MODWRKFLOW-21)

This implements a custom mime-type detector that avoids bringing in additional dependencies (`CompressFileMagic.java`).
Use a miime-type detection based on Wikipedia mime-types database.

Bring in Apache Commons Compress dependency to perform the archive extraction and manipulation.

Rename the `TaskRepo` to `NodeRepo` so as to be less confusing.
This fixing an incomplete refactor from a long time ago.

This creates the new end point: `/import`.
On success an HTTP 201 with the created Workflow is returned.
The location of the workflow is returned in the HTTP header part of the HTTP 201 response.

New exceptions specific to the import process are added.

An `ExtractedWorkflow` class is added that is intended to reduce the number of parameters passed to a function.
Out of convenience, several related constants are provided in this class.

A new repo method `existsById` is provided out of necessity.
Not having this and calling the method without explicitly being defined resulted in errors.
The `@RestResource(exported = false)` is necessary to prevent this method from potentially being exposed via the Spring Data Rest end points.

The `.tar.gz`, `.tar.bz2`, and `.zip` formats are implemented and working.
The current design requires that the archives to not be stored within a sub-directory.
The `workflow.json`, the `fwz.json`, and related files must be at the top-level of the archive.
Adding sub-directory support for a single directory is considered out of scope for this issue.

This performs an in-memory processing of the given file on the expectation that the workflow file size is reasonably small.
Improving this to detect file size and use other methods is considered out of scope.

This is designed around the expectation that the `code` values are to be stringified for proper escaping of the code.

The files are expected to be in UTF-8 encoding.

The JSON files are automatically ordered on import based on dependencies of any particular JSON file in a top-down manner via a cache in memory using the `ExtractedWorkflow` class.

This does not address the expansion of local variables that the `fw-cli` program would perform.
This can potentially be done via additional parameters to the multipart form data.
Such functionality is not performed due to being considered out of scope.