### PR TITLE
MODWRKFLOW-42: If Workflow is not found, Invalid Token message is incorrectly printed.

### DIFF
--- a/service/src/main/java/org/folio/rest/workflow/controller/WorkflowController.java
+++ b/service/src/main/java/org/folio/rest/workflow/controller/WorkflowController.java
@@ -93,8 +93,11 @@ public class WorkflowController {
     @PathVariable String id,
     @TenantHeader String tenant,
     @TokenHeader String token
-  ) throws WorkflowEngineServiceException {
+  ) throws WorkflowEngineServiceException, WorkflowNotFoundException {
     log.info("Activating: {}", id);
+
+    workflowEngineService.exists(id);
+
     return workflowEngineService.activate(id, tenant, token);
   }
 

--- a/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
@@ -103,7 +103,7 @@ public class WorkflowEngineService {
   }
 
   /**
-   * Check that the Workflow exists or thrown an exception.
+   * Check that the Workflow exists or throw an exception.
    *
    * @param workflowId The Workflow to check.
    *


### PR DESCRIPTION
Resolves [MODWRKFLOW-42](https://folio-org.atlassian.net/browse/MODWRKFLOW-42).

The `deactivate` controller end point already has this check.
This adds the same check to the `activate` controller end point.

Also fix a mistake in the grammar of the `exists()` function documentation.