### PR TITLE
MODWRKFLOW-14: Clean up trailing slash work-around.

### DIFF
--- a/service/src/main/java/org/folio/rest/workflow/controller/ActionController.java
+++ b/service/src/main/java/org/folio/rest/workflow/controller/ActionController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping({"/actions", "/actions/"})
+@RequestMapping("/actions")
 public class ActionController {
 
   private OkapiDiscoveryService okapiDiscoveryService;

--- a/service/src/main/java/org/folio/rest/workflow/controller/EventController.java
+++ b/service/src/main/java/org/folio/rest/workflow/controller/EventController.java
@@ -38,7 +38,7 @@ import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.HandlerMapping;
 
 @RestController
-@RequestMapping({"/events", "/events/"})
+@RequestMapping("/events")
 public class EventController {
 
   private static final Logger logger = LoggerFactory.getLogger(EventController.class);
@@ -66,17 +66,14 @@ public class EventController {
     this.objectMapper = objectMapper;
   }
 
-  // @formatter:off
   @PostMapping(value = "/**", consumes = "application/json", produces = { MediaType.APPLICATION_JSON_VALUE })
   public JsonNode postHandleEvents(
     @RequestBody(required = false) JsonNode body,
     HttpServletRequest request
   ) throws EventPublishException {
-  // @formatter:on
     return processRequest(request, body);
   }
 
-  // @formatter:off
   @PostMapping(value = "/**", consumes = "multipart/form-data", produces = { MediaType.APPLICATION_JSON_VALUE })
   public JsonNode postHandleEventsWithFile(
     @RequestParam("file") MultipartFile multipartFile,
@@ -84,7 +81,6 @@ public class EventController {
     @TenantHeader String tenant,
     HttpServletRequest request
   ) throws EventPublishException, IOException {
-  // @formatter:on
 
     if (!TENANT_PATTERN.matcher(tenant).matches()) {
       throw new FileSystemException("Invalid tenant directory name");

--- a/service/src/main/java/org/folio/rest/workflow/controller/WorkflowController.java
+++ b/service/src/main/java/org/folio/rest/workflow/controller/WorkflowController.java
@@ -34,7 +34,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @RestController
-@RequestMapping({"/workflows", "/workflows/"})
+@RequestMapping("/workflows")
 public class WorkflowController {
 
   private WorkflowEngineService workflowEngineService;
@@ -53,7 +53,7 @@ public class WorkflowController {
     this.workflowRepo = workflowRepo;
   }
 
-  @PostMapping(value = { "/import", "/import/" }, produces = { MediaType.APPLICATION_JSON_VALUE }, consumes = { MediaType.MULTIPART_FORM_DATA_VALUE })
+  @PostMapping(value = "/import", produces = { MediaType.APPLICATION_JSON_VALUE }, consumes = { MediaType.MULTIPART_FORM_DATA_VALUE })
   public ResponseEntity<Object> importWorkflow(
       @RequestPart(name = "file") MultipartFile fwz,
       @TenantHeader String tenant,
@@ -68,7 +68,7 @@ public class WorkflowController {
     return ResponseEntity.created(location).body(workflow);
   }
 
-  @GetMapping(value = { "/search", "/search/" }, produces = { MediaType.APPLICATION_JSON_VALUE })
+  @GetMapping(value = "/search", produces = { MediaType.APPLICATION_JSON_VALUE })
   public JsonNode searchWorkflows(
     @RequestParam String query,
     @RequestParam(defaultValue="0") Long offset,
@@ -79,7 +79,7 @@ public class WorkflowController {
     return workflowCqlService.findByCql(query, offset, limit);
   }
 
-  @GetMapping(value = {"/{id}", "/{id}/"}, produces = { MediaType.APPLICATION_JSON_VALUE })
+  @GetMapping(value = "/{id}", produces = { MediaType.APPLICATION_JSON_VALUE })
   public Workflow getWorkflow(
     @PathVariable String id,
     @TenantHeader String tenant,
@@ -88,7 +88,7 @@ public class WorkflowController {
     return workflowRepo.getReferenceById(id);
   }
 
-  @PutMapping(value = {"/{id}/activate", "/{id}/activate/"}, produces = { MediaType.APPLICATION_JSON_VALUE })
+  @PutMapping(value = "/{id}/activate", produces = { MediaType.APPLICATION_JSON_VALUE })
   public Workflow activateWorkflow(
     @PathVariable String id,
     @TenantHeader String tenant,
@@ -98,7 +98,7 @@ public class WorkflowController {
     return workflowEngineService.activate(id, tenant, token);
   }
 
-  @PutMapping(value = {"/{id}/deactivate", "/{id}/deactivate/"}, produces = { MediaType.APPLICATION_JSON_VALUE })
+  @PutMapping(value = "/{id}/deactivate", produces = { MediaType.APPLICATION_JSON_VALUE })
   public Workflow deactivateWorkflow(
     @PathVariable String id,
     @TenantHeader String tenant,
@@ -111,7 +111,7 @@ public class WorkflowController {
     return workflowEngineService.deactivate(id, tenant, token);
   }
 
-  @DeleteMapping(value = {"/{id}/delete", "/{id}/delete/"})
+  @DeleteMapping(value = "/{id}/delete")
   public ResponseEntity<Object> deleteWorkflow(
     @PathVariable String id,
     @TenantHeader String tenant,
@@ -127,7 +127,7 @@ public class WorkflowController {
     return ResponseEntity.noContent().build();
   }
 
-  @GetMapping(value = {"/{id}/history", "/{id}/history/"}, produces = { MediaType.APPLICATION_JSON_VALUE })
+  @GetMapping(value = "/{id}/history", produces = { MediaType.APPLICATION_JSON_VALUE })
   public JsonNode workflowHistory(
     @PathVariable String id,
     @TenantHeader String tenant,
@@ -137,7 +137,7 @@ public class WorkflowController {
     return workflowEngineService.history(id, tenant, token);
   }
 
-  @PostMapping(value = {"/{id}/start", "/{id}/start/"}, produces = { MediaType.APPLICATION_JSON_VALUE })
+  @PostMapping(value = "/{id}/start", produces = { MediaType.APPLICATION_JSON_VALUE })
   public JsonNode startWorkflow(
     @PathVariable String id,
     @TenantHeader String tenant,

--- a/service/src/main/resources/openapi.yaml
+++ b/service/src/main/resources/openapi.yaml
@@ -6,199 +6,11360 @@ servers:
 - url: http://localhost:9000
   description: Generated server url
 tags:
+- name: tenant
+  description: the tenant API
 - name: Actuator
   description: Monitor and interact
   externalDocs:
     description: Spring Boot Actuator Web API Documentation
     url: https://docs.spring.io/spring-boot/docs/current/actuator-api/html/
 paths:
-  /workflow-engine/workflows/deactivate:
+  /nodes:
+    get:
+      tags:
+      - node-entity-controller
+      description: get-node
+      operationId: getCollectionResource-node-get_1
+      parameters:
+      - name: page
+        in: query
+        description: Zero-based page index (0..N)
+        required: false
+        schema:
+          minimum: 0
+          type: integer
+          default: 0
+      - name: size
+        in: query
+        description: The size of the page to be returned
+        required: false
+        schema:
+          minimum: 1
+          type: integer
+          default: 20
+      - name: sort
+        in: query
+        description: "Sorting criteria in the format: property,(asc|desc). Default\
+          \ sort order is ascending. Multiple sort criteria are supported."
+        required: false
+        schema:
+          type: array
+          items:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/PagedModelEntityModelNode'
+            application/x-spring-data-compact+json:
+              schema:
+                $ref: '#/components/schemas/PagedModelEntityModelNode'
+            text/uri-list:
+              schema:
+                type: string
     post:
+      tags:
+      - node-entity-controller
+      description: create-node
+      operationId: postCollectionResource-node-post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/CompressFileTaskRequestBody'
+              - $ref: '#/components/schemas/ConditionRequestBody'
+              - $ref: '#/components/schemas/ConnectToRequestBody'
+              - $ref: '#/components/schemas/DatabaseConnectionTaskRequestBody'
+              - $ref: '#/components/schemas/DatabaseDisconnectTaskRequestBody'
+              - $ref: '#/components/schemas/DatabaseQueryTaskRequestBody'
+              - $ref: '#/components/schemas/DirectoryTaskRequestBody'
+              - $ref: '#/components/schemas/EmailTaskRequestBody'
+              - $ref: '#/components/schemas/EndEventRequestBody'
+              - $ref: '#/components/schemas/EventSubprocessRequestBody'
+              - $ref: '#/components/schemas/ExclusiveGatewayRequestBody'
+              - $ref: '#/components/schemas/FileTaskRequestBody'
+              - $ref: '#/components/schemas/FtpTaskRequestBody'
+              - $ref: '#/components/schemas/InclusiveGatewayRequestBody'
+              - $ref: '#/components/schemas/InputTaskRequestBody'
+              - $ref: '#/components/schemas/MoveToLastGatewayRequestBody'
+              - $ref: '#/components/schemas/MoveToNodeRequestBody'
+              - $ref: '#/components/schemas/ParallelGatewayRequestBody'
+              - $ref: '#/components/schemas/ProcessorTaskRequestBody'
+              - $ref: '#/components/schemas/ReceiveTaskRequestBody'
+              - $ref: '#/components/schemas/RequestTaskRequestBody'
+              - $ref: '#/components/schemas/ScriptTaskRequestBody'
+              - $ref: '#/components/schemas/StartEventRequestBody'
+              - $ref: '#/components/schemas/SubprocessRequestBody'
+        required: true
+      responses:
+        "201":
+          description: Created
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/EntityModelNode'
+  /nodes/{id}:
+    get:
+      tags:
+      - node-entity-controller
+      description: get-node
+      operationId: getItemResource-node-get
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/EntityModelNode'
+        "404":
+          description: Not Found
+    put:
+      tags:
+      - node-entity-controller
+      description: update-node
+      operationId: putItemResource-node-put
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/CompressFileTaskRequestBody'
+              - $ref: '#/components/schemas/ConditionRequestBody'
+              - $ref: '#/components/schemas/ConnectToRequestBody'
+              - $ref: '#/components/schemas/DatabaseConnectionTaskRequestBody'
+              - $ref: '#/components/schemas/DatabaseDisconnectTaskRequestBody'
+              - $ref: '#/components/schemas/DatabaseQueryTaskRequestBody'
+              - $ref: '#/components/schemas/DirectoryTaskRequestBody'
+              - $ref: '#/components/schemas/EmailTaskRequestBody'
+              - $ref: '#/components/schemas/EndEventRequestBody'
+              - $ref: '#/components/schemas/EventSubprocessRequestBody'
+              - $ref: '#/components/schemas/ExclusiveGatewayRequestBody'
+              - $ref: '#/components/schemas/FileTaskRequestBody'
+              - $ref: '#/components/schemas/FtpTaskRequestBody'
+              - $ref: '#/components/schemas/InclusiveGatewayRequestBody'
+              - $ref: '#/components/schemas/InputTaskRequestBody'
+              - $ref: '#/components/schemas/MoveToLastGatewayRequestBody'
+              - $ref: '#/components/schemas/MoveToNodeRequestBody'
+              - $ref: '#/components/schemas/ParallelGatewayRequestBody'
+              - $ref: '#/components/schemas/ProcessorTaskRequestBody'
+              - $ref: '#/components/schemas/ReceiveTaskRequestBody'
+              - $ref: '#/components/schemas/RequestTaskRequestBody'
+              - $ref: '#/components/schemas/ScriptTaskRequestBody'
+              - $ref: '#/components/schemas/StartEventRequestBody'
+              - $ref: '#/components/schemas/SubprocessRequestBody'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/EntityModelNode'
+        "201":
+          description: Created
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/EntityModelNode'
+        "204":
+          description: No Content
+    delete:
+      tags:
+      - node-entity-controller
+      description: delete-node
+      operationId: deleteItemResource-node-delete
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "204":
+          description: No Content
+        "404":
+          description: Not Found
+    patch:
+      tags:
+      - node-entity-controller
+      description: patch-node
+      operationId: patchItemResource-node-patch
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - $ref: '#/components/schemas/CompressFileTaskRequestBody'
+              - $ref: '#/components/schemas/ConditionRequestBody'
+              - $ref: '#/components/schemas/ConnectToRequestBody'
+              - $ref: '#/components/schemas/DatabaseConnectionTaskRequestBody'
+              - $ref: '#/components/schemas/DatabaseDisconnectTaskRequestBody'
+              - $ref: '#/components/schemas/DatabaseQueryTaskRequestBody'
+              - $ref: '#/components/schemas/DirectoryTaskRequestBody'
+              - $ref: '#/components/schemas/EmailTaskRequestBody'
+              - $ref: '#/components/schemas/EndEventRequestBody'
+              - $ref: '#/components/schemas/EventSubprocessRequestBody'
+              - $ref: '#/components/schemas/ExclusiveGatewayRequestBody'
+              - $ref: '#/components/schemas/FileTaskRequestBody'
+              - $ref: '#/components/schemas/FtpTaskRequestBody'
+              - $ref: '#/components/schemas/InclusiveGatewayRequestBody'
+              - $ref: '#/components/schemas/InputTaskRequestBody'
+              - $ref: '#/components/schemas/MoveToLastGatewayRequestBody'
+              - $ref: '#/components/schemas/MoveToNodeRequestBody'
+              - $ref: '#/components/schemas/ParallelGatewayRequestBody'
+              - $ref: '#/components/schemas/ProcessorTaskRequestBody'
+              - $ref: '#/components/schemas/ReceiveTaskRequestBody'
+              - $ref: '#/components/schemas/RequestTaskRequestBody'
+              - $ref: '#/components/schemas/ScriptTaskRequestBody'
+              - $ref: '#/components/schemas/StartEventRequestBody'
+              - $ref: '#/components/schemas/SubprocessRequestBody'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/EntityModelNode'
+        "204":
+          description: No Content
+  /profile:
+    get:
+      tags:
+      - profile-controller
+      operationId: listAllFormsOfMetadata_1
+      responses:
+        "200":
+          description: OK
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/RepresentationModelObject'
+  /profile/nodes:
+    get:
+      tags:
+      - profile-controller
+      operationId: descriptor_1_1_1
+      responses:
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                type: string
+            application/alps+json:
+              schema:
+                type: string
+            application/schema+json:
+              schema:
+                $ref: '#/components/schemas/JsonSchema'
+  /profile/triggers:
+    get:
+      tags:
+      - profile-controller
+      operationId: descriptor_1_1_2
+      responses:
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                type: string
+            application/alps+json:
+              schema:
+                type: string
+            application/schema+json:
+              schema:
+                $ref: '#/components/schemas/JsonSchema'
+  /profile/workflows:
+    get:
+      tags:
+      - profile-controller
+      operationId: descriptor_1_1_3
+      responses:
+        "200":
+          description: OK
+          content:
+            '*/*':
+              schema:
+                type: string
+            application/alps+json:
+              schema:
+                type: string
+            application/schema+json:
+              schema:
+                $ref: '#/components/schemas/JsonSchema'
+  /triggers:
+    get:
+      tags:
+      - trigger-entity-controller
+      description: get-trigger
+      operationId: getCollectionResource-trigger-get_1
+      parameters:
+      - name: page
+        in: query
+        description: Zero-based page index (0..N)
+        required: false
+        schema:
+          minimum: 0
+          type: integer
+          default: 0
+      - name: size
+        in: query
+        description: The size of the page to be returned
+        required: false
+        schema:
+          minimum: 1
+          type: integer
+          default: 20
+      - name: sort
+        in: query
+        description: "Sorting criteria in the format: property,(asc|desc). Default\
+          \ sort order is ascending. Multiple sort criteria are supported."
+        required: false
+        schema:
+          type: array
+          items:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/PagedModelEntityModelTrigger'
+            application/x-spring-data-compact+json:
+              schema:
+                $ref: '#/components/schemas/PagedModelEntityModelTrigger'
+            text/uri-list:
+              schema:
+                type: string
+    post:
+      tags:
+      - trigger-entity-controller
+      description: create-trigger
+      operationId: postCollectionResource-trigger-post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TriggerRequestBody'
+        required: true
+      responses:
+        "201":
+          description: Created
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/EntityModelTrigger'
+  /triggers/search/findViewAllBy:
+    get:
+      tags:
+      - trigger-search-controller
+      operationId: executeSearch-trigger-get
+      parameters:
+      - name: type
+        in: query
+        schema:
+          type: object
+          properties:
+            name:
+              type: string
+            module:
+              type: object
+              properties:
+                name:
+                  type: string
+                classLoader:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    registeredAsParallelCapable:
+                      type: boolean
+                    parent:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        registeredAsParallelCapable:
+                          type: boolean
+                        definedPackages:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              sealed:
+                                type: boolean
+                              specificationTitle:
+                                type: string
+                              specificationVersion:
+                                type: string
+                              specificationVendor:
+                                type: string
+                              implementationTitle:
+                                type: string
+                              implementationVersion:
+                                type: string
+                              implementationVendor:
+                                type: string
+                        defaultAssertionStatus:
+                          type: boolean
+                          writeOnly: true
+                    definedPackages:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          sealed:
+                            type: boolean
+                          specificationTitle:
+                            type: string
+                          specificationVersion:
+                            type: string
+                          specificationVendor:
+                            type: string
+                          implementationTitle:
+                            type: string
+                          implementationVersion:
+                            type: string
+                          implementationVendor:
+                            type: string
+                    defaultAssertionStatus:
+                      type: boolean
+                      writeOnly: true
+                descriptor:
+                  type: object
+                  properties:
+                    open:
+                      type: boolean
+                    automatic:
+                      type: boolean
+                named:
+                  type: boolean
+                annotations:
+                  type: array
+                  items:
+                    type: object
+                declaredAnnotations:
+                  type: array
+                  items:
+                    type: object
+                packages:
+                  uniqueItems: true
+                  type: array
+                  items:
+                    type: string
+                nativeAccessEnabled:
+                  type: boolean
+                layer:
+                  type: object
+            protectionDomain:
+              type: object
+              properties:
+                principals:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                permissions:
+                  type: object
+                  properties:
+                    readOnly:
+                      type: boolean
+                classLoader:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    registeredAsParallelCapable:
+                      type: boolean
+                    parent:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        registeredAsParallelCapable:
+                          type: boolean
+                        definedPackages:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              sealed:
+                                type: boolean
+                              specificationTitle:
+                                type: string
+                              specificationVersion:
+                                type: string
+                              specificationVendor:
+                                type: string
+                              implementationTitle:
+                                type: string
+                              implementationVersion:
+                                type: string
+                              implementationVendor:
+                                type: string
+                        defaultAssertionStatus:
+                          type: boolean
+                          writeOnly: true
+                    definedPackages:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          sealed:
+                            type: boolean
+                          specificationTitle:
+                            type: string
+                          specificationVersion:
+                            type: string
+                          specificationVendor:
+                            type: string
+                          implementationTitle:
+                            type: string
+                          implementationVersion:
+                            type: string
+                          implementationVendor:
+                            type: string
+                    defaultAssertionStatus:
+                      type: boolean
+                      writeOnly: true
+                codeSource:
+                  type: object
+                  properties:
+                    location:
+                      type: string
+                      format: url
+                    certificates:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          type:
+                            type: string
+                          encoded:
+                            type: string
+                            format: byte
+                          publicKey:
+                            type: object
+                            properties:
+                              encoded:
+                                type: string
+                                format: byte
+                              format:
+                                type: string
+                              algorithm:
+                                type: string
+                    codeSigners:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          signerCertPath:
+                            type: object
+                            properties:
+                              certificates:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    type:
+                                      type: string
+                                    encoded:
+                                      type: string
+                                      format: byte
+                                    publicKey:
+                                      type: object
+                                      properties:
+                                        encoded:
+                                          type: string
+                                          format: byte
+                                        format:
+                                          type: string
+                                        algorithm:
+                                          type: string
+                              type:
+                                type: string
+                              encoded:
+                                type: string
+                                format: byte
+                              encodings:
+                                type: object
+                          timestamp:
+                            type: object
+                            properties:
+                              timestamp:
+                                type: string
+                                format: date-time
+                              signerCertPath:
+                                type: object
+                                properties:
+                                  certificates:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                        encoded:
+                                          type: string
+                                          format: byte
+                                        publicKey:
+                                          type: object
+                                          properties:
+                                            encoded:
+                                              type: string
+                                              format: byte
+                                            format:
+                                              type: string
+                                            algorithm:
+                                              type: string
+                                  type:
+                                    type: string
+                                  encoded:
+                                    type: string
+                                    format: byte
+                                  encodings:
+                                    type: object
+            modifiers:
+              type: integer
+              format: int32
+            interface:
+              type: boolean
+            array:
+              type: boolean
+            primitive:
+              type: boolean
+            hidden:
+              type: boolean
+            annotation:
+              type: boolean
+            enum:
+              type: boolean
+            record:
+              type: boolean
+            typeParameters:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  bounds:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                  annotatedBounds:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        type:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                  typeName:
+                    type: string
+                  annotations:
+                    type: array
+                    items:
+                      type: object
+                  declaredAnnotations:
+                    type: array
+                    items:
+                      type: object
+            classLoader:
+              type: object
+              properties:
+                name:
+                  type: string
+                registeredAsParallelCapable:
+                  type: boolean
+                parent:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    registeredAsParallelCapable:
+                      type: boolean
+                    definedPackages:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          sealed:
+                            type: boolean
+                          specificationTitle:
+                            type: string
+                          specificationVersion:
+                            type: string
+                          specificationVendor:
+                            type: string
+                          implementationTitle:
+                            type: string
+                          implementationVersion:
+                            type: string
+                          implementationVendor:
+                            type: string
+                    defaultAssertionStatus:
+                      type: boolean
+                      writeOnly: true
+                unnamedModule:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    classLoader:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        registeredAsParallelCapable:
+                          type: boolean
+                        parent:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            registeredAsParallelCapable:
+                              type: boolean
+                            definedPackages:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  sealed:
+                                    type: boolean
+                                  specificationTitle:
+                                    type: string
+                                  specificationVersion:
+                                    type: string
+                                  specificationVendor:
+                                    type: string
+                                  implementationTitle:
+                                    type: string
+                                  implementationVersion:
+                                    type: string
+                                  implementationVendor:
+                                    type: string
+                            defaultAssertionStatus:
+                              type: boolean
+                              writeOnly: true
+                        definedPackages:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              sealed:
+                                type: boolean
+                              specificationTitle:
+                                type: string
+                              specificationVersion:
+                                type: string
+                              specificationVendor:
+                                type: string
+                              implementationTitle:
+                                type: string
+                              implementationVersion:
+                                type: string
+                              implementationVendor:
+                                type: string
+                        defaultAssertionStatus:
+                          type: boolean
+                          writeOnly: true
+                    descriptor:
+                      type: object
+                      properties:
+                        open:
+                          type: boolean
+                        automatic:
+                          type: boolean
+                    named:
+                      type: boolean
+                    annotations:
+                      type: array
+                      items:
+                        type: object
+                    declaredAnnotations:
+                      type: array
+                      items:
+                        type: object
+                    packages:
+                      uniqueItems: true
+                      type: array
+                      items:
+                        type: string
+                    nativeAccessEnabled:
+                      type: boolean
+                    layer:
+                      type: object
+                definedPackages:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      sealed:
+                        type: boolean
+                      specificationTitle:
+                        type: string
+                      specificationVersion:
+                        type: string
+                      specificationVendor:
+                        type: string
+                      implementationTitle:
+                        type: string
+                      implementationVersion:
+                        type: string
+                      implementationVendor:
+                        type: string
+                defaultAssertionStatus:
+                  type: boolean
+                  writeOnly: true
+            memberClass:
+              type: boolean
+            localClass:
+              type: boolean
+            anonymousClass:
+              type: boolean
+            unnamedClass:
+              type: boolean
+            simpleName:
+              type: string
+            canonicalName:
+              type: string
+            synthetic:
+              type: boolean
+            packageName:
+              type: string
+            genericSuperclass:
+              type: object
+              properties:
+                typeName:
+                  type: string
+            package:
+              type: object
+              properties:
+                name:
+                  type: string
+                annotations:
+                  type: array
+                  items:
+                    type: object
+                declaredAnnotations:
+                  type: array
+                  items:
+                    type: object
+                sealed:
+                  type: boolean
+                specificationTitle:
+                  type: string
+                specificationVersion:
+                  type: string
+                specificationVendor:
+                  type: string
+                implementationTitle:
+                  type: string
+                implementationVersion:
+                  type: string
+                implementationVendor:
+                  type: string
+            genericInterfaces:
+              type: array
+              items:
+                type: object
+                properties:
+                  typeName:
+                    type: string
+            signers:
+              type: array
+              items:
+                type: object
+            enclosingMethod:
+              type: object
+              properties:
+                name:
+                  type: string
+                modifiers:
+                  type: integer
+                  format: int32
+                typeParameters:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      bounds:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                      genericDeclaration:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          modifiers:
+                            type: integer
+                            format: int32
+                          synthetic:
+                            type: boolean
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          accessible:
+                            type: boolean
+                            deprecated: true
+                          varArgs:
+                            type: boolean
+                          parameterCount:
+                            type: integer
+                            format: int32
+                          parameterAnnotations:
+                            type: array
+                            items:
+                              type: array
+                              items:
+                                type: object
+                          genericParameterTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                          genericExceptionTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                          default:
+                            type: boolean
+                          genericReturnType:
+                            type: object
+                            properties:
+                              typeName:
+                                type: string
+                          bridge:
+                            type: boolean
+                          defaultValue:
+                            type: object
+                          annotatedReturnType:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                          annotatedParameterTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                          parameters:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                modifiers:
+                                  type: integer
+                                  format: int32
+                                synthetic:
+                                  type: boolean
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                annotatedType:
+                                  type: object
+                                  properties:
+                                    annotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    declaredAnnotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    type:
+                                      type: object
+                                      properties:
+                                        typeName:
+                                          type: string
+                                parameterizedType:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                                varArgs:
+                                  type: boolean
+                                namePresent:
+                                  type: boolean
+                                declaringExecutable:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                    modifiers:
+                                      type: integer
+                                      format: int32
+                                    typeParameters:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          name:
+                                            type: string
+                                          bounds:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                          genericDeclaration:
+                                            type: object
+                                          annotatedBounds:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                annotations:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                declaredAnnotations:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                type:
+                                                  type: object
+                                                  properties:
+                                                    typeName:
+                                                      type: string
+                                          typeName:
+                                            type: string
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                    synthetic:
+                                      type: boolean
+                                    declaredAnnotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    varArgs:
+                                      type: boolean
+                                    annotatedParameterTypes:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                    parameterCount:
+                                      type: integer
+                                      format: int32
+                                    parameterAnnotations:
+                                      type: array
+                                      items:
+                                        type: array
+                                        items:
+                                          type: object
+                                    genericParameterTypes:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                    genericExceptionTypes:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                    annotatedReturnType:
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        declaredAnnotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        type:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                    annotatedReceiverType:
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        declaredAnnotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        type:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                    annotatedExceptionTypes:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                    annotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    accessible:
+                                      type: boolean
+                                      deprecated: true
+                                implicit:
+                                  type: boolean
+                          annotatedReceiverType:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                          annotatedExceptionTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                      annotatedBounds:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            type:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                      typeName:
+                        type: string
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                synthetic:
+                  type: boolean
+                declaredAnnotations:
+                  type: array
+                  items:
+                    type: object
+                accessible:
+                  type: boolean
+                  deprecated: true
+                varArgs:
+                  type: boolean
+                parameterCount:
+                  type: integer
+                  format: int32
+                parameterAnnotations:
+                  type: array
+                  items:
+                    type: array
+                    items:
+                      type: object
+                genericParameterTypes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      typeName:
+                        type: string
+                genericExceptionTypes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      typeName:
+                        type: string
+                default:
+                  type: boolean
+                genericReturnType:
+                  type: object
+                  properties:
+                    typeName:
+                      type: string
+                bridge:
+                  type: boolean
+                defaultValue:
+                  type: object
+                annotatedReturnType:
+                  type: object
+                  properties:
+                    annotations:
+                      type: array
+                      items:
+                        type: object
+                    declaredAnnotations:
+                      type: array
+                      items:
+                        type: object
+                    type:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                annotatedParameterTypes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                parameters:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      modifiers:
+                        type: integer
+                        format: int32
+                      synthetic:
+                        type: boolean
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      annotatedType:
+                        type: object
+                        properties:
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          type:
+                            type: object
+                            properties:
+                              typeName:
+                                type: string
+                      parameterizedType:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                      varArgs:
+                        type: boolean
+                      namePresent:
+                        type: boolean
+                      declaringExecutable:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          modifiers:
+                            type: integer
+                            format: int32
+                          typeParameters:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                bounds:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                                genericDeclaration:
+                                  type: object
+                                annotatedBounds:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      type:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                typeName:
+                                  type: string
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                          synthetic:
+                            type: boolean
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          varArgs:
+                            type: boolean
+                          annotatedParameterTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                          parameterCount:
+                            type: integer
+                            format: int32
+                          parameterAnnotations:
+                            type: array
+                            items:
+                              type: array
+                              items:
+                                type: object
+                          genericParameterTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                          genericExceptionTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                          annotatedReturnType:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                          annotatedReceiverType:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                          annotatedExceptionTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                          accessible:
+                            type: boolean
+                            deprecated: true
+                      implicit:
+                        type: boolean
+                annotatedReceiverType:
+                  type: object
+                  properties:
+                    annotations:
+                      type: array
+                      items:
+                        type: object
+                    declaredAnnotations:
+                      type: array
+                      items:
+                        type: object
+                    type:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                annotatedExceptionTypes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                annotations:
+                  type: array
+                  items:
+                    type: object
+            enclosingConstructor:
+              type: object
+              properties:
+                name:
+                  type: string
+                modifiers:
+                  type: integer
+                  format: int32
+                typeParameters:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      bounds:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                      genericDeclaration:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          modifiers:
+                            type: integer
+                            format: int32
+                          synthetic:
+                            type: boolean
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          accessible:
+                            type: boolean
+                            deprecated: true
+                          varArgs:
+                            type: boolean
+                          parameterCount:
+                            type: integer
+                            format: int32
+                          parameterAnnotations:
+                            type: array
+                            items:
+                              type: array
+                              items:
+                                type: object
+                          genericParameterTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                          genericExceptionTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                          annotatedReturnType:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                          annotatedReceiverType:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                          annotatedParameterTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                          parameters:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                modifiers:
+                                  type: integer
+                                  format: int32
+                                synthetic:
+                                  type: boolean
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                annotatedType:
+                                  type: object
+                                  properties:
+                                    annotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    declaredAnnotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    type:
+                                      type: object
+                                      properties:
+                                        typeName:
+                                          type: string
+                                parameterizedType:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                                varArgs:
+                                  type: boolean
+                                namePresent:
+                                  type: boolean
+                                declaringExecutable:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                    modifiers:
+                                      type: integer
+                                      format: int32
+                                    typeParameters:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          name:
+                                            type: string
+                                          bounds:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                          genericDeclaration:
+                                            type: object
+                                          annotatedBounds:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                annotations:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                declaredAnnotations:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                type:
+                                                  type: object
+                                                  properties:
+                                                    typeName:
+                                                      type: string
+                                          typeName:
+                                            type: string
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                    synthetic:
+                                      type: boolean
+                                    declaredAnnotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    varArgs:
+                                      type: boolean
+                                    annotatedParameterTypes:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                    parameterCount:
+                                      type: integer
+                                      format: int32
+                                    parameterAnnotations:
+                                      type: array
+                                      items:
+                                        type: array
+                                        items:
+                                          type: object
+                                    genericParameterTypes:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                    genericExceptionTypes:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                    annotatedReturnType:
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        declaredAnnotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        type:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                    annotatedReceiverType:
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        declaredAnnotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        type:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                    annotatedExceptionTypes:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                    annotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    accessible:
+                                      type: boolean
+                                      deprecated: true
+                                implicit:
+                                  type: boolean
+                          annotatedExceptionTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                      annotatedBounds:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            type:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                      typeName:
+                        type: string
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                synthetic:
+                  type: boolean
+                declaredAnnotations:
+                  type: array
+                  items:
+                    type: object
+                accessible:
+                  type: boolean
+                  deprecated: true
+                varArgs:
+                  type: boolean
+                parameterCount:
+                  type: integer
+                  format: int32
+                parameterAnnotations:
+                  type: array
+                  items:
+                    type: array
+                    items:
+                      type: object
+                genericParameterTypes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      typeName:
+                        type: string
+                genericExceptionTypes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      typeName:
+                        type: string
+                annotatedReturnType:
+                  type: object
+                  properties:
+                    annotations:
+                      type: array
+                      items:
+                        type: object
+                    declaredAnnotations:
+                      type: array
+                      items:
+                        type: object
+                    type:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                annotatedReceiverType:
+                  type: object
+                  properties:
+                    annotations:
+                      type: array
+                      items:
+                        type: object
+                    declaredAnnotations:
+                      type: array
+                      items:
+                        type: object
+                    type:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                annotatedParameterTypes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                parameters:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      modifiers:
+                        type: integer
+                        format: int32
+                      synthetic:
+                        type: boolean
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      annotatedType:
+                        type: object
+                        properties:
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          type:
+                            type: object
+                            properties:
+                              typeName:
+                                type: string
+                      parameterizedType:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                      varArgs:
+                        type: boolean
+                      namePresent:
+                        type: boolean
+                      declaringExecutable:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          modifiers:
+                            type: integer
+                            format: int32
+                          typeParameters:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                bounds:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                                genericDeclaration:
+                                  type: object
+                                annotatedBounds:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      type:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                typeName:
+                                  type: string
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                          synthetic:
+                            type: boolean
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          varArgs:
+                            type: boolean
+                          annotatedParameterTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                          parameterCount:
+                            type: integer
+                            format: int32
+                          parameterAnnotations:
+                            type: array
+                            items:
+                              type: array
+                              items:
+                                type: object
+                          genericParameterTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                          genericExceptionTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                          annotatedReturnType:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                          annotatedReceiverType:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                          annotatedExceptionTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                          accessible:
+                            type: boolean
+                            deprecated: true
+                      implicit:
+                        type: boolean
+                annotatedExceptionTypes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                annotations:
+                  type: array
+                  items:
+                    type: object
+            typeName:
+              type: string
+            fields:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  modifiers:
+                    type: integer
+                    format: int32
+                  synthetic:
+                    type: boolean
+                  declaredAnnotations:
+                    type: array
+                    items:
+                      type: object
+                  accessible:
+                    type: boolean
+                    deprecated: true
+                  genericType:
+                    type: object
+                    properties:
+                      typeName:
+                        type: string
+                  enumConstant:
+                    type: boolean
+                  annotatedType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                  annotations:
+                    type: array
+                    items:
+                      type: object
+            methods:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  modifiers:
+                    type: integer
+                    format: int32
+                  typeParameters:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        bounds:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              typeName:
+                                type: string
+                        genericDeclaration:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            modifiers:
+                              type: integer
+                              format: int32
+                            synthetic:
+                              type: boolean
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            accessible:
+                              type: boolean
+                              deprecated: true
+                            varArgs:
+                              type: boolean
+                            parameterCount:
+                              type: integer
+                              format: int32
+                            parameterAnnotations:
+                              type: array
+                              items:
+                                type: array
+                                items:
+                                  type: object
+                            genericParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            genericExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            default:
+                              type: boolean
+                            genericReturnType:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                            bridge:
+                              type: boolean
+                            defaultValue:
+                              type: object
+                            annotatedReturnType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            parameters:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  modifiers:
+                                    type: integer
+                                    format: int32
+                                  synthetic:
+                                    type: boolean
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  annotatedType:
+                                    type: object
+                                    properties:
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      type:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                  parameterizedType:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                                  varArgs:
+                                    type: boolean
+                                  namePresent:
+                                    type: boolean
+                                  declaringExecutable:
+                                    type: object
+                                    properties:
+                                      name:
+                                        type: string
+                                      modifiers:
+                                        type: integer
+                                        format: int32
+                                      typeParameters:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            name:
+                                              type: string
+                                            bounds:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  typeName:
+                                                    type: string
+                                            genericDeclaration:
+                                              type: object
+                                            annotatedBounds:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  annotations:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                  declaredAnnotations:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                  type:
+                                                    type: object
+                                                    properties:
+                                                      typeName:
+                                                        type: string
+                                            typeName:
+                                              type: string
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                      synthetic:
+                                        type: boolean
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      varArgs:
+                                        type: boolean
+                                      annotatedParameterTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            type:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                      parameterCount:
+                                        type: integer
+                                        format: int32
+                                      parameterAnnotations:
+                                        type: array
+                                        items:
+                                          type: array
+                                          items:
+                                            type: object
+                                      genericParameterTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                      genericExceptionTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                      annotatedReturnType:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                      annotatedReceiverType:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                      annotatedExceptionTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            type:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      accessible:
+                                        type: boolean
+                                        deprecated: true
+                                  implicit:
+                                    type: boolean
+                            annotatedReceiverType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                        annotatedBounds:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                        typeName:
+                          type: string
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                  synthetic:
+                    type: boolean
+                  declaredAnnotations:
+                    type: array
+                    items:
+                      type: object
+                  accessible:
+                    type: boolean
+                    deprecated: true
+                  varArgs:
+                    type: boolean
+                  parameterCount:
+                    type: integer
+                    format: int32
+                  parameterAnnotations:
+                    type: array
+                    items:
+                      type: array
+                      items:
+                        type: object
+                  genericParameterTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                  genericExceptionTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                  default:
+                    type: boolean
+                  genericReturnType:
+                    type: object
+                    properties:
+                      typeName:
+                        type: string
+                  bridge:
+                    type: boolean
+                  defaultValue:
+                    type: object
+                  annotatedReturnType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                  annotatedParameterTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        type:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                  parameters:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        modifiers:
+                          type: integer
+                          format: int32
+                        synthetic:
+                          type: boolean
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        annotatedType:
+                          type: object
+                          properties:
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            type:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                        parameterizedType:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                        varArgs:
+                          type: boolean
+                        namePresent:
+                          type: boolean
+                        declaringExecutable:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            modifiers:
+                              type: integer
+                              format: int32
+                            typeParameters:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  bounds:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        typeName:
+                                          type: string
+                                  genericDeclaration:
+                                    type: object
+                                  annotatedBounds:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        declaredAnnotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        type:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                  typeName:
+                                    type: string
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                            synthetic:
+                              type: boolean
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            varArgs:
+                              type: boolean
+                            annotatedParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            parameterCount:
+                              type: integer
+                              format: int32
+                            parameterAnnotations:
+                              type: array
+                              items:
+                                type: array
+                                items:
+                                  type: object
+                            genericParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            genericExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            annotatedReturnType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedReceiverType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            accessible:
+                              type: boolean
+                              deprecated: true
+                        implicit:
+                          type: boolean
+                  annotatedReceiverType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                  annotatedExceptionTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        type:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                  annotations:
+                    type: array
+                    items:
+                      type: object
+            constructors:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  modifiers:
+                    type: integer
+                    format: int32
+                  typeParameters:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        bounds:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              typeName:
+                                type: string
+                        genericDeclaration:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            modifiers:
+                              type: integer
+                              format: int32
+                            synthetic:
+                              type: boolean
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            accessible:
+                              type: boolean
+                              deprecated: true
+                            varArgs:
+                              type: boolean
+                            parameterCount:
+                              type: integer
+                              format: int32
+                            parameterAnnotations:
+                              type: array
+                              items:
+                                type: array
+                                items:
+                                  type: object
+                            genericParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            genericExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            annotatedReturnType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedReceiverType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            parameters:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  modifiers:
+                                    type: integer
+                                    format: int32
+                                  synthetic:
+                                    type: boolean
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  annotatedType:
+                                    type: object
+                                    properties:
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      type:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                  parameterizedType:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                                  varArgs:
+                                    type: boolean
+                                  namePresent:
+                                    type: boolean
+                                  declaringExecutable:
+                                    type: object
+                                    properties:
+                                      name:
+                                        type: string
+                                      modifiers:
+                                        type: integer
+                                        format: int32
+                                      typeParameters:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            name:
+                                              type: string
+                                            bounds:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  typeName:
+                                                    type: string
+                                            genericDeclaration:
+                                              type: object
+                                            annotatedBounds:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  annotations:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                  declaredAnnotations:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                  type:
+                                                    type: object
+                                                    properties:
+                                                      typeName:
+                                                        type: string
+                                            typeName:
+                                              type: string
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                      synthetic:
+                                        type: boolean
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      varArgs:
+                                        type: boolean
+                                      annotatedParameterTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            type:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                      parameterCount:
+                                        type: integer
+                                        format: int32
+                                      parameterAnnotations:
+                                        type: array
+                                        items:
+                                          type: array
+                                          items:
+                                            type: object
+                                      genericParameterTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                      genericExceptionTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                      annotatedReturnType:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                      annotatedReceiverType:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                      annotatedExceptionTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            type:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      accessible:
+                                        type: boolean
+                                        deprecated: true
+                                  implicit:
+                                    type: boolean
+                            annotatedExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                        annotatedBounds:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                        typeName:
+                          type: string
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                  synthetic:
+                    type: boolean
+                  declaredAnnotations:
+                    type: array
+                    items:
+                      type: object
+                  accessible:
+                    type: boolean
+                    deprecated: true
+                  varArgs:
+                    type: boolean
+                  parameterCount:
+                    type: integer
+                    format: int32
+                  parameterAnnotations:
+                    type: array
+                    items:
+                      type: array
+                      items:
+                        type: object
+                  genericParameterTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                  genericExceptionTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                  annotatedReturnType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                  annotatedReceiverType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                  annotatedParameterTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        type:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                  parameters:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        modifiers:
+                          type: integer
+                          format: int32
+                        synthetic:
+                          type: boolean
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        annotatedType:
+                          type: object
+                          properties:
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            type:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                        parameterizedType:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                        varArgs:
+                          type: boolean
+                        namePresent:
+                          type: boolean
+                        declaringExecutable:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            modifiers:
+                              type: integer
+                              format: int32
+                            typeParameters:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  bounds:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        typeName:
+                                          type: string
+                                  genericDeclaration:
+                                    type: object
+                                  annotatedBounds:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        declaredAnnotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        type:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                  typeName:
+                                    type: string
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                            synthetic:
+                              type: boolean
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            varArgs:
+                              type: boolean
+                            annotatedParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            parameterCount:
+                              type: integer
+                              format: int32
+                            parameterAnnotations:
+                              type: array
+                              items:
+                                type: array
+                                items:
+                                  type: object
+                            genericParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            genericExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            annotatedReturnType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedReceiverType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            accessible:
+                              type: boolean
+                              deprecated: true
+                        implicit:
+                          type: boolean
+                  annotatedExceptionTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        type:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                  annotations:
+                    type: array
+                    items:
+                      type: object
+            declaredFields:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  modifiers:
+                    type: integer
+                    format: int32
+                  synthetic:
+                    type: boolean
+                  declaredAnnotations:
+                    type: array
+                    items:
+                      type: object
+                  accessible:
+                    type: boolean
+                    deprecated: true
+                  genericType:
+                    type: object
+                    properties:
+                      typeName:
+                        type: string
+                  enumConstant:
+                    type: boolean
+                  annotatedType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                  annotations:
+                    type: array
+                    items:
+                      type: object
+            recordComponents:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  accessor:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      modifiers:
+                        type: integer
+                        format: int32
+                      synthetic:
+                        type: boolean
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      accessible:
+                        type: boolean
+                        deprecated: true
+                      varArgs:
+                        type: boolean
+                      parameterCount:
+                        type: integer
+                        format: int32
+                      parameterAnnotations:
+                        type: array
+                        items:
+                          type: array
+                          items:
+                            type: object
+                      genericParameterTypes:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                      genericExceptionTypes:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                      default:
+                        type: boolean
+                      genericReturnType:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                      bridge:
+                        type: boolean
+                      defaultValue:
+                        type: object
+                      annotatedReturnType:
+                        type: object
+                        properties:
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          type:
+                            type: object
+                            properties:
+                              typeName:
+                                type: string
+                      annotatedParameterTypes:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            type:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                      parameters:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            modifiers:
+                              type: integer
+                              format: int32
+                            synthetic:
+                              type: boolean
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            annotatedType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            parameterizedType:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                            varArgs:
+                              type: boolean
+                            namePresent:
+                              type: boolean
+                            declaringExecutable:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                modifiers:
+                                  type: integer
+                                  format: int32
+                                typeParameters:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      name:
+                                        type: string
+                                      bounds:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                      genericDeclaration:
+                                        type: object
+                                      annotatedBounds:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            type:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                      typeName:
+                                        type: string
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                synthetic:
+                                  type: boolean
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                varArgs:
+                                  type: boolean
+                                annotatedParameterTypes:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      type:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                parameterCount:
+                                  type: integer
+                                  format: int32
+                                parameterAnnotations:
+                                  type: array
+                                  items:
+                                    type: array
+                                    items:
+                                      type: object
+                                genericParameterTypes:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                                genericExceptionTypes:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                                annotatedReturnType:
+                                  type: object
+                                  properties:
+                                    annotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    declaredAnnotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    type:
+                                      type: object
+                                      properties:
+                                        typeName:
+                                          type: string
+                                annotatedReceiverType:
+                                  type: object
+                                  properties:
+                                    annotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    declaredAnnotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    type:
+                                      type: object
+                                      properties:
+                                        typeName:
+                                          type: string
+                                annotatedExceptionTypes:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      type:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                accessible:
+                                  type: boolean
+                                  deprecated: true
+                            implicit:
+                              type: boolean
+                      annotatedReceiverType:
+                        type: object
+                        properties:
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          type:
+                            type: object
+                            properties:
+                              typeName:
+                                type: string
+                      annotatedExceptionTypes:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            type:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                  annotations:
+                    type: array
+                    items:
+                      type: object
+                  declaredAnnotations:
+                    type: array
+                    items:
+                      type: object
+                  genericSignature:
+                    type: string
+                  genericType:
+                    type: object
+                    properties:
+                      typeName:
+                        type: string
+                  annotatedType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+            declaredMethods:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  modifiers:
+                    type: integer
+                    format: int32
+                  typeParameters:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        bounds:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              typeName:
+                                type: string
+                        genericDeclaration:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            modifiers:
+                              type: integer
+                              format: int32
+                            synthetic:
+                              type: boolean
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            accessible:
+                              type: boolean
+                              deprecated: true
+                            varArgs:
+                              type: boolean
+                            parameterCount:
+                              type: integer
+                              format: int32
+                            parameterAnnotations:
+                              type: array
+                              items:
+                                type: array
+                                items:
+                                  type: object
+                            genericParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            genericExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            default:
+                              type: boolean
+                            genericReturnType:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                            bridge:
+                              type: boolean
+                            defaultValue:
+                              type: object
+                            annotatedReturnType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            parameters:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  modifiers:
+                                    type: integer
+                                    format: int32
+                                  synthetic:
+                                    type: boolean
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  annotatedType:
+                                    type: object
+                                    properties:
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      type:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                  parameterizedType:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                                  varArgs:
+                                    type: boolean
+                                  namePresent:
+                                    type: boolean
+                                  declaringExecutable:
+                                    type: object
+                                    properties:
+                                      name:
+                                        type: string
+                                      modifiers:
+                                        type: integer
+                                        format: int32
+                                      typeParameters:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            name:
+                                              type: string
+                                            bounds:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  typeName:
+                                                    type: string
+                                            genericDeclaration:
+                                              type: object
+                                            annotatedBounds:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  annotations:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                  declaredAnnotations:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                  type:
+                                                    type: object
+                                                    properties:
+                                                      typeName:
+                                                        type: string
+                                            typeName:
+                                              type: string
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                      synthetic:
+                                        type: boolean
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      varArgs:
+                                        type: boolean
+                                      annotatedParameterTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            type:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                      parameterCount:
+                                        type: integer
+                                        format: int32
+                                      parameterAnnotations:
+                                        type: array
+                                        items:
+                                          type: array
+                                          items:
+                                            type: object
+                                      genericParameterTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                      genericExceptionTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                      annotatedReturnType:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                      annotatedReceiverType:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                      annotatedExceptionTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            type:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      accessible:
+                                        type: boolean
+                                        deprecated: true
+                                  implicit:
+                                    type: boolean
+                            annotatedReceiverType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                        annotatedBounds:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                        typeName:
+                          type: string
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                  synthetic:
+                    type: boolean
+                  declaredAnnotations:
+                    type: array
+                    items:
+                      type: object
+                  accessible:
+                    type: boolean
+                    deprecated: true
+                  varArgs:
+                    type: boolean
+                  parameterCount:
+                    type: integer
+                    format: int32
+                  parameterAnnotations:
+                    type: array
+                    items:
+                      type: array
+                      items:
+                        type: object
+                  genericParameterTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                  genericExceptionTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                  default:
+                    type: boolean
+                  genericReturnType:
+                    type: object
+                    properties:
+                      typeName:
+                        type: string
+                  bridge:
+                    type: boolean
+                  defaultValue:
+                    type: object
+                  annotatedReturnType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                  annotatedParameterTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        type:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                  parameters:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        modifiers:
+                          type: integer
+                          format: int32
+                        synthetic:
+                          type: boolean
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        annotatedType:
+                          type: object
+                          properties:
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            type:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                        parameterizedType:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                        varArgs:
+                          type: boolean
+                        namePresent:
+                          type: boolean
+                        declaringExecutable:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            modifiers:
+                              type: integer
+                              format: int32
+                            typeParameters:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  bounds:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        typeName:
+                                          type: string
+                                  genericDeclaration:
+                                    type: object
+                                  annotatedBounds:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        declaredAnnotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        type:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                  typeName:
+                                    type: string
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                            synthetic:
+                              type: boolean
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            varArgs:
+                              type: boolean
+                            annotatedParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            parameterCount:
+                              type: integer
+                              format: int32
+                            parameterAnnotations:
+                              type: array
+                              items:
+                                type: array
+                                items:
+                                  type: object
+                            genericParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            genericExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            annotatedReturnType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedReceiverType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            accessible:
+                              type: boolean
+                              deprecated: true
+                        implicit:
+                          type: boolean
+                  annotatedReceiverType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                  annotatedExceptionTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        type:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                  annotations:
+                    type: array
+                    items:
+                      type: object
+            declaredConstructors:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  modifiers:
+                    type: integer
+                    format: int32
+                  typeParameters:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        bounds:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              typeName:
+                                type: string
+                        genericDeclaration:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            modifiers:
+                              type: integer
+                              format: int32
+                            synthetic:
+                              type: boolean
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            accessible:
+                              type: boolean
+                              deprecated: true
+                            varArgs:
+                              type: boolean
+                            parameterCount:
+                              type: integer
+                              format: int32
+                            parameterAnnotations:
+                              type: array
+                              items:
+                                type: array
+                                items:
+                                  type: object
+                            genericParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            genericExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            annotatedReturnType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedReceiverType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            parameters:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  modifiers:
+                                    type: integer
+                                    format: int32
+                                  synthetic:
+                                    type: boolean
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  annotatedType:
+                                    type: object
+                                    properties:
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      type:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                  parameterizedType:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                                  varArgs:
+                                    type: boolean
+                                  namePresent:
+                                    type: boolean
+                                  declaringExecutable:
+                                    type: object
+                                    properties:
+                                      name:
+                                        type: string
+                                      modifiers:
+                                        type: integer
+                                        format: int32
+                                      typeParameters:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            name:
+                                              type: string
+                                            bounds:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  typeName:
+                                                    type: string
+                                            genericDeclaration:
+                                              type: object
+                                            annotatedBounds:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  annotations:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                  declaredAnnotations:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                  type:
+                                                    type: object
+                                                    properties:
+                                                      typeName:
+                                                        type: string
+                                            typeName:
+                                              type: string
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                      synthetic:
+                                        type: boolean
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      varArgs:
+                                        type: boolean
+                                      annotatedParameterTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            type:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                      parameterCount:
+                                        type: integer
+                                        format: int32
+                                      parameterAnnotations:
+                                        type: array
+                                        items:
+                                          type: array
+                                          items:
+                                            type: object
+                                      genericParameterTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                      genericExceptionTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                      annotatedReturnType:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                      annotatedReceiverType:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                      annotatedExceptionTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            type:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      accessible:
+                                        type: boolean
+                                        deprecated: true
+                                  implicit:
+                                    type: boolean
+                            annotatedExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                        annotatedBounds:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                        typeName:
+                          type: string
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                  synthetic:
+                    type: boolean
+                  declaredAnnotations:
+                    type: array
+                    items:
+                      type: object
+                  accessible:
+                    type: boolean
+                    deprecated: true
+                  varArgs:
+                    type: boolean
+                  parameterCount:
+                    type: integer
+                    format: int32
+                  parameterAnnotations:
+                    type: array
+                    items:
+                      type: array
+                      items:
+                        type: object
+                  genericParameterTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                  genericExceptionTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                  annotatedReturnType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                  annotatedReceiverType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                  annotatedParameterTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        type:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                  parameters:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        modifiers:
+                          type: integer
+                          format: int32
+                        synthetic:
+                          type: boolean
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        annotatedType:
+                          type: object
+                          properties:
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            type:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                        parameterizedType:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                        varArgs:
+                          type: boolean
+                        namePresent:
+                          type: boolean
+                        declaringExecutable:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            modifiers:
+                              type: integer
+                              format: int32
+                            typeParameters:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  bounds:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        typeName:
+                                          type: string
+                                  genericDeclaration:
+                                    type: object
+                                  annotatedBounds:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        declaredAnnotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        type:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                  typeName:
+                                    type: string
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                            synthetic:
+                              type: boolean
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            varArgs:
+                              type: boolean
+                            annotatedParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            parameterCount:
+                              type: integer
+                              format: int32
+                            parameterAnnotations:
+                              type: array
+                              items:
+                                type: array
+                                items:
+                                  type: object
+                            genericParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            genericExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            annotatedReturnType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedReceiverType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            accessible:
+                              type: boolean
+                              deprecated: true
+                        implicit:
+                          type: boolean
+                  annotatedExceptionTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        type:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                  annotations:
+                    type: array
+                    items:
+                      type: object
+            enumConstants:
+              type: array
+              items:
+                type: object
+            annotations:
+              type: array
+              items:
+                type: object
+            declaredAnnotations:
+              type: array
+              items:
+                type: object
+            annotatedSuperclass:
+              type: object
+              properties:
+                annotations:
+                  type: array
+                  items:
+                    type: object
+                declaredAnnotations:
+                  type: array
+                  items:
+                    type: object
+                type:
+                  type: object
+                  properties:
+                    typeName:
+                      type: string
+            annotatedInterfaces:
+              type: array
+              items:
+                type: object
+                properties:
+                  annotations:
+                    type: array
+                    items:
+                      type: object
+                  declaredAnnotations:
+                    type: array
+                    items:
+                      type: object
+                  type:
+                    type: object
+                    properties:
+                      typeName:
+                        type: string
+            sealed:
+              type: boolean
+      responses:
+        "200":
+          description: OK
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/CollectionModelEntityModelTrigger'
+        "404":
+          description: Not Found
+  /triggers/{id}:
+    get:
+      tags:
+      - trigger-entity-controller
+      description: get-trigger
+      operationId: getItemResource-trigger-get
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/EntityModelTrigger'
+        "404":
+          description: Not Found
+    put:
+      tags:
+      - trigger-entity-controller
+      description: update-trigger
+      operationId: putItemResource-trigger-put
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TriggerRequestBody'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/EntityModelTrigger'
+        "201":
+          description: Created
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/EntityModelTrigger'
+        "204":
+          description: No Content
+    delete:
+      tags:
+      - trigger-entity-controller
+      description: delete-trigger
+      operationId: deleteItemResource-trigger-delete
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "204":
+          description: No Content
+        "404":
+          description: Not Found
+    patch:
+      tags:
+      - trigger-entity-controller
+      description: patch-trigger
+      operationId: patchItemResource-trigger-patch
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TriggerRequestBody'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/EntityModelTrigger'
+        "204":
+          description: No Content
+  /workflows:
+    get:
+      tags:
+      - workflow-entity-controller
+      description: get-workflow
+      operationId: getCollectionResource-workflow-get_1
+      parameters:
+      - name: page
+        in: query
+        description: Zero-based page index (0..N)
+        required: false
+        schema:
+          minimum: 0
+          type: integer
+          default: 0
+      - name: size
+        in: query
+        description: The size of the page to be returned
+        required: false
+        schema:
+          minimum: 1
+          type: integer
+          default: 20
+      - name: sort
+        in: query
+        description: "Sorting criteria in the format: property,(asc|desc). Default\
+          \ sort order is ascending. Multiple sort criteria are supported."
+        required: false
+        schema:
+          type: array
+          items:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/PagedModelEntityModelWorkflow'
+            application/x-spring-data-compact+json:
+              schema:
+                $ref: '#/components/schemas/PagedModelEntityModelWorkflow'
+            text/uri-list:
+              schema:
+                type: string
+    post:
+      tags:
+      - workflow-entity-controller
+      description: create-workflow
+      operationId: postCollectionResource-workflow-post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WorkflowRequestBody'
+        required: true
+      responses:
+        "201":
+          description: Created
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/EntityModelWorkflow'
+  /workflows/search/getViewById:
+    get:
+      tags:
+      - workflow-search-controller
+      operationId: executeSearch-workflow-get
+      parameters:
+      - name: id
+        in: query
+        schema:
+          type: string
+      - name: type
+        in: query
+        schema:
+          type: object
+          properties:
+            name:
+              type: string
+            module:
+              type: object
+              properties:
+                name:
+                  type: string
+                classLoader:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    registeredAsParallelCapable:
+                      type: boolean
+                    parent:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        registeredAsParallelCapable:
+                          type: boolean
+                        definedPackages:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              sealed:
+                                type: boolean
+                              specificationTitle:
+                                type: string
+                              specificationVersion:
+                                type: string
+                              specificationVendor:
+                                type: string
+                              implementationTitle:
+                                type: string
+                              implementationVersion:
+                                type: string
+                              implementationVendor:
+                                type: string
+                        defaultAssertionStatus:
+                          type: boolean
+                          writeOnly: true
+                    definedPackages:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          sealed:
+                            type: boolean
+                          specificationTitle:
+                            type: string
+                          specificationVersion:
+                            type: string
+                          specificationVendor:
+                            type: string
+                          implementationTitle:
+                            type: string
+                          implementationVersion:
+                            type: string
+                          implementationVendor:
+                            type: string
+                    defaultAssertionStatus:
+                      type: boolean
+                      writeOnly: true
+                descriptor:
+                  type: object
+                  properties:
+                    open:
+                      type: boolean
+                    automatic:
+                      type: boolean
+                named:
+                  type: boolean
+                annotations:
+                  type: array
+                  items:
+                    type: object
+                declaredAnnotations:
+                  type: array
+                  items:
+                    type: object
+                packages:
+                  uniqueItems: true
+                  type: array
+                  items:
+                    type: string
+                nativeAccessEnabled:
+                  type: boolean
+                layer:
+                  type: object
+            protectionDomain:
+              type: object
+              properties:
+                principals:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                permissions:
+                  type: object
+                  properties:
+                    readOnly:
+                      type: boolean
+                classLoader:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    registeredAsParallelCapable:
+                      type: boolean
+                    parent:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        registeredAsParallelCapable:
+                          type: boolean
+                        definedPackages:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              sealed:
+                                type: boolean
+                              specificationTitle:
+                                type: string
+                              specificationVersion:
+                                type: string
+                              specificationVendor:
+                                type: string
+                              implementationTitle:
+                                type: string
+                              implementationVersion:
+                                type: string
+                              implementationVendor:
+                                type: string
+                        defaultAssertionStatus:
+                          type: boolean
+                          writeOnly: true
+                    definedPackages:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          sealed:
+                            type: boolean
+                          specificationTitle:
+                            type: string
+                          specificationVersion:
+                            type: string
+                          specificationVendor:
+                            type: string
+                          implementationTitle:
+                            type: string
+                          implementationVersion:
+                            type: string
+                          implementationVendor:
+                            type: string
+                    defaultAssertionStatus:
+                      type: boolean
+                      writeOnly: true
+                codeSource:
+                  type: object
+                  properties:
+                    location:
+                      type: string
+                      format: url
+                    certificates:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          type:
+                            type: string
+                          encoded:
+                            type: string
+                            format: byte
+                          publicKey:
+                            type: object
+                            properties:
+                              encoded:
+                                type: string
+                                format: byte
+                              format:
+                                type: string
+                              algorithm:
+                                type: string
+                    codeSigners:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          signerCertPath:
+                            type: object
+                            properties:
+                              certificates:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    type:
+                                      type: string
+                                    encoded:
+                                      type: string
+                                      format: byte
+                                    publicKey:
+                                      type: object
+                                      properties:
+                                        encoded:
+                                          type: string
+                                          format: byte
+                                        format:
+                                          type: string
+                                        algorithm:
+                                          type: string
+                              type:
+                                type: string
+                              encoded:
+                                type: string
+                                format: byte
+                              encodings:
+                                type: object
+                          timestamp:
+                            type: object
+                            properties:
+                              timestamp:
+                                type: string
+                                format: date-time
+                              signerCertPath:
+                                type: object
+                                properties:
+                                  certificates:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        type:
+                                          type: string
+                                        encoded:
+                                          type: string
+                                          format: byte
+                                        publicKey:
+                                          type: object
+                                          properties:
+                                            encoded:
+                                              type: string
+                                              format: byte
+                                            format:
+                                              type: string
+                                            algorithm:
+                                              type: string
+                                  type:
+                                    type: string
+                                  encoded:
+                                    type: string
+                                    format: byte
+                                  encodings:
+                                    type: object
+            modifiers:
+              type: integer
+              format: int32
+            interface:
+              type: boolean
+            array:
+              type: boolean
+            primitive:
+              type: boolean
+            hidden:
+              type: boolean
+            annotation:
+              type: boolean
+            enum:
+              type: boolean
+            record:
+              type: boolean
+            typeParameters:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  bounds:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                  annotatedBounds:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        type:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                  typeName:
+                    type: string
+                  annotations:
+                    type: array
+                    items:
+                      type: object
+                  declaredAnnotations:
+                    type: array
+                    items:
+                      type: object
+            classLoader:
+              type: object
+              properties:
+                name:
+                  type: string
+                registeredAsParallelCapable:
+                  type: boolean
+                parent:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    registeredAsParallelCapable:
+                      type: boolean
+                    definedPackages:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          sealed:
+                            type: boolean
+                          specificationTitle:
+                            type: string
+                          specificationVersion:
+                            type: string
+                          specificationVendor:
+                            type: string
+                          implementationTitle:
+                            type: string
+                          implementationVersion:
+                            type: string
+                          implementationVendor:
+                            type: string
+                    defaultAssertionStatus:
+                      type: boolean
+                      writeOnly: true
+                unnamedModule:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    classLoader:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        registeredAsParallelCapable:
+                          type: boolean
+                        parent:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            registeredAsParallelCapable:
+                              type: boolean
+                            definedPackages:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  sealed:
+                                    type: boolean
+                                  specificationTitle:
+                                    type: string
+                                  specificationVersion:
+                                    type: string
+                                  specificationVendor:
+                                    type: string
+                                  implementationTitle:
+                                    type: string
+                                  implementationVersion:
+                                    type: string
+                                  implementationVendor:
+                                    type: string
+                            defaultAssertionStatus:
+                              type: boolean
+                              writeOnly: true
+                        definedPackages:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              name:
+                                type: string
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              sealed:
+                                type: boolean
+                              specificationTitle:
+                                type: string
+                              specificationVersion:
+                                type: string
+                              specificationVendor:
+                                type: string
+                              implementationTitle:
+                                type: string
+                              implementationVersion:
+                                type: string
+                              implementationVendor:
+                                type: string
+                        defaultAssertionStatus:
+                          type: boolean
+                          writeOnly: true
+                    descriptor:
+                      type: object
+                      properties:
+                        open:
+                          type: boolean
+                        automatic:
+                          type: boolean
+                    named:
+                      type: boolean
+                    annotations:
+                      type: array
+                      items:
+                        type: object
+                    declaredAnnotations:
+                      type: array
+                      items:
+                        type: object
+                    packages:
+                      uniqueItems: true
+                      type: array
+                      items:
+                        type: string
+                    nativeAccessEnabled:
+                      type: boolean
+                    layer:
+                      type: object
+                definedPackages:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      sealed:
+                        type: boolean
+                      specificationTitle:
+                        type: string
+                      specificationVersion:
+                        type: string
+                      specificationVendor:
+                        type: string
+                      implementationTitle:
+                        type: string
+                      implementationVersion:
+                        type: string
+                      implementationVendor:
+                        type: string
+                defaultAssertionStatus:
+                  type: boolean
+                  writeOnly: true
+            memberClass:
+              type: boolean
+            localClass:
+              type: boolean
+            anonymousClass:
+              type: boolean
+            unnamedClass:
+              type: boolean
+            simpleName:
+              type: string
+            canonicalName:
+              type: string
+            synthetic:
+              type: boolean
+            packageName:
+              type: string
+            genericSuperclass:
+              type: object
+              properties:
+                typeName:
+                  type: string
+            package:
+              type: object
+              properties:
+                name:
+                  type: string
+                annotations:
+                  type: array
+                  items:
+                    type: object
+                declaredAnnotations:
+                  type: array
+                  items:
+                    type: object
+                sealed:
+                  type: boolean
+                specificationTitle:
+                  type: string
+                specificationVersion:
+                  type: string
+                specificationVendor:
+                  type: string
+                implementationTitle:
+                  type: string
+                implementationVersion:
+                  type: string
+                implementationVendor:
+                  type: string
+            genericInterfaces:
+              type: array
+              items:
+                type: object
+                properties:
+                  typeName:
+                    type: string
+            signers:
+              type: array
+              items:
+                type: object
+            enclosingMethod:
+              type: object
+              properties:
+                name:
+                  type: string
+                modifiers:
+                  type: integer
+                  format: int32
+                typeParameters:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      bounds:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                      genericDeclaration:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          modifiers:
+                            type: integer
+                            format: int32
+                          synthetic:
+                            type: boolean
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          accessible:
+                            type: boolean
+                            deprecated: true
+                          varArgs:
+                            type: boolean
+                          parameterCount:
+                            type: integer
+                            format: int32
+                          parameterAnnotations:
+                            type: array
+                            items:
+                              type: array
+                              items:
+                                type: object
+                          genericParameterTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                          genericExceptionTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                          default:
+                            type: boolean
+                          genericReturnType:
+                            type: object
+                            properties:
+                              typeName:
+                                type: string
+                          bridge:
+                            type: boolean
+                          defaultValue:
+                            type: object
+                          annotatedReturnType:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                          annotatedParameterTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                          parameters:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                modifiers:
+                                  type: integer
+                                  format: int32
+                                synthetic:
+                                  type: boolean
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                annotatedType:
+                                  type: object
+                                  properties:
+                                    annotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    declaredAnnotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    type:
+                                      type: object
+                                      properties:
+                                        typeName:
+                                          type: string
+                                parameterizedType:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                                varArgs:
+                                  type: boolean
+                                namePresent:
+                                  type: boolean
+                                declaringExecutable:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                    modifiers:
+                                      type: integer
+                                      format: int32
+                                    typeParameters:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          name:
+                                            type: string
+                                          bounds:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                          genericDeclaration:
+                                            type: object
+                                          annotatedBounds:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                annotations:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                declaredAnnotations:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                type:
+                                                  type: object
+                                                  properties:
+                                                    typeName:
+                                                      type: string
+                                          typeName:
+                                            type: string
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                    synthetic:
+                                      type: boolean
+                                    declaredAnnotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    varArgs:
+                                      type: boolean
+                                    annotatedParameterTypes:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                    parameterCount:
+                                      type: integer
+                                      format: int32
+                                    parameterAnnotations:
+                                      type: array
+                                      items:
+                                        type: array
+                                        items:
+                                          type: object
+                                    genericParameterTypes:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                    genericExceptionTypes:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                    annotatedReturnType:
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        declaredAnnotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        type:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                    annotatedReceiverType:
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        declaredAnnotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        type:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                    annotatedExceptionTypes:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                    annotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    accessible:
+                                      type: boolean
+                                      deprecated: true
+                                implicit:
+                                  type: boolean
+                          annotatedReceiverType:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                          annotatedExceptionTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                      annotatedBounds:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            type:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                      typeName:
+                        type: string
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                synthetic:
+                  type: boolean
+                declaredAnnotations:
+                  type: array
+                  items:
+                    type: object
+                accessible:
+                  type: boolean
+                  deprecated: true
+                varArgs:
+                  type: boolean
+                parameterCount:
+                  type: integer
+                  format: int32
+                parameterAnnotations:
+                  type: array
+                  items:
+                    type: array
+                    items:
+                      type: object
+                genericParameterTypes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      typeName:
+                        type: string
+                genericExceptionTypes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      typeName:
+                        type: string
+                default:
+                  type: boolean
+                genericReturnType:
+                  type: object
+                  properties:
+                    typeName:
+                      type: string
+                bridge:
+                  type: boolean
+                defaultValue:
+                  type: object
+                annotatedReturnType:
+                  type: object
+                  properties:
+                    annotations:
+                      type: array
+                      items:
+                        type: object
+                    declaredAnnotations:
+                      type: array
+                      items:
+                        type: object
+                    type:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                annotatedParameterTypes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                parameters:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      modifiers:
+                        type: integer
+                        format: int32
+                      synthetic:
+                        type: boolean
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      annotatedType:
+                        type: object
+                        properties:
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          type:
+                            type: object
+                            properties:
+                              typeName:
+                                type: string
+                      parameterizedType:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                      varArgs:
+                        type: boolean
+                      namePresent:
+                        type: boolean
+                      declaringExecutable:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          modifiers:
+                            type: integer
+                            format: int32
+                          typeParameters:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                bounds:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                                genericDeclaration:
+                                  type: object
+                                annotatedBounds:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      type:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                typeName:
+                                  type: string
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                          synthetic:
+                            type: boolean
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          varArgs:
+                            type: boolean
+                          annotatedParameterTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                          parameterCount:
+                            type: integer
+                            format: int32
+                          parameterAnnotations:
+                            type: array
+                            items:
+                              type: array
+                              items:
+                                type: object
+                          genericParameterTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                          genericExceptionTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                          annotatedReturnType:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                          annotatedReceiverType:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                          annotatedExceptionTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                          accessible:
+                            type: boolean
+                            deprecated: true
+                      implicit:
+                        type: boolean
+                annotatedReceiverType:
+                  type: object
+                  properties:
+                    annotations:
+                      type: array
+                      items:
+                        type: object
+                    declaredAnnotations:
+                      type: array
+                      items:
+                        type: object
+                    type:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                annotatedExceptionTypes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                annotations:
+                  type: array
+                  items:
+                    type: object
+            enclosingConstructor:
+              type: object
+              properties:
+                name:
+                  type: string
+                modifiers:
+                  type: integer
+                  format: int32
+                typeParameters:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      bounds:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                      genericDeclaration:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          modifiers:
+                            type: integer
+                            format: int32
+                          synthetic:
+                            type: boolean
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          accessible:
+                            type: boolean
+                            deprecated: true
+                          varArgs:
+                            type: boolean
+                          parameterCount:
+                            type: integer
+                            format: int32
+                          parameterAnnotations:
+                            type: array
+                            items:
+                              type: array
+                              items:
+                                type: object
+                          genericParameterTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                          genericExceptionTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                          annotatedReturnType:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                          annotatedReceiverType:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                          annotatedParameterTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                          parameters:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                modifiers:
+                                  type: integer
+                                  format: int32
+                                synthetic:
+                                  type: boolean
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                annotatedType:
+                                  type: object
+                                  properties:
+                                    annotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    declaredAnnotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    type:
+                                      type: object
+                                      properties:
+                                        typeName:
+                                          type: string
+                                parameterizedType:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                                varArgs:
+                                  type: boolean
+                                namePresent:
+                                  type: boolean
+                                declaringExecutable:
+                                  type: object
+                                  properties:
+                                    name:
+                                      type: string
+                                    modifiers:
+                                      type: integer
+                                      format: int32
+                                    typeParameters:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          name:
+                                            type: string
+                                          bounds:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                          genericDeclaration:
+                                            type: object
+                                          annotatedBounds:
+                                            type: array
+                                            items:
+                                              type: object
+                                              properties:
+                                                annotations:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                declaredAnnotations:
+                                                  type: array
+                                                  items:
+                                                    type: object
+                                                type:
+                                                  type: object
+                                                  properties:
+                                                    typeName:
+                                                      type: string
+                                          typeName:
+                                            type: string
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                    synthetic:
+                                      type: boolean
+                                    declaredAnnotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    varArgs:
+                                      type: boolean
+                                    annotatedParameterTypes:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                    parameterCount:
+                                      type: integer
+                                      format: int32
+                                    parameterAnnotations:
+                                      type: array
+                                      items:
+                                        type: array
+                                        items:
+                                          type: object
+                                    genericParameterTypes:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                    genericExceptionTypes:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                    annotatedReturnType:
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        declaredAnnotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        type:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                    annotatedReceiverType:
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        declaredAnnotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        type:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                    annotatedExceptionTypes:
+                                      type: array
+                                      items:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                    annotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    accessible:
+                                      type: boolean
+                                      deprecated: true
+                                implicit:
+                                  type: boolean
+                          annotatedExceptionTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                      annotatedBounds:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            type:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                      typeName:
+                        type: string
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                synthetic:
+                  type: boolean
+                declaredAnnotations:
+                  type: array
+                  items:
+                    type: object
+                accessible:
+                  type: boolean
+                  deprecated: true
+                varArgs:
+                  type: boolean
+                parameterCount:
+                  type: integer
+                  format: int32
+                parameterAnnotations:
+                  type: array
+                  items:
+                    type: array
+                    items:
+                      type: object
+                genericParameterTypes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      typeName:
+                        type: string
+                genericExceptionTypes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      typeName:
+                        type: string
+                annotatedReturnType:
+                  type: object
+                  properties:
+                    annotations:
+                      type: array
+                      items:
+                        type: object
+                    declaredAnnotations:
+                      type: array
+                      items:
+                        type: object
+                    type:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                annotatedReceiverType:
+                  type: object
+                  properties:
+                    annotations:
+                      type: array
+                      items:
+                        type: object
+                    declaredAnnotations:
+                      type: array
+                      items:
+                        type: object
+                    type:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                annotatedParameterTypes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                parameters:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      modifiers:
+                        type: integer
+                        format: int32
+                      synthetic:
+                        type: boolean
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      annotatedType:
+                        type: object
+                        properties:
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          type:
+                            type: object
+                            properties:
+                              typeName:
+                                type: string
+                      parameterizedType:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                      varArgs:
+                        type: boolean
+                      namePresent:
+                        type: boolean
+                      declaringExecutable:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          modifiers:
+                            type: integer
+                            format: int32
+                          typeParameters:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                bounds:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                                genericDeclaration:
+                                  type: object
+                                annotatedBounds:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      type:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                typeName:
+                                  type: string
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                          synthetic:
+                            type: boolean
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          varArgs:
+                            type: boolean
+                          annotatedParameterTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                          parameterCount:
+                            type: integer
+                            format: int32
+                          parameterAnnotations:
+                            type: array
+                            items:
+                              type: array
+                              items:
+                                type: object
+                          genericParameterTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                          genericExceptionTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                          annotatedReturnType:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                          annotatedReceiverType:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                          annotatedExceptionTypes:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                          accessible:
+                            type: boolean
+                            deprecated: true
+                      implicit:
+                        type: boolean
+                annotatedExceptionTypes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                annotations:
+                  type: array
+                  items:
+                    type: object
+            typeName:
+              type: string
+            fields:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  modifiers:
+                    type: integer
+                    format: int32
+                  synthetic:
+                    type: boolean
+                  declaredAnnotations:
+                    type: array
+                    items:
+                      type: object
+                  accessible:
+                    type: boolean
+                    deprecated: true
+                  genericType:
+                    type: object
+                    properties:
+                      typeName:
+                        type: string
+                  enumConstant:
+                    type: boolean
+                  annotatedType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                  annotations:
+                    type: array
+                    items:
+                      type: object
+            methods:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  modifiers:
+                    type: integer
+                    format: int32
+                  typeParameters:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        bounds:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              typeName:
+                                type: string
+                        genericDeclaration:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            modifiers:
+                              type: integer
+                              format: int32
+                            synthetic:
+                              type: boolean
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            accessible:
+                              type: boolean
+                              deprecated: true
+                            varArgs:
+                              type: boolean
+                            parameterCount:
+                              type: integer
+                              format: int32
+                            parameterAnnotations:
+                              type: array
+                              items:
+                                type: array
+                                items:
+                                  type: object
+                            genericParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            genericExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            default:
+                              type: boolean
+                            genericReturnType:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                            bridge:
+                              type: boolean
+                            defaultValue:
+                              type: object
+                            annotatedReturnType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            parameters:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  modifiers:
+                                    type: integer
+                                    format: int32
+                                  synthetic:
+                                    type: boolean
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  annotatedType:
+                                    type: object
+                                    properties:
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      type:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                  parameterizedType:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                                  varArgs:
+                                    type: boolean
+                                  namePresent:
+                                    type: boolean
+                                  declaringExecutable:
+                                    type: object
+                                    properties:
+                                      name:
+                                        type: string
+                                      modifiers:
+                                        type: integer
+                                        format: int32
+                                      typeParameters:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            name:
+                                              type: string
+                                            bounds:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  typeName:
+                                                    type: string
+                                            genericDeclaration:
+                                              type: object
+                                            annotatedBounds:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  annotations:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                  declaredAnnotations:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                  type:
+                                                    type: object
+                                                    properties:
+                                                      typeName:
+                                                        type: string
+                                            typeName:
+                                              type: string
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                      synthetic:
+                                        type: boolean
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      varArgs:
+                                        type: boolean
+                                      annotatedParameterTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            type:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                      parameterCount:
+                                        type: integer
+                                        format: int32
+                                      parameterAnnotations:
+                                        type: array
+                                        items:
+                                          type: array
+                                          items:
+                                            type: object
+                                      genericParameterTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                      genericExceptionTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                      annotatedReturnType:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                      annotatedReceiverType:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                      annotatedExceptionTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            type:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      accessible:
+                                        type: boolean
+                                        deprecated: true
+                                  implicit:
+                                    type: boolean
+                            annotatedReceiverType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                        annotatedBounds:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                        typeName:
+                          type: string
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                  synthetic:
+                    type: boolean
+                  declaredAnnotations:
+                    type: array
+                    items:
+                      type: object
+                  accessible:
+                    type: boolean
+                    deprecated: true
+                  varArgs:
+                    type: boolean
+                  parameterCount:
+                    type: integer
+                    format: int32
+                  parameterAnnotations:
+                    type: array
+                    items:
+                      type: array
+                      items:
+                        type: object
+                  genericParameterTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                  genericExceptionTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                  default:
+                    type: boolean
+                  genericReturnType:
+                    type: object
+                    properties:
+                      typeName:
+                        type: string
+                  bridge:
+                    type: boolean
+                  defaultValue:
+                    type: object
+                  annotatedReturnType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                  annotatedParameterTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        type:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                  parameters:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        modifiers:
+                          type: integer
+                          format: int32
+                        synthetic:
+                          type: boolean
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        annotatedType:
+                          type: object
+                          properties:
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            type:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                        parameterizedType:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                        varArgs:
+                          type: boolean
+                        namePresent:
+                          type: boolean
+                        declaringExecutable:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            modifiers:
+                              type: integer
+                              format: int32
+                            typeParameters:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  bounds:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        typeName:
+                                          type: string
+                                  genericDeclaration:
+                                    type: object
+                                  annotatedBounds:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        declaredAnnotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        type:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                  typeName:
+                                    type: string
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                            synthetic:
+                              type: boolean
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            varArgs:
+                              type: boolean
+                            annotatedParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            parameterCount:
+                              type: integer
+                              format: int32
+                            parameterAnnotations:
+                              type: array
+                              items:
+                                type: array
+                                items:
+                                  type: object
+                            genericParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            genericExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            annotatedReturnType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedReceiverType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            accessible:
+                              type: boolean
+                              deprecated: true
+                        implicit:
+                          type: boolean
+                  annotatedReceiverType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                  annotatedExceptionTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        type:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                  annotations:
+                    type: array
+                    items:
+                      type: object
+            constructors:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  modifiers:
+                    type: integer
+                    format: int32
+                  typeParameters:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        bounds:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              typeName:
+                                type: string
+                        genericDeclaration:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            modifiers:
+                              type: integer
+                              format: int32
+                            synthetic:
+                              type: boolean
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            accessible:
+                              type: boolean
+                              deprecated: true
+                            varArgs:
+                              type: boolean
+                            parameterCount:
+                              type: integer
+                              format: int32
+                            parameterAnnotations:
+                              type: array
+                              items:
+                                type: array
+                                items:
+                                  type: object
+                            genericParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            genericExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            annotatedReturnType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedReceiverType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            parameters:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  modifiers:
+                                    type: integer
+                                    format: int32
+                                  synthetic:
+                                    type: boolean
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  annotatedType:
+                                    type: object
+                                    properties:
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      type:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                  parameterizedType:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                                  varArgs:
+                                    type: boolean
+                                  namePresent:
+                                    type: boolean
+                                  declaringExecutable:
+                                    type: object
+                                    properties:
+                                      name:
+                                        type: string
+                                      modifiers:
+                                        type: integer
+                                        format: int32
+                                      typeParameters:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            name:
+                                              type: string
+                                            bounds:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  typeName:
+                                                    type: string
+                                            genericDeclaration:
+                                              type: object
+                                            annotatedBounds:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  annotations:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                  declaredAnnotations:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                  type:
+                                                    type: object
+                                                    properties:
+                                                      typeName:
+                                                        type: string
+                                            typeName:
+                                              type: string
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                      synthetic:
+                                        type: boolean
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      varArgs:
+                                        type: boolean
+                                      annotatedParameterTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            type:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                      parameterCount:
+                                        type: integer
+                                        format: int32
+                                      parameterAnnotations:
+                                        type: array
+                                        items:
+                                          type: array
+                                          items:
+                                            type: object
+                                      genericParameterTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                      genericExceptionTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                      annotatedReturnType:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                      annotatedReceiverType:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                      annotatedExceptionTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            type:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      accessible:
+                                        type: boolean
+                                        deprecated: true
+                                  implicit:
+                                    type: boolean
+                            annotatedExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                        annotatedBounds:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                        typeName:
+                          type: string
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                  synthetic:
+                    type: boolean
+                  declaredAnnotations:
+                    type: array
+                    items:
+                      type: object
+                  accessible:
+                    type: boolean
+                    deprecated: true
+                  varArgs:
+                    type: boolean
+                  parameterCount:
+                    type: integer
+                    format: int32
+                  parameterAnnotations:
+                    type: array
+                    items:
+                      type: array
+                      items:
+                        type: object
+                  genericParameterTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                  genericExceptionTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                  annotatedReturnType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                  annotatedReceiverType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                  annotatedParameterTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        type:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                  parameters:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        modifiers:
+                          type: integer
+                          format: int32
+                        synthetic:
+                          type: boolean
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        annotatedType:
+                          type: object
+                          properties:
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            type:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                        parameterizedType:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                        varArgs:
+                          type: boolean
+                        namePresent:
+                          type: boolean
+                        declaringExecutable:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            modifiers:
+                              type: integer
+                              format: int32
+                            typeParameters:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  bounds:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        typeName:
+                                          type: string
+                                  genericDeclaration:
+                                    type: object
+                                  annotatedBounds:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        declaredAnnotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        type:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                  typeName:
+                                    type: string
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                            synthetic:
+                              type: boolean
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            varArgs:
+                              type: boolean
+                            annotatedParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            parameterCount:
+                              type: integer
+                              format: int32
+                            parameterAnnotations:
+                              type: array
+                              items:
+                                type: array
+                                items:
+                                  type: object
+                            genericParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            genericExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            annotatedReturnType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedReceiverType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            accessible:
+                              type: boolean
+                              deprecated: true
+                        implicit:
+                          type: boolean
+                  annotatedExceptionTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        type:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                  annotations:
+                    type: array
+                    items:
+                      type: object
+            declaredFields:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  modifiers:
+                    type: integer
+                    format: int32
+                  synthetic:
+                    type: boolean
+                  declaredAnnotations:
+                    type: array
+                    items:
+                      type: object
+                  accessible:
+                    type: boolean
+                    deprecated: true
+                  genericType:
+                    type: object
+                    properties:
+                      typeName:
+                        type: string
+                  enumConstant:
+                    type: boolean
+                  annotatedType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                  annotations:
+                    type: array
+                    items:
+                      type: object
+            recordComponents:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  accessor:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      modifiers:
+                        type: integer
+                        format: int32
+                      synthetic:
+                        type: boolean
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      accessible:
+                        type: boolean
+                        deprecated: true
+                      varArgs:
+                        type: boolean
+                      parameterCount:
+                        type: integer
+                        format: int32
+                      parameterAnnotations:
+                        type: array
+                        items:
+                          type: array
+                          items:
+                            type: object
+                      genericParameterTypes:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                      genericExceptionTypes:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                      default:
+                        type: boolean
+                      genericReturnType:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                      bridge:
+                        type: boolean
+                      defaultValue:
+                        type: object
+                      annotatedReturnType:
+                        type: object
+                        properties:
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          type:
+                            type: object
+                            properties:
+                              typeName:
+                                type: string
+                      annotatedParameterTypes:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            type:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                      parameters:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            modifiers:
+                              type: integer
+                              format: int32
+                            synthetic:
+                              type: boolean
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            annotatedType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            parameterizedType:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                            varArgs:
+                              type: boolean
+                            namePresent:
+                              type: boolean
+                            declaringExecutable:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                modifiers:
+                                  type: integer
+                                  format: int32
+                                typeParameters:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      name:
+                                        type: string
+                                      bounds:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                      genericDeclaration:
+                                        type: object
+                                      annotatedBounds:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            type:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                      typeName:
+                                        type: string
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                synthetic:
+                                  type: boolean
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                varArgs:
+                                  type: boolean
+                                annotatedParameterTypes:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      type:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                parameterCount:
+                                  type: integer
+                                  format: int32
+                                parameterAnnotations:
+                                  type: array
+                                  items:
+                                    type: array
+                                    items:
+                                      type: object
+                                genericParameterTypes:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                                genericExceptionTypes:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                                annotatedReturnType:
+                                  type: object
+                                  properties:
+                                    annotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    declaredAnnotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    type:
+                                      type: object
+                                      properties:
+                                        typeName:
+                                          type: string
+                                annotatedReceiverType:
+                                  type: object
+                                  properties:
+                                    annotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    declaredAnnotations:
+                                      type: array
+                                      items:
+                                        type: object
+                                    type:
+                                      type: object
+                                      properties:
+                                        typeName:
+                                          type: string
+                                annotatedExceptionTypes:
+                                  type: array
+                                  items:
+                                    type: object
+                                    properties:
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      type:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                accessible:
+                                  type: boolean
+                                  deprecated: true
+                            implicit:
+                              type: boolean
+                      annotatedReceiverType:
+                        type: object
+                        properties:
+                          annotations:
+                            type: array
+                            items:
+                              type: object
+                          declaredAnnotations:
+                            type: array
+                            items:
+                              type: object
+                          type:
+                            type: object
+                            properties:
+                              typeName:
+                                type: string
+                      annotatedExceptionTypes:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            type:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                  annotations:
+                    type: array
+                    items:
+                      type: object
+                  declaredAnnotations:
+                    type: array
+                    items:
+                      type: object
+                  genericSignature:
+                    type: string
+                  genericType:
+                    type: object
+                    properties:
+                      typeName:
+                        type: string
+                  annotatedType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+            declaredMethods:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  modifiers:
+                    type: integer
+                    format: int32
+                  typeParameters:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        bounds:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              typeName:
+                                type: string
+                        genericDeclaration:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            modifiers:
+                              type: integer
+                              format: int32
+                            synthetic:
+                              type: boolean
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            accessible:
+                              type: boolean
+                              deprecated: true
+                            varArgs:
+                              type: boolean
+                            parameterCount:
+                              type: integer
+                              format: int32
+                            parameterAnnotations:
+                              type: array
+                              items:
+                                type: array
+                                items:
+                                  type: object
+                            genericParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            genericExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            default:
+                              type: boolean
+                            genericReturnType:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                            bridge:
+                              type: boolean
+                            defaultValue:
+                              type: object
+                            annotatedReturnType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            parameters:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  modifiers:
+                                    type: integer
+                                    format: int32
+                                  synthetic:
+                                    type: boolean
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  annotatedType:
+                                    type: object
+                                    properties:
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      type:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                  parameterizedType:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                                  varArgs:
+                                    type: boolean
+                                  namePresent:
+                                    type: boolean
+                                  declaringExecutable:
+                                    type: object
+                                    properties:
+                                      name:
+                                        type: string
+                                      modifiers:
+                                        type: integer
+                                        format: int32
+                                      typeParameters:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            name:
+                                              type: string
+                                            bounds:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  typeName:
+                                                    type: string
+                                            genericDeclaration:
+                                              type: object
+                                            annotatedBounds:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  annotations:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                  declaredAnnotations:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                  type:
+                                                    type: object
+                                                    properties:
+                                                      typeName:
+                                                        type: string
+                                            typeName:
+                                              type: string
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                      synthetic:
+                                        type: boolean
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      varArgs:
+                                        type: boolean
+                                      annotatedParameterTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            type:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                      parameterCount:
+                                        type: integer
+                                        format: int32
+                                      parameterAnnotations:
+                                        type: array
+                                        items:
+                                          type: array
+                                          items:
+                                            type: object
+                                      genericParameterTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                      genericExceptionTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                      annotatedReturnType:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                      annotatedReceiverType:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                      annotatedExceptionTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            type:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      accessible:
+                                        type: boolean
+                                        deprecated: true
+                                  implicit:
+                                    type: boolean
+                            annotatedReceiverType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                        annotatedBounds:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                        typeName:
+                          type: string
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                  synthetic:
+                    type: boolean
+                  declaredAnnotations:
+                    type: array
+                    items:
+                      type: object
+                  accessible:
+                    type: boolean
+                    deprecated: true
+                  varArgs:
+                    type: boolean
+                  parameterCount:
+                    type: integer
+                    format: int32
+                  parameterAnnotations:
+                    type: array
+                    items:
+                      type: array
+                      items:
+                        type: object
+                  genericParameterTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                  genericExceptionTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                  default:
+                    type: boolean
+                  genericReturnType:
+                    type: object
+                    properties:
+                      typeName:
+                        type: string
+                  bridge:
+                    type: boolean
+                  defaultValue:
+                    type: object
+                  annotatedReturnType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                  annotatedParameterTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        type:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                  parameters:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        modifiers:
+                          type: integer
+                          format: int32
+                        synthetic:
+                          type: boolean
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        annotatedType:
+                          type: object
+                          properties:
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            type:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                        parameterizedType:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                        varArgs:
+                          type: boolean
+                        namePresent:
+                          type: boolean
+                        declaringExecutable:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            modifiers:
+                              type: integer
+                              format: int32
+                            typeParameters:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  bounds:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        typeName:
+                                          type: string
+                                  genericDeclaration:
+                                    type: object
+                                  annotatedBounds:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        declaredAnnotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        type:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                  typeName:
+                                    type: string
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                            synthetic:
+                              type: boolean
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            varArgs:
+                              type: boolean
+                            annotatedParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            parameterCount:
+                              type: integer
+                              format: int32
+                            parameterAnnotations:
+                              type: array
+                              items:
+                                type: array
+                                items:
+                                  type: object
+                            genericParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            genericExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            annotatedReturnType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedReceiverType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            accessible:
+                              type: boolean
+                              deprecated: true
+                        implicit:
+                          type: boolean
+                  annotatedReceiverType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                  annotatedExceptionTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        type:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                  annotations:
+                    type: array
+                    items:
+                      type: object
+            declaredConstructors:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  modifiers:
+                    type: integer
+                    format: int32
+                  typeParameters:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        bounds:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              typeName:
+                                type: string
+                        genericDeclaration:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            modifiers:
+                              type: integer
+                              format: int32
+                            synthetic:
+                              type: boolean
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            accessible:
+                              type: boolean
+                              deprecated: true
+                            varArgs:
+                              type: boolean
+                            parameterCount:
+                              type: integer
+                              format: int32
+                            parameterAnnotations:
+                              type: array
+                              items:
+                                type: array
+                                items:
+                                  type: object
+                            genericParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            genericExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            annotatedReturnType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedReceiverType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            parameters:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  modifiers:
+                                    type: integer
+                                    format: int32
+                                  synthetic:
+                                    type: boolean
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  annotatedType:
+                                    type: object
+                                    properties:
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      type:
+                                        type: object
+                                        properties:
+                                          typeName:
+                                            type: string
+                                  parameterizedType:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                                  varArgs:
+                                    type: boolean
+                                  namePresent:
+                                    type: boolean
+                                  declaringExecutable:
+                                    type: object
+                                    properties:
+                                      name:
+                                        type: string
+                                      modifiers:
+                                        type: integer
+                                        format: int32
+                                      typeParameters:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            name:
+                                              type: string
+                                            bounds:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  typeName:
+                                                    type: string
+                                            genericDeclaration:
+                                              type: object
+                                            annotatedBounds:
+                                              type: array
+                                              items:
+                                                type: object
+                                                properties:
+                                                  annotations:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                  declaredAnnotations:
+                                                    type: array
+                                                    items:
+                                                      type: object
+                                                  type:
+                                                    type: object
+                                                    properties:
+                                                      typeName:
+                                                        type: string
+                                            typeName:
+                                              type: string
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                      synthetic:
+                                        type: boolean
+                                      declaredAnnotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      varArgs:
+                                        type: boolean
+                                      annotatedParameterTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            type:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                      parameterCount:
+                                        type: integer
+                                        format: int32
+                                      parameterAnnotations:
+                                        type: array
+                                        items:
+                                          type: array
+                                          items:
+                                            type: object
+                                      genericParameterTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                      genericExceptionTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                      annotatedReturnType:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                      annotatedReceiverType:
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          declaredAnnotations:
+                                            type: array
+                                            items:
+                                              type: object
+                                          type:
+                                            type: object
+                                            properties:
+                                              typeName:
+                                                type: string
+                                      annotatedExceptionTypes:
+                                        type: array
+                                        items:
+                                          type: object
+                                          properties:
+                                            annotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            declaredAnnotations:
+                                              type: array
+                                              items:
+                                                type: object
+                                            type:
+                                              type: object
+                                              properties:
+                                                typeName:
+                                                  type: string
+                                      annotations:
+                                        type: array
+                                        items:
+                                          type: object
+                                      accessible:
+                                        type: boolean
+                                        deprecated: true
+                                  implicit:
+                                    type: boolean
+                            annotatedExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                        annotatedBounds:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              annotations:
+                                type: array
+                                items:
+                                  type: object
+                              declaredAnnotations:
+                                type: array
+                                items:
+                                  type: object
+                              type:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                        typeName:
+                          type: string
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                  synthetic:
+                    type: boolean
+                  declaredAnnotations:
+                    type: array
+                    items:
+                      type: object
+                  accessible:
+                    type: boolean
+                    deprecated: true
+                  varArgs:
+                    type: boolean
+                  parameterCount:
+                    type: integer
+                    format: int32
+                  parameterAnnotations:
+                    type: array
+                    items:
+                      type: array
+                      items:
+                        type: object
+                  genericParameterTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                  genericExceptionTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        typeName:
+                          type: string
+                  annotatedReturnType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                  annotatedReceiverType:
+                    type: object
+                    properties:
+                      annotations:
+                        type: array
+                        items:
+                          type: object
+                      declaredAnnotations:
+                        type: array
+                        items:
+                          type: object
+                      type:
+                        type: object
+                        properties:
+                          typeName:
+                            type: string
+                  annotatedParameterTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        type:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                  parameters:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        modifiers:
+                          type: integer
+                          format: int32
+                        synthetic:
+                          type: boolean
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        annotatedType:
+                          type: object
+                          properties:
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            type:
+                              type: object
+                              properties:
+                                typeName:
+                                  type: string
+                        parameterizedType:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                        varArgs:
+                          type: boolean
+                        namePresent:
+                          type: boolean
+                        declaringExecutable:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            modifiers:
+                              type: integer
+                              format: int32
+                            typeParameters:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  bounds:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        typeName:
+                                          type: string
+                                  genericDeclaration:
+                                    type: object
+                                  annotatedBounds:
+                                    type: array
+                                    items:
+                                      type: object
+                                      properties:
+                                        annotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        declaredAnnotations:
+                                          type: array
+                                          items:
+                                            type: object
+                                        type:
+                                          type: object
+                                          properties:
+                                            typeName:
+                                              type: string
+                                  typeName:
+                                    type: string
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                            synthetic:
+                              type: boolean
+                            declaredAnnotations:
+                              type: array
+                              items:
+                                type: object
+                            varArgs:
+                              type: boolean
+                            annotatedParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            parameterCount:
+                              type: integer
+                              format: int32
+                            parameterAnnotations:
+                              type: array
+                              items:
+                                type: array
+                                items:
+                                  type: object
+                            genericParameterTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            genericExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  typeName:
+                                    type: string
+                            annotatedReturnType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedReceiverType:
+                              type: object
+                              properties:
+                                annotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                declaredAnnotations:
+                                  type: array
+                                  items:
+                                    type: object
+                                type:
+                                  type: object
+                                  properties:
+                                    typeName:
+                                      type: string
+                            annotatedExceptionTypes:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  annotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  declaredAnnotations:
+                                    type: array
+                                    items:
+                                      type: object
+                                  type:
+                                    type: object
+                                    properties:
+                                      typeName:
+                                        type: string
+                            annotations:
+                              type: array
+                              items:
+                                type: object
+                            accessible:
+                              type: boolean
+                              deprecated: true
+                        implicit:
+                          type: boolean
+                  annotatedExceptionTypes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        annotations:
+                          type: array
+                          items:
+                            type: object
+                        declaredAnnotations:
+                          type: array
+                          items:
+                            type: object
+                        type:
+                          type: object
+                          properties:
+                            typeName:
+                              type: string
+                  annotations:
+                    type: array
+                    items:
+                      type: object
+            enumConstants:
+              type: array
+              items:
+                type: object
+            annotations:
+              type: array
+              items:
+                type: object
+            declaredAnnotations:
+              type: array
+              items:
+                type: object
+            annotatedSuperclass:
+              type: object
+              properties:
+                annotations:
+                  type: array
+                  items:
+                    type: object
+                declaredAnnotations:
+                  type: array
+                  items:
+                    type: object
+                type:
+                  type: object
+                  properties:
+                    typeName:
+                      type: string
+            annotatedInterfaces:
+              type: array
+              items:
+                type: object
+                properties:
+                  annotations:
+                    type: array
+                    items:
+                      type: object
+                  declaredAnnotations:
+                    type: array
+                    items:
+                      type: object
+                  type:
+                    type: object
+                    properties:
+                      typeName:
+                        type: string
+            sealed:
+              type: boolean
+      responses:
+        "200":
+          description: OK
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/EntityModelWorkflow'
+        "404":
+          description: Not Found
+  /workflows/{id}:
+    get:
+      tags:
+      - workflow-entity-controller
+      description: get-workflow
+      operationId: getItemResource-workflow-get_1
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: tenant
+        in: query
+        required: true
+        schema:
+          type: string
+      - name: token
+        in: query
+        required: true
+        schema:
+          type: string
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "500":
+          description: Internal Server Error
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "404":
+          description: Not Found
+        "403":
+          description: Forbidden
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "204":
+          description: No Content
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "200":
+          description: OK
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/EntityModelWorkflow'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Workflow'
+    put:
+      tags:
+      - workflow-entity-controller
+      description: update-workflow
+      operationId: putItemResource-workflow-put
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WorkflowRequestBody'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/EntityModelWorkflow'
+        "201":
+          description: Created
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/EntityModelWorkflow'
+        "204":
+          description: No Content
+    patch:
+      tags:
+      - workflow-entity-controller
+      description: patch-workflow
+      operationId: patchItemResource-workflow-patch
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WorkflowRequestBody'
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/EntityModelWorkflow'
+        "204":
+          description: No Content
+  /workflows/{id}/nodes:
+    get:
+      tags:
+      - workflow-property-reference-controller
+      description: get-node-by-workflow-Id
+      operationId: followPropertyReference-workflow-get_1
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/CollectionModelNode'
+            text/uri-list:
+              schema:
+                type: string
+        "404":
+          description: Not Found
+    put:
+      tags:
+      - workflow-property-reference-controller
+      description: update-node-by-workflow-Id
+      operationId: createPropertyReference-workflow-put
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CollectionModelObject'
+          application/x-spring-data-compact+json:
+            schema:
+              $ref: '#/components/schemas/CollectionModelObject'
+          text/uri-list:
+            schema:
+              type: string
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/CollectionModelNode'
+        "201":
+          description: Created
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/CollectionModelNode'
+        "204":
+          description: No Content
+    patch:
+      tags:
+      - workflow-property-reference-controller
+      description: patch-node-by-workflow-Id
+      operationId: createPropertyReference-workflow-patch
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CollectionModelObject'
+          application/x-spring-data-compact+json:
+            schema:
+              $ref: '#/components/schemas/CollectionModelObject'
+          text/uri-list:
+            schema:
+              type: string
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/CollectionModelNode'
+        "204":
+          description: No Content
+  /workflows/{id}/nodes/{propertyId}:
+    get:
+      tags:
+      - workflow-property-reference-controller
+      description: get-node-by-workflow-Id
+      operationId: followPropertyReference-workflow-get
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: propertyId
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/CollectionModelNode'
+        "404":
+          description: Not Found
+  /workflows/{id}/deactivate:
+    put:
       tags:
       - workflow-controller
       operationId: deactivateWorkflow
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Workflow'
-        required: true
-      responses:
-        "400":
-          description: Bad Request
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "500":
-          description: Internal Server Error
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "204":
-          description: No Content
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "404":
-          description: Not Found
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Workflow'
-  /workflow-engine/workflows/deactivate/:
-    post:
-      tags:
-      - workflow-controller
-      operationId: deactivateWorkflow_1
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Workflow'
-        required: true
-      responses:
-        "400":
-          description: Bad Request
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "500":
-          description: Internal Server Error
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "204":
-          description: No Content
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "404":
-          description: Not Found
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Workflow'
-  /workflow-engine/workflows/activate/:
-    post:
-      tags:
-      - workflow-controller
-      operationId: activateWorkflow
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                workflow:
-                  $ref: '#/components/schemas/Workflow'
-                tenant:
-                  type: string
-        required: true
-      responses:
-        "400":
-          description: Bad Request
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "500":
-          description: Internal Server Error
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "204":
-          description: No Content
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "404":
-          description: Not Found
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Workflow'
-  /workflow-engine/workflows/activate:
-    post:
-      tags:
-      - workflow-controller
-      operationId: activateWorkflow_1
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                workflow:
-                  $ref: '#/components/schemas/Workflow'
-                tenant:
-                  type: string
-        required: true
-      responses:
-        "400":
-          description: Bad Request
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "500":
-          description: Internal Server Error
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "204":
-          description: No Content
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "404":
-          description: Not Found
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Workflow'
-  /_/tenant:
-    post:
-      tags:
-      - tenant-controller
-      operationId: create
       parameters:
-      - name: accept
-        in: header
-        required: false
+      - name: id
+        in: path
+        required: true
         schema:
           type: string
       requestBody:
@@ -209,8 +11370,126 @@ paths:
               properties:
                 tenant:
                   type: string
-                attributes:
-                  $ref: '#/components/schemas/TenantAttributes'
+                token:
+                  type: string
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "500":
+          description: Internal Server Error
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "404":
+          description: Not Found
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "403":
+          description: Forbidden
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "204":
+          description: No Content
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Workflow'
+  /workflows/{id}/activate:
+    put:
+      tags:
+      - workflow-controller
+      operationId: activateWorkflow
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                tenant:
+                  type: string
+                token:
+                  type: string
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "500":
+          description: Internal Server Error
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "404":
+          description: Not Found
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "403":
+          description: Forbidden
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "204":
+          description: No Content
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Workflow'
+  /workflows/{id}/start:
+    post:
+      tags:
+      - workflow-controller
+      operationId: startWorkflow
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                tenant:
+                  type: string
+                token:
+                  type: string
+                context:
+                  $ref: '#/components/schemas/JsonNode'
         required: true
       responses:
         "400":
@@ -225,8 +11504,59 @@ paths:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/ResponseErrors'
+        "404":
+          description: Not Found
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "403":
+          description: Forbidden
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
         "204":
           description: No Content
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsonNode'
+  /workflows/import:
+    post:
+      tags:
+      - workflow-controller
+      operationId: importWorkflow
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              required:
+              - file
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+                tenant:
+                  type: string
+                token:
+                  type: string
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "500":
+          description: Internal Server Error
           content:
             application/hal+json:
               schema:
@@ -237,12 +11567,165 @@ paths:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/ResponseErrors'
+        "403":
+          description: Forbidden
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "204":
+          description: No Content
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+  /events/**:
+    post:
+      tags:
+      - event-controller
+      operationId: postHandleEventsWithFile_1
+      parameters:
+      - name: path
+        in: query
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              required:
+              - file
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+                tenant:
+                  type: string
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JsonNode'
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "500":
+          description: Internal Server Error
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "404":
+          description: Not Found
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "403":
+          description: Forbidden
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "204":
+          description: No Content
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsonNode'
+  /_/tenant:
+    post:
+      tags:
+      - tenant-controller
+      - tenant
+      description: "Create tenant job (create, upgrade, delete)"
+      operationId: postTenant_1
+      parameters:
+      - name: accept
+        in: header
+        required: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/tenantAttributes'
+        required: true
+      responses:
+        "400":
+          description: Bad request
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+            application/json:
+              schema:
+                type: string
+            text/plain:
+              schema:
+                type: string
+        "500":
+          description: Internal server error
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+            application/json:
+              schema:
+                type: string
+            text/plain:
+              schema:
+                type: string
+        "404":
+          description: Not Found
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "403":
+          description: Forbidden
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "204":
+          description: Job completed
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
         "200":
           description: OK
           content:
             application/hal+json:
               schema:
                 type: string
+        "422":
+          description: Validation errors
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errors'
+            text/plain:
+              schema:
+                $ref: '#/components/schemas/errors'
     delete:
       tags:
       - tenant-controller
@@ -271,8 +11754,56 @@ paths:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/ResponseErrors'
+        "404":
+          description: Not Found
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "403":
+          description: Forbidden
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
         "204":
           description: No Content
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "200":
+          description: OK
+  /workflows/{id}/history:
+    get:
+      tags:
+      - workflow-controller
+      operationId: workflowHistory
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: tenant
+        in: query
+        required: true
+        schema:
+          type: string
+      - name: token
+        in: query
+        required: true
+        schema:
+          type: string
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "500":
+          description: Internal Server Error
           content:
             application/hal+json:
               schema:
@@ -283,8 +11814,91 @@ paths:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/ResponseErrors'
+        "403":
+          description: Forbidden
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "204":
+          description: No Content
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
         "200":
           description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsonNode'
+  /workflows/search:
+    get:
+      tags:
+      - workflow-controller
+      operationId: searchWorkflows
+      parameters:
+      - name: query
+        in: query
+        required: true
+        schema:
+          type: string
+      - name: offset
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int64
+          default: 0
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 20
+      - name: tenant
+        in: query
+        required: true
+        schema:
+          type: string
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "500":
+          description: Internal Server Error
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "404":
+          description: Not Found
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "403":
+          description: Forbidden
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "204":
+          description: No Content
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsonNode'
   /admin:
     get:
       tags:
@@ -304,14 +11918,20 @@ paths:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/ResponseErrors'
-        "204":
-          description: No Content
+        "404":
+          description: Not Found
           content:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/ResponseErrors'
-        "404":
-          description: Not Found
+        "403":
+          description: Forbidden
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "204":
+          description: No Content
           content:
             application/hal+json:
               schema:
@@ -359,14 +11979,20 @@ paths:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/ResponseErrors'
-        "204":
-          description: No Content
+        "404":
+          description: Not Found
           content:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/ResponseErrors'
-        "404":
-          description: Not Found
+        "403":
+          description: Forbidden
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "204":
+          description: No Content
           content:
             application/hal+json:
               schema:
@@ -402,14 +12028,20 @@ paths:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/ResponseErrors'
-        "204":
-          description: No Content
+        "404":
+          description: Not Found
           content:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/ResponseErrors'
-        "404":
-          description: Not Found
+        "403":
+          description: Forbidden
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "204":
+          description: No Content
           content:
             application/hal+json:
               schema:
@@ -445,14 +12077,20 @@ paths:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/ResponseErrors'
-        "204":
-          description: No Content
+        "404":
+          description: Not Found
           content:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/ResponseErrors'
-        "404":
-          description: Not Found
+        "403":
+          description: Forbidden
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "204":
+          description: No Content
           content:
             application/hal+json:
               schema:
@@ -469,6 +12107,143 @@ paths:
             application/json:
               schema:
                 type: object
+  /actions:
+    get:
+      tags:
+      - action-controller
+      operationId: getActions
+      parameters:
+      - name: tenant
+        in: query
+        required: true
+        schema:
+          type: string
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "500":
+          description: Internal Server Error
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "404":
+          description: Not Found
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "403":
+          description: Forbidden
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "204":
+          description: No Content
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Action'
+  /_/tenant/{operationId}:
+    get:
+      tags:
+      - tenant
+      description: Does tenant id already exist
+      operationId: getTenant
+      parameters:
+      - name: operationId
+        in: path
+        description: Operation ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "500":
+          description: Internal server error
+          content:
+            text/plain:
+              schema:
+                type: string
+        "404":
+          description: Not Found
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "403":
+          description: Forbidden
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "204":
+          description: No Content
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "200":
+          description: true or false indicator
+          content:
+            text/plain:
+              schema:
+                type: string
+    delete:
+      tags:
+      - tenant
+      description: drop tenant id
+      operationId: deleteTenant
+      parameters:
+      - name: operationId
+        in: path
+        description: Operation ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "400":
+          description: Bad request
+        "500":
+          description: Internal server error
+          content:
+            text/plain:
+              schema:
+                type: string
+        "404":
+          description: Not Found
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "403":
+          description: Forbidden
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "204":
+          description: Delete succeeded
+        "200":
+          description: OK
   /_/ramls:
     get:
       tags:
@@ -503,14 +12278,20 @@ paths:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/ResponseErrors'
-        "204":
-          description: No Content
+        "404":
+          description: Not Found
           content:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/ResponseErrors'
-        "404":
-          description: Not Found
+        "403":
+          description: Forbidden
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "204":
+          description: No Content
           content:
             application/hal+json:
               schema:
@@ -555,14 +12336,78 @@ paths:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/ResponseErrors'
+        "404":
+          description: Not Found
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "403":
+          description: Forbidden
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
         "204":
           description: No Content
           content:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/ResponseErrors'
+        "200":
+          description: OK
+          content:
+            application/hal+json:
+              schema:
+                type: object
+  /workflows/{id}/delete:
+    delete:
+      tags:
+      - workflow-controller
+      operationId: deleteWorkflow
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                tenant:
+                  type: string
+                token:
+                  type: string
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "500":
+          description: Internal Server Error
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
         "404":
           description: Not Found
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "403":
+          description: Forbidden
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/ResponseErrors'
+        "204":
+          description: No Content
           content:
             application/hal+json:
               schema:
@@ -607,232 +12452,58 @@ components:
         total_records:
           type: integer
           format: int32
-    CompressFileTask:
-      required:
-      - name
+    AbstractJsonSchemaPropertyObject:
       type: object
-      allOf:
-      - $ref: '#/components/schemas/Node'
-      - type: object
-        properties:
-          asyncAfter:
-            type: boolean
-          asyncBefore:
-            type: boolean
-          inputVariables:
-            uniqueItems: true
-            type: array
-            items:
-              $ref: '#/components/schemas/EmbeddedVariable'
-          outputVariable:
-            $ref: '#/components/schemas/EmbeddedVariable'
-          source:
-            type: string
-          destination:
-            type: string
-          format:
-            type: string
-            enum:
-            - BZIP2
-            - GZIP
-            - ZIP
-          container:
-            type: string
-            enum:
-            - NONE
-            - TAR
-    Condition:
-      required:
-      - answer
-      - expression
-      - name
+      properties:
+        title:
+          type: string
+        readOnly:
+          type: boolean
+    Item:
       type: object
-      allOf:
-      - $ref: '#/components/schemas/Node'
-      - type: object
+      properties:
+        type:
+          type: string
         properties:
-          answer:
-            maxLength: 64
-            minLength: 2
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/AbstractJsonSchemaPropertyObject'
+        requiredProperties:
+          type: array
+          items:
             type: string
-          expression:
-            maxLength: 128
-            minLength: 4
-            type: string
-    ConnectTo:
-      required:
-      - name
-      - nodeId
+    JsonSchema:
       type: object
-      allOf:
-      - $ref: '#/components/schemas/Node'
-      - type: object
+      properties:
+        title:
+          type: string
+        description:
+          type: string
         properties:
-          nodeId:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/AbstractJsonSchemaPropertyObject'
+        requiredProperties:
+          type: array
+          items:
             type: string
-    DatabaseConnectionTask:
-      required:
-      - name
+        definitions:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/Item'
+        type:
+          type: string
+        $schema:
+          type: string
+    Links:
       type: object
-      allOf:
-      - $ref: '#/components/schemas/Node'
-      - type: object
-        properties:
-          asyncAfter:
-            type: boolean
-          asyncBefore:
-            type: boolean
-          inputVariables:
-            uniqueItems: true
-            type: array
-            items:
-              $ref: '#/components/schemas/EmbeddedVariable'
-          outputVariable:
-            $ref: '#/components/schemas/EmbeddedVariable'
-          designation:
-            type: string
-          password:
-            type: string
-          url:
-            type: string
-          username:
-            type: string
-    DatabaseDisconnectTask:
-      required:
-      - name
+      additionalProperties:
+        $ref: '#/components/schemas/Link'
+    RepresentationModelObject:
       type: object
-      allOf:
-      - $ref: '#/components/schemas/Node'
-      - type: object
-        properties:
-          asyncAfter:
-            type: boolean
-          asyncBefore:
-            type: boolean
-          inputVariables:
-            uniqueItems: true
-            type: array
-            items:
-              $ref: '#/components/schemas/EmbeddedVariable'
-          outputVariable:
-            $ref: '#/components/schemas/EmbeddedVariable'
-          designation:
-            type: string
-    DatabaseQueryTask:
-      required:
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/Node'
-      - type: object
-        properties:
-          asyncAfter:
-            type: boolean
-          asyncBefore:
-            type: boolean
-          inputVariables:
-            uniqueItems: true
-            type: array
-            items:
-              $ref: '#/components/schemas/EmbeddedVariable'
-          outputVariable:
-            $ref: '#/components/schemas/EmbeddedVariable'
-          designation:
-            type: string
-          outputPath:
-            type: string
-          query:
-            type: string
-          resultType:
-            type: string
-            enum:
-            - CSV
-            - TSV
-            - JSON
-          includeHeader:
-            type: boolean
-    DirectoryTask:
-      required:
-      - action
-      - name
-      - path
-      - workflow
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/Node'
-      - type: object
-        properties:
-          asyncAfter:
-            type: boolean
-          asyncBefore:
-            type: boolean
-          inputVariables:
-            uniqueItems: true
-            type: array
-            items:
-              $ref: '#/components/schemas/EmbeddedVariable'
-          outputVariable:
-            $ref: '#/components/schemas/EmbeddedVariable'
-          path:
-            type: string
-          workflow:
-            type: string
-          action:
-            type: string
-            enum:
-            - READ_NEXT
-            - DELETE_NEXT
-            - LIST
-            - WRITE
-    EmailTask:
-      required:
-      - mailFrom
-      - mailSubject
-      - mailText
-      - mailTo
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/Node'
-      - type: object
-        properties:
-          asyncAfter:
-            type: boolean
-          asyncBefore:
-            type: boolean
-          inputVariables:
-            uniqueItems: true
-            type: array
-            items:
-              $ref: '#/components/schemas/EmbeddedVariable'
-          outputVariable:
-            $ref: '#/components/schemas/EmbeddedVariable'
-          attachmentPath:
-            type: string
-          includeAttachment:
-            type: string
-          mailBcc:
-            type: string
-          mailCc:
-            type: string
-          mailFrom:
-            maxLength: 256
-            minLength: 3
-            type: string
-          mailText:
-            maxLength: 2147483647
-            minLength: 2
-            type: string
-          mailTo:
-            maxLength: 256
-            minLength: 3
-            type: string
-          mailMarkup:
-            type: string
-          mailSubject:
-            maxLength: 256
-            minLength: 2
-            type: string
+      properties:
+        _links:
+          $ref: '#/components/schemas/Links'
     EmbeddedInput:
       required:
       - inputType
@@ -981,30 +12652,560 @@ components:
           type: boolean
         asTransient:
           type: boolean
-    EndEvent:
+    EntityModelWorkflow:
+      required:
+      - name
+      - versionTag
+      type: object
+      properties:
+        active:
+          type: boolean
+        deploymentId:
+          type: string
+        description:
+          maxLength: 512
+          minLength: 0
+          type: string
+        historyTimeToLive:
+          minimum: 0
+          type: integer
+          format: int32
+        initialContext:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/JsonNode'
+        name:
+          maxLength: 64
+          minLength: 4
+          type: string
+        setup:
+          $ref: '#/components/schemas/Setup'
+        versionTag:
+          maxLength: 64
+          minLength: 1
+          type: string
+        _links:
+          $ref: '#/components/schemas/Links'
+    JsonNode:
+      type: object
+    Node:
+      required:
+      - name
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          maxLength: 64
+          minLength: 3
+          type: string
+        description:
+          maxLength: 512
+          minLength: 0
+          type: string
+        deserializeAs:
+          type: string
+          readOnly: true
+        identifier:
+          type: string
+      discriminator:
+        propertyName: deserializeAs
+    PageMetadata:
+      type: object
+      properties:
+        size:
+          type: integer
+          format: int64
+        totalElements:
+          type: integer
+          format: int64
+        totalPages:
+          type: integer
+          format: int64
+        number:
+          type: integer
+          format: int64
+    PagedModelEntityModelWorkflow:
+      type: object
+      properties:
+        _embedded:
+          type: object
+          properties:
+            workflows:
+              type: array
+              items:
+                $ref: '#/components/schemas/EntityModelWorkflow'
+        _links:
+          $ref: '#/components/schemas/Links'
+        page:
+          $ref: '#/components/schemas/PageMetadata'
+    Setup:
+      type: object
+      properties:
+        asyncAfter:
+          type: boolean
+        asyncBefore:
+          type: boolean
+    Workflow:
+      required:
+      - name
+      - versionTag
+      type: object
+      properties:
+        id:
+          type: string
+        active:
+          type: boolean
+        deploymentId:
+          type: string
+        description:
+          maxLength: 512
+          minLength: 0
+          type: string
+        historyTimeToLive:
+          minimum: 0
+          type: integer
+          format: int32
+        initialContext:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/JsonNode'
+        name:
+          maxLength: 64
+          minLength: 4
+          type: string
+        nodes:
+          type: array
+          items:
+            $ref: '#/components/schemas/Node'
+        setup:
+          $ref: '#/components/schemas/Setup'
+        versionTag:
+          maxLength: 64
+          minLength: 1
+          type: string
+    CollectionModelNode:
+      type: object
+      properties:
+        _embedded:
+          type: object
+          properties:
+            nodes:
+              type: array
+              items:
+                oneOf:
+                - $ref: '#/components/schemas/CompressFileTaskResponse'
+                - $ref: '#/components/schemas/ConditionResponse'
+                - $ref: '#/components/schemas/ConnectToResponse'
+                - $ref: '#/components/schemas/DatabaseConnectionTaskResponse'
+                - $ref: '#/components/schemas/DatabaseDisconnectTaskResponse'
+                - $ref: '#/components/schemas/DatabaseQueryTaskResponse'
+                - $ref: '#/components/schemas/DirectoryTaskResponse'
+                - $ref: '#/components/schemas/EmailTaskResponse'
+                - $ref: '#/components/schemas/EndEventResponse'
+                - $ref: '#/components/schemas/EventSubprocessResponse'
+                - $ref: '#/components/schemas/ExclusiveGatewayResponse'
+                - $ref: '#/components/schemas/FileTaskResponse'
+                - $ref: '#/components/schemas/FtpTaskResponse'
+                - $ref: '#/components/schemas/InclusiveGatewayResponse'
+                - $ref: '#/components/schemas/InputTaskResponse'
+                - $ref: '#/components/schemas/MoveToLastGatewayResponse'
+                - $ref: '#/components/schemas/MoveToNodeResponse'
+                - $ref: '#/components/schemas/ParallelGatewayResponse'
+                - $ref: '#/components/schemas/ProcessorTaskResponse'
+                - $ref: '#/components/schemas/ReceiveTaskResponse'
+                - $ref: '#/components/schemas/RequestTaskResponse'
+                - $ref: '#/components/schemas/ScriptTaskResponse'
+                - $ref: '#/components/schemas/StartEventResponse'
+                - $ref: '#/components/schemas/SubprocessResponse'
+        _links:
+          $ref: '#/components/schemas/Links'
+    CollectionModelObject:
+      type: object
+      properties:
+        _embedded:
+          type: object
+          properties:
+            objects:
+              type: array
+              items:
+                type: object
+        _links:
+          $ref: '#/components/schemas/Links'
+    EntityModelNode:
+      required:
+      - name
+      type: object
+      properties:
+        name:
+          maxLength: 64
+          minLength: 3
+          type: string
+        description:
+          maxLength: 512
+          minLength: 0
+          type: string
+        deserializeAs:
+          type: string
+          readOnly: true
+        identifier:
+          type: string
+        _links:
+          $ref: '#/components/schemas/Links'
+    PagedModelEntityModelNode:
+      type: object
+      properties:
+        _embedded:
+          type: object
+          properties:
+            nodes:
+              type: array
+              items:
+                $ref: '#/components/schemas/EntityModelNode'
+        _links:
+          $ref: '#/components/schemas/Links'
+        page:
+          $ref: '#/components/schemas/PageMetadata'
+    EntityModelTrigger:
+      required:
+      - method
+      - name
+      - pathPattern
+      type: object
+      properties:
+        name:
+          maxLength: 64
+          minLength: 4
+          type: string
+        description:
+          maxLength: 256
+          minLength: 0
+          type: string
+        pathPattern:
+          maxLength: 256
+          minLength: 2
+          type: string
+        method:
+          type: string
+          enum:
+          - GET
+          - HEAD
+          - POST
+          - PUT
+          - PATCH
+          - DELETE
+          - OPTIONS
+          - TRACE
+        _links:
+          $ref: '#/components/schemas/Links'
+    PagedModelEntityModelTrigger:
+      type: object
+      properties:
+        _embedded:
+          type: object
+          properties:
+            triggers:
+              type: array
+              items:
+                $ref: '#/components/schemas/EntityModelTrigger'
+        _links:
+          $ref: '#/components/schemas/Links'
+        page:
+          $ref: '#/components/schemas/PageMetadata'
+    CollectionModelEntityModelTrigger:
+      type: object
+      properties:
+        _embedded:
+          type: object
+          properties:
+            triggers:
+              type: array
+              items:
+                $ref: '#/components/schemas/EntityModelTrigger'
+        _links:
+          $ref: '#/components/schemas/Links'
+    TriggerRequestBody:
+      required:
+      - method
+      - name
+      - pathPattern
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          maxLength: 64
+          minLength: 4
+          type: string
+        description:
+          maxLength: 256
+          minLength: 0
+          type: string
+        pathPattern:
+          maxLength: 256
+          minLength: 2
+          type: string
+        method:
+          type: string
+          enum:
+          - GET
+          - HEAD
+          - POST
+          - PUT
+          - PATCH
+          - DELETE
+          - OPTIONS
+          - TRACE
+    CompressFileTaskRequestBody:
       required:
       - name
       type: object
       allOf:
-      - $ref: '#/components/schemas/Node'
-    EventSubprocess:
-      required:
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/Node'
+      - $ref: '#/components/schemas/NodeRequestBody'
       - type: object
         properties:
           asyncAfter:
             type: boolean
           asyncBefore:
             type: boolean
-    ExclusiveGateway:
+          inputVariables:
+            uniqueItems: true
+            type: array
+            items:
+              $ref: '#/components/schemas/EmbeddedVariable'
+          outputVariable:
+            $ref: '#/components/schemas/EmbeddedVariable'
+          source:
+            type: string
+          destination:
+            type: string
+          format:
+            type: string
+            enum:
+            - BZIP2
+            - GZIP
+            - ZIP
+          container:
+            type: string
+            enum:
+            - NONE
+            - TAR
+    ConditionRequestBody:
+      required:
+      - answer
+      - expression
+      - name
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/NodeRequestBody'
+      - type: object
+        properties:
+          answer:
+            maxLength: 64
+            minLength: 2
+            type: string
+          expression:
+            maxLength: 128
+            minLength: 4
+            type: string
+    ConnectToRequestBody:
+      required:
+      - name
+      - nodeId
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/NodeRequestBody'
+      - type: object
+        properties:
+          nodeId:
+            type: string
+    DatabaseConnectionTaskRequestBody:
       required:
       - name
       type: object
       allOf:
-      - $ref: '#/components/schemas/Node'
+      - $ref: '#/components/schemas/NodeRequestBody'
+      - type: object
+        properties:
+          asyncAfter:
+            type: boolean
+          asyncBefore:
+            type: boolean
+          inputVariables:
+            uniqueItems: true
+            type: array
+            items:
+              $ref: '#/components/schemas/EmbeddedVariable'
+          outputVariable:
+            $ref: '#/components/schemas/EmbeddedVariable'
+          designation:
+            type: string
+          password:
+            type: string
+          url:
+            type: string
+          username:
+            type: string
+    DatabaseDisconnectTaskRequestBody:
+      required:
+      - name
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/NodeRequestBody'
+      - type: object
+        properties:
+          asyncAfter:
+            type: boolean
+          asyncBefore:
+            type: boolean
+          inputVariables:
+            uniqueItems: true
+            type: array
+            items:
+              $ref: '#/components/schemas/EmbeddedVariable'
+          outputVariable:
+            $ref: '#/components/schemas/EmbeddedVariable'
+          designation:
+            type: string
+    DatabaseQueryTaskRequestBody:
+      required:
+      - name
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/NodeRequestBody'
+      - type: object
+        properties:
+          asyncAfter:
+            type: boolean
+          asyncBefore:
+            type: boolean
+          inputVariables:
+            uniqueItems: true
+            type: array
+            items:
+              $ref: '#/components/schemas/EmbeddedVariable'
+          outputVariable:
+            $ref: '#/components/schemas/EmbeddedVariable'
+          designation:
+            type: string
+          outputPath:
+            type: string
+          query:
+            type: string
+          resultType:
+            type: string
+            enum:
+            - CSV
+            - TSV
+            - JSON
+          includeHeader:
+            type: boolean
+    DirectoryTaskRequestBody:
+      required:
+      - action
+      - name
+      - path
+      - workflow
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/NodeRequestBody'
+      - type: object
+        properties:
+          asyncAfter:
+            type: boolean
+          asyncBefore:
+            type: boolean
+          inputVariables:
+            uniqueItems: true
+            type: array
+            items:
+              $ref: '#/components/schemas/EmbeddedVariable'
+          outputVariable:
+            $ref: '#/components/schemas/EmbeddedVariable'
+          path:
+            type: string
+          workflow:
+            type: string
+          action:
+            type: string
+            enum:
+            - READ_NEXT
+            - DELETE_NEXT
+            - LIST
+            - WRITE
+    EmailTaskRequestBody:
+      required:
+      - mailFrom
+      - mailSubject
+      - mailText
+      - mailTo
+      - name
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/NodeRequestBody'
+      - type: object
+        properties:
+          asyncAfter:
+            type: boolean
+          asyncBefore:
+            type: boolean
+          inputVariables:
+            uniqueItems: true
+            type: array
+            items:
+              $ref: '#/components/schemas/EmbeddedVariable'
+          outputVariable:
+            $ref: '#/components/schemas/EmbeddedVariable'
+          attachmentPath:
+            type: string
+          includeAttachment:
+            type: string
+          mailBcc:
+            type: string
+          mailCc:
+            type: string
+          mailFrom:
+            maxLength: 256
+            minLength: 3
+            type: string
+          mailText:
+            maxLength: 2147483647
+            minLength: 2
+            type: string
+          mailTo:
+            maxLength: 256
+            minLength: 3
+            type: string
+          mailMarkup:
+            type: string
+          mailSubject:
+            maxLength: 256
+            minLength: 2
+            type: string
+    EndEventRequestBody:
+      required:
+      - name
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/NodeRequestBody'
+    EventSubprocessRequestBody:
+      required:
+      - name
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/NodeRequestBody'
+      - type: object
+        properties:
+          asyncAfter:
+            type: boolean
+          asyncBefore:
+            type: boolean
+    ExclusiveGatewayRequestBody:
+      required:
+      - name
+      type: object
+      allOf:
+      - $ref: '#/components/schemas/NodeRequestBody'
       - type: object
         properties:
           direction:
@@ -1014,12 +13215,12 @@ components:
             - CONVERGING
             - DIVERGING
             - MIXED
-    FileTask:
+    FileTaskRequestBody:
       required:
       - name
       type: object
       allOf:
-      - $ref: '#/components/schemas/Node'
+      - $ref: '#/components/schemas/NodeRequestBody'
       - type: object
         properties:
           asyncAfter:
@@ -1052,12 +13253,12 @@ components:
             type: string
           target:
             type: string
-    FtpTask:
+    FtpTaskRequestBody:
       required:
       - name
       type: object
       allOf:
-      - $ref: '#/components/schemas/Node'
+      - $ref: '#/components/schemas/NodeRequestBody'
       - type: object
         properties:
           asyncAfter:
@@ -1093,12 +13294,12 @@ components:
             type: string
           basePath:
             type: string
-    InclusiveGateway:
+    InclusiveGatewayRequestBody:
       required:
       - name
       type: object
       allOf:
-      - $ref: '#/components/schemas/Node'
+      - $ref: '#/components/schemas/NodeRequestBody'
       - type: object
         properties:
           direction:
@@ -1108,12 +13309,12 @@ components:
             - CONVERGING
             - DIVERGING
             - MIXED
-    InputTask:
+    InputTaskRequestBody:
       required:
       - name
       type: object
       allOf:
-      - $ref: '#/components/schemas/Node'
+      - $ref: '#/components/schemas/NodeRequestBody'
       - type: object
         properties:
           asyncAfter:
@@ -1132,14 +13333,12 @@ components:
             type: array
             items:
               $ref: '#/components/schemas/EmbeddedInput'
-    JsonNode:
-      type: object
-    MoveToLastGateway:
+    MoveToLastGatewayRequestBody:
       required:
       - name
       type: object
       allOf:
-      - $ref: '#/components/schemas/Node'
+      - $ref: '#/components/schemas/NodeRequestBody'
       - type: object
         properties:
           direction:
@@ -1149,18 +13348,18 @@ components:
             - CONVERGING
             - DIVERGING
             - MIXED
-    MoveToNode:
+    MoveToNodeRequestBody:
       required:
       - gatewayId
       - name
       type: object
       allOf:
-      - $ref: '#/components/schemas/Node'
+      - $ref: '#/components/schemas/NodeRequestBody'
       - type: object
         properties:
           gatewayId:
             type: string
-    Node:
+    NodeRequestBody:
       required:
       - name
       type: object
@@ -1182,12 +13381,12 @@ components:
           type: string
       discriminator:
         propertyName: deserializeAs
-    ParallelGateway:
+    ParallelGatewayRequestBody:
       required:
       - name
       type: object
       allOf:
-      - $ref: '#/components/schemas/Node'
+      - $ref: '#/components/schemas/NodeRequestBody'
       - type: object
         properties:
           direction:
@@ -1197,12 +13396,12 @@ components:
             - CONVERGING
             - DIVERGING
             - MIXED
-    ProcessorTask:
+    ProcessorTaskRequestBody:
       required:
       - name
       type: object
       allOf:
-      - $ref: '#/components/schemas/Node'
+      - $ref: '#/components/schemas/NodeRequestBody'
       - type: object
         properties:
           asyncAfter:
@@ -1218,13 +13417,13 @@ components:
             $ref: '#/components/schemas/EmbeddedVariable'
           processor:
             $ref: '#/components/schemas/EmbeddedProcessor'
-    ReceiveTask:
+    ReceiveTaskRequestBody:
       required:
       - message
       - name
       type: object
       allOf:
-      - $ref: '#/components/schemas/Node'
+      - $ref: '#/components/schemas/NodeRequestBody'
       - type: object
         properties:
           asyncAfter:
@@ -1242,12 +13441,12 @@ components:
             maxLength: 256
             minLength: 4
             type: string
-    RequestTask:
+    RequestTaskRequestBody:
       required:
       - name
       type: object
       allOf:
-      - $ref: '#/components/schemas/Node'
+      - $ref: '#/components/schemas/NodeRequestBody'
       - type: object
         properties:
           asyncAfter:
@@ -1268,13 +13467,13 @@ components:
               $ref: '#/components/schemas/EmbeddedVariable'
           request:
             $ref: '#/components/schemas/EmbeddedRequest'
-    ScriptTask:
+    ScriptTaskRequestBody:
       required:
       - code
       - name
       type: object
       allOf:
-      - $ref: '#/components/schemas/Node'
+      - $ref: '#/components/schemas/NodeRequestBody'
       - type: object
         properties:
           asyncAfter:
@@ -1294,20 +13493,13 @@ components:
             type: string
           scriptFormat:
             type: string
-    Setup:
-      type: object
-      properties:
-        asyncAfter:
-          type: boolean
-        asyncBefore:
-          type: boolean
-    StartEvent:
+    StartEventRequestBody:
       required:
       - name
       - type
       type: object
       allOf:
-      - $ref: '#/components/schemas/Node'
+      - $ref: '#/components/schemas/NodeRequestBody'
       - type: object
         properties:
           asyncBefore:
@@ -1325,13 +13517,13 @@ components:
             - SCHEDULED
             - SIGNAL
             - NONE
-    Subprocess:
+    SubprocessRequestBody:
       required:
       - name
       - type
       type: object
       allOf:
-      - $ref: '#/components/schemas/Node'
+      - $ref: '#/components/schemas/NodeRequestBody'
       - type: object
         properties:
           asyncAfter:
@@ -1347,7 +13539,7 @@ components:
             - TRANSACTION
           multiInstance:
             type: boolean
-    Workflow:
+    WorkflowRequestBody:
       required:
       - name
       - versionTag
@@ -1378,44 +13570,78 @@ components:
         nodes:
           type: array
           items:
-            oneOf:
-            - $ref: '#/components/schemas/CompressFileTask'
-            - $ref: '#/components/schemas/Condition'
-            - $ref: '#/components/schemas/ConnectTo'
-            - $ref: '#/components/schemas/DatabaseConnectionTask'
-            - $ref: '#/components/schemas/DatabaseDisconnectTask'
-            - $ref: '#/components/schemas/DatabaseQueryTask'
-            - $ref: '#/components/schemas/DirectoryTask'
-            - $ref: '#/components/schemas/EmailTask'
-            - $ref: '#/components/schemas/EndEvent'
-            - $ref: '#/components/schemas/EventSubprocess'
-            - $ref: '#/components/schemas/ExclusiveGateway'
-            - $ref: '#/components/schemas/FileTask'
-            - $ref: '#/components/schemas/FtpTask'
-            - $ref: '#/components/schemas/InclusiveGateway'
-            - $ref: '#/components/schemas/InputTask'
-            - $ref: '#/components/schemas/MoveToLastGateway'
-            - $ref: '#/components/schemas/MoveToNode'
-            - $ref: '#/components/schemas/ParallelGateway'
-            - $ref: '#/components/schemas/ProcessorTask'
-            - $ref: '#/components/schemas/ReceiveTask'
-            - $ref: '#/components/schemas/RequestTask'
-            - $ref: '#/components/schemas/ScriptTask'
-            - $ref: '#/components/schemas/StartEvent'
-            - $ref: '#/components/schemas/Subprocess'
+            type: string
         setup:
           $ref: '#/components/schemas/Setup'
         versionTag:
           maxLength: 64
           minLength: 1
           type: string
-    TenantAttributes:
+    error:
+      required:
+      - message
       type: object
       properties:
-        moduleTo:
+        message:
           type: string
-        moduleFrom:
+          description: Error message text
+        type:
           type: string
+          description: Error message type
+        code:
+          type: string
+          description: Error message code
+        parameters:
+          type: array
+          description: List of key/value parameters
+          items:
+            $ref: '#/components/schemas/parameter'
+      description: An error message
+    errors:
+      type: object
+      properties:
+        errors:
+          type: array
+          description: List of error messages
+          items:
+            $ref: '#/components/schemas/error'
+        total_records:
+          type: integer
+          description: Total number of errors
+          format: int32
+      description: A set of error messages
+    parameter:
+      required:
+      - key
+      type: object
+      properties:
+        key:
+          type: string
+          description: The key for this parameter
+        value:
+          type: string
+          description: The value of this parameter
+      description: Key/value parameter
+    tenantAttributes:
+      type: object
+      properties:
+        module_from:
+          type: string
+          description: "Existing module ID. If omitted, the module is not enabled\
+            \ already"
+        module_to:
+          type: string
+          description: "Target module ID. If omitted, the existing module is disabled"
+        purge:
+          type: boolean
+          description: On disable should data also be purged
+        parameters:
+          type: array
+          description: List of key/value parameters
+          items:
+            $ref: '#/components/schemas/parameter'
+      description: "Configuration how to install, upgrade or delete a module for a\
+        \ tenant"
     Link:
       type: object
       properties:
@@ -1435,3 +13661,25 @@ components:
           type: string
         templated:
           type: boolean
+    Action:
+      required:
+      - interfaceName
+      - method
+      - pathPattern
+      type: object
+      properties:
+        interfaceName:
+          type: string
+        pathPattern:
+          type: string
+        method:
+          type: string
+          enum:
+          - GET
+          - HEAD
+          - POST
+          - PUT
+          - PATCH
+          - DELETE
+          - OPTIONS
+          - TRACE


### PR DESCRIPTION
Resolves [MODWRKFLOW-14](https://folio-org.atlassian.net/browse/MODWRKFLOW-14).

These extra paths with a trailing forward-slash `/` (U+002F) should not longer be needed.

The `openapi.xml` file is rebuilt using `mvn clean verify -P openapi`.

There should no longer be any controller endpoints with explicit trailing slashes defined.