### PR TITLE
MODWRKFLOW-27: Add missing module descriptor settings for FWZ import end point.

### DIFF
--- a/service/descriptors/ModuleDescriptor-template.json
+++ b/service/descriptors/ModuleDescriptor-template.json
@@ -133,6 +133,12 @@
           "permissionsDesired": ["workflow.workflows.domain.*", "workflow.workflows.domain.all"]
         },
         {
+          "methods": ["POST"],
+          "pathPattern": "/workflows/import",
+          "permissionsRequired": ["workflow.workflows.item.post"],
+          "permissionsDesired": ["workflow.workflows.domain.*", "workflow.workflows.domain.all"]
+        },
+        {
           "methods": ["PUT"],
           "pathPattern": "/workflows/{id}",
           "permissionsRequired": ["workflow.workflows.item.put"],


### PR DESCRIPTION
[MODWRKFLOW-27](https://folio-org.atlassian.net/browse/MODWRKFLOW-27)

I overlooked updating the module descriptor and this is required.