### PR TITLE
Add support for Jacoco to allow for local coverage reports.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,26 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.12</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>


### PR DESCRIPTION
This can be tested by doing the following (using firefox as an example web browser):
```shell
mvn clean test jacoco:report
firefox components/target/site/jacoco/index.html
firefox service/target/site/jacoco/index.html
```