### PR TITLE
MODWRKFLOW-28: Handle not found on delete.

### DIFF
--- a/service/src/main/java/org/folio/rest/workflow/controller/WorkflowController.java
+++ b/service/src/main/java/org/folio/rest/workflow/controller/WorkflowController.java
@@ -9,6 +9,7 @@ import org.apache.commons.compress.archivers.ArchiveException;
 import org.apache.commons.compress.compressors.CompressorException;
 import org.folio.rest.workflow.exception.WorkflowEngineServiceException;
 import org.folio.rest.workflow.exception.WorkflowImportException;
+import org.folio.rest.workflow.exception.WorkflowNotFoundException;
 import org.folio.rest.workflow.model.Workflow;
 import org.folio.rest.workflow.service.WorkflowCqlService;
 import org.folio.rest.workflow.service.WorkflowEngineService;
@@ -89,8 +90,11 @@ public class WorkflowController {
     @PathVariable String id,
     @TenantHeader String tenant,
     @TokenHeader String token
-  ) throws WorkflowEngineServiceException {
+  ) throws WorkflowEngineServiceException, WorkflowNotFoundException {
     log.info("Deactivating: {}", id);
+
+    workflowEngineService.exists(id);
+
     return workflowEngineService.deactivate(id, tenant, token);
   }
 
