### PR TITLE
Deployment improvements

### DIFF
--- a/components/pom.xml
+++ b/components/pom.xml
@@ -5,7 +5,7 @@
 
   <parent>
     <groupId>org.folio</groupId>
-    <artifactId>workflow-parent</artifactId>
+    <artifactId>mod-workflow</artifactId>
     <version>1.2.0-SNAPSHOT</version>
   </parent>
 

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -11,8 +11,8 @@
 
   <artifactId>workflow-components</artifactId>
 
-  <name>Workflow Components</name>
-  <description>Okapi workflow components</description>
+  <name>Okapi Workflow Components</name>
+  <description>Okapi workflow components library using Spring Boot</description>
 
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <version>2.1.0-SNAPSHOT</version>
   </parent>
 
-  <artifactId>workflow-parent</artifactId>
+  <artifactId>mod-workflow</artifactId>
   <version>1.2.0-SNAPSHOT</version>
 
   <name>Workflow Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,8 @@
   <artifactId>mod-workflow</artifactId>
   <version>1.2.0-SNAPSHOT</version>
 
-  <name>Workflow Parent</name>
-  <description></description>
+  <name>Okapi Workflow Module</name>
+  <description>Okapi workflow module using Spring Boot</description>
 
   <licenses>
     <license>

--- a/service/descriptors/ModuleDescriptor-template.json
+++ b/service/descriptors/ModuleDescriptor-template.json
@@ -458,7 +458,10 @@
     "dockerArgs": {
       "HostConfig": {
         "Memory": 402653184,
-        "PortBindings": { "8081/tcp": [ { "HostPort": "%p" } ] }
+        "PortBindings": {
+          "8081/tcp": [ { "HostPort": "%p" } ],
+          "61616/tcp": [ { "HostPort": "61616" } ]
+        }
       }
     },
     "env": [

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -11,8 +11,8 @@
 
   <artifactId>workflow-service</artifactId>
 
-  <name>Workflow Service</name>
-  <description>Okapi workflow module using Spring Boot</description>
+  <name>Okapi Workflow Service</name>
+  <description>Okapi workflow service using Spring Boot</description>
 
   <packaging>jar</packaging>
 

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -5,7 +5,7 @@
 
   <parent>
     <groupId>org.folio</groupId>
-    <artifactId>workflow-parent</artifactId>
+    <artifactId>mod-workflow</artifactId>
     <version>1.2.0-SNAPSHOT</version>
   </parent>
 


### PR DESCRIPTION
This is a follow up to #104.

This adds the ActiveMQ port to the Deployment Descriptor.
Additional work may yet be needed to get ActiveMQ fully working across docker containers in the Scratch environment.

This also fixes the problem with "Workflow Parent".
This changes the name of the module and sub-modules/sub-projects (Components, and Service) to follow the same pattern as `mod-camunda` and all of the other Folio OKAPI modules.
The use of `workflow-parent` is no more and now it should show up as `mod-workflow`.
This change should hopefully help contribute to a well working FOLIO Scratch environment.

With this change, I am expecting the `mod-workflow` Dockerhub to now show up correctly.
see: https://hub.docker.com/r/folioci/workflow-parent
see: https://hub.docker.com/r/folioci/mod-workflow