@@ -99,8 +103,11 @@ public class WorkflowController {
     @PathVariable String id,
     @TenantHeader String tenant,
     @TokenHeader String token
-  ) throws WorkflowEngineServiceException {
+  ) throws WorkflowEngineServiceException, WorkflowNotFoundException {
     log.info("Deleting: {}", id);
+
+    workflowEngineService.exists(id);
+
     workflowEngineService.delete(id, tenant, token);
 
     // Ensure that a HTTP 204 is returned on success.

--- a/service/src/main/java/org/folio/rest/workflow/exception/WorkflowNotFoundException.java
+++ b/service/src/main/java/org/folio/rest/workflow/exception/WorkflowNotFoundException.java
@@ -4,7 +4,7 @@ public class WorkflowNotFoundException extends Exception {
 
   private static final long serialVersionUID = -7896387728725860219L;
 
-  private final static String WORKFLOW_NOT_FOUND_MESSAGE = "The workflow: %s, cannot be found.";
+  private final static String WORKFLOW_NOT_FOUND_MESSAGE = "The workflow: %s cannot be found.";
 
   public WorkflowNotFoundException(String id) {
     super(String.format(WORKFLOW_NOT_FOUND_MESSAGE, id));

--- a/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.folio.rest.workflow.dto.WorkflowDto;
 import org.folio.rest.workflow.dto.WorkflowOperationalDto;
 import org.folio.rest.workflow.exception.WorkflowEngineServiceException;
+import org.folio.rest.workflow.exception.WorkflowNotFoundException;
 import org.folio.rest.workflow.model.Workflow;
 import org.folio.rest.workflow.model.repo.WorkflowRepo;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -74,11 +75,6 @@ public class WorkflowEngineService {
   public Workflow deactivate(String workflowId, String tenant, String token)
       throws WorkflowEngineServiceException {
 
-    if (!workflowRepo.existsById(workflowId)) {
-      log.warn("Unable to find Workflow: {}", workflowId);
-      return null;
-    }
-
     WorkflowDto workflow = workflowRepo.getViewById(workflowId, WorkflowDto.class);
     return sendWorkflowRequest(workflow, WORKFLOW_ENGINE_DEACTIVATE_URL_TEMPLATE, tenant, token);
   }
@@ -104,6 +100,19 @@ public class WorkflowEngineService {
     }
 
     workflowRepo.deleteById(workflowId);
+  }
+
+  /**
+   * Check that the Workflow exists or thrown an exception.
+   *
+   * @param workflowId The Workflow to check.
+   *
+   * @throws WorkflowNotFoundException The exception when the Workflow is not found.
+   */
+  public void exists(String workflowId) throws WorkflowNotFoundException {
+    if (!workflowRepo.existsById(workflowId)) {
+      throw new WorkflowNotFoundException(workflowId);
+    }
   }
 
   public JsonNode start(String workflowId, String tenant, String token, JsonNode context)

--- a/service/src/test/java/org/folio/rest/workflow/service/WorkflowEngineServiceTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/service/WorkflowEngineServiceTest.java
@@ -99,7 +99,7 @@ class WorkflowEngineServiceTest {
   }
 
   @Test
-  void deactivateWorksTest() throws WorkflowEngineServiceException, WorkflowNotFoundException {
+  void deactivateWorksTest() throws WorkflowEngineServiceException {
     WorkflowDto workflowDto = (WorkflowDto) workflow;
     ResponseEntity<Workflow> responseEntity = new ResponseEntity<>(HttpStatus.OK);
     setField(responseEntity, "body", workflow);
@@ -115,7 +115,7 @@ class WorkflowEngineServiceTest {
   }
 
   @Test
-  void deleteWorksTest() throws WorkflowEngineServiceException, WorkflowNotFoundException {
+  void deleteWorksTest() throws WorkflowEngineServiceException {
     WorkflowDto workflowDto = (WorkflowDto) workflow;
     ResponseEntity<Workflow> responseEntity = new ResponseEntity<>(HttpStatus.OK);
     setField(responseEntity, "body", workflow);
@@ -132,7 +132,7 @@ class WorkflowEngineServiceTest {
   }
 
   @Test
-  void deleteThrowsExceptionUnableGetUpdatedTest() throws IOException, WorkflowEngineServiceException {
+  void deleteThrowsExceptionUnableGetUpdatedTest() throws IOException {
     WorkflowDto workflowDto = (WorkflowDto) workflow;
     ResponseEntity<Workflow> responseEntity = new ResponseEntity<>(HttpStatus.ACCEPTED);
     setField(responseEntity, "body", workflow);
@@ -149,7 +149,7 @@ class WorkflowEngineServiceTest {
   }
 
   @Test
-  void deleteThrowsExceptionFailedToSaveTest() throws IOException, WorkflowEngineServiceException {
+  void deleteThrowsExceptionFailedToSaveTest() {
     WorkflowDto workflowDto = (WorkflowDto) workflow;
     ResponseEntity<Workflow> responseEntity = new ResponseEntity<>(HttpStatus.OK);
     setField(responseEntity, "body", workflow);
@@ -167,7 +167,7 @@ class WorkflowEngineServiceTest {
   }
 
   @Test
-  void deleteThrowsExceptionFailedToSendWithNullResponseBodyTest() throws IOException, WorkflowEngineServiceException {
+  void deleteThrowsExceptionFailedToSendWithNullResponseBodyTest() {
     WorkflowDto workflowDto = (WorkflowDto) workflow;
     ResponseEntity<Workflow> responseEntity = new ResponseEntity<>(HttpStatus.OK);
     setField(responseEntity, "body", null);
@@ -184,14 +184,14 @@ class WorkflowEngineServiceTest {
   }
 
   @Test
-  void existsWorksTest() throws IOException, WorkflowNotFoundException {
+  void existsWorksTest() {
     when(workflowRepo.existsById(anyString())).thenReturn(true);
 
     assertDoesNotThrow(() -> workflowEngineService.exists(UUID));
   }
 
   @Test
-  void existsThrowsExceptionWorkflowNotFoundTest() throws IOException, WorkflowNotFoundException {
+  void existsThrowsExceptionWorkflowNotFoundTest() {
     when(workflowRepo.existsById(anyString())).thenReturn(false);
 
     assertThrows(WorkflowNotFoundException.class, () -> {

--- a/service/src/test/java/org/folio/rest/workflow/service/WorkflowEngineServiceTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/service/WorkflowEngineServiceTest.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.folio.rest.workflow.dto.WorkflowDto;
 import org.folio.rest.workflow.dto.WorkflowOperationalDto;
@@ -132,7 +131,7 @@ class WorkflowEngineServiceTest {
   }
 
   @Test
-  void deleteThrowsExceptionUnableGetUpdatedTest() throws IOException {
+  void deleteThrowsExceptionUnableGetUpdatedTest() {
     WorkflowDto workflowDto = (WorkflowDto) workflow;
     ResponseEntity<Workflow> responseEntity = new ResponseEntity<>(HttpStatus.ACCEPTED);
     setField(responseEntity, "body", workflow);


### PR DESCRIPTION
[MODWRKFLOW-28](https://folio-org.atlassian.net/browse/MODWRKFLOW-28)

The JPA delete entity is documented to fail silently when there is no entity found.

The existence check must be manually perfored to guarantee that a 404 Not Found happens.

The `delete` and `deactivate` share the same code so move the existence check into its own function.

Add appropriate unit tests.
Update existing unit tests.
Remove no longer needed unit tests.