### PR TITLE
MODWRKFLOW-43: Upgrade to spring-boot 3.3.7 and folio-spring-base to 8.2.2.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM folioci/alpine-jre-openjdk17:latest
+FROM folioci/alpine-jre-openjdk21:latest
 
 # Install latest patch versions of packages: https://pythonspeed.com/articles/security-updates-in-docker/
 USER root

--- a/components/.gitignore
+++ b/components/.gitignore
@@ -1,2 +1,1 @@
-events/
 /target_test-classes/

--- a/components/src/main/java/org/folio/rest/workflow/model/Node.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/Node.java
@@ -1,9 +1,8 @@
 package org.folio.rest.workflow.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
@@ -12,6 +11,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
+import org.folio.rest.workflow.model.converter.JsonNodeConverter;
 import org.folio.rest.workflow.model.has.HasId;
 import org.folio.rest.workflow.model.has.HasInformational;
 import org.folio.rest.workflow.model.has.HasName;
@@ -20,59 +20,7 @@ import org.folio.spring.domain.model.AbstractBaseEntity;
 
 @Entity
 @Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "deserializeAs")
-@JsonSubTypes({
-
-    @JsonSubTypes.Type(value = CompressFileTask.class, name = "CompressFileTask"),
-
-    @JsonSubTypes.Type(value = Condition.class, name = "Condition"),
-
-    @JsonSubTypes.Type(value = ConnectTo.class, name = "ConnectTo"),
-
-    @JsonSubTypes.Type(value = DatabaseConnectionTask.class, name = "DatabaseConnectionTask"),
-
-    @JsonSubTypes.Type(value = DatabaseDisconnectTask.class, name = "DatabaseDisconnectTask"),
-
-    @JsonSubTypes.Type(value = DatabaseQueryTask.class, name = "DatabaseQueryTask"),
-
-    @JsonSubTypes.Type(value = DirectoryTask.class, name = "DirectoryTask"),
-
-    @JsonSubTypes.Type(value = EmailTask.class, name = "EmailTask"),
-
-    @JsonSubTypes.Type(value = EndEvent.class, name = "EndEvent"),
-
-    @JsonSubTypes.Type(value = EventSubprocess.class, name = "EventSubprocess"),
-
-    @JsonSubTypes.Type(value = ExclusiveGateway.class, name = "ExclusiveGateway"),
-
-    @JsonSubTypes.Type(value = FileTask.class, name = "FileTask"),
-
-    @JsonSubTypes.Type(value = FtpTask.class, name = "FtpTask"),
-
-    @JsonSubTypes.Type(value = InclusiveGateway.class, name = "InclusiveGateway"),
-
-    @JsonSubTypes.Type(value = InputTask.class, name = "InputTask"),
-
-    @JsonSubTypes.Type(value = MoveToLastGateway.class, name = "MoveToLastGateway"),
-
-    @JsonSubTypes.Type(value = MoveToNode.class, name = "MoveToNode"),
-
-    @JsonSubTypes.Type(value = ParallelGateway.class, name = "ParallelGateway"),
-
-    @JsonSubTypes.Type(value = ProcessorTask.class, name = "ProcessorTask"),
-
-    @JsonSubTypes.Type(value = ReceiveTask.class, name = "ReceiveTask"),
-
-    @JsonSubTypes.Type(value = RequestTask.class, name = "RequestTask"),
-
-    @JsonSubTypes.Type(value = ScriptTask.class, name = "ScriptTask"),
-
-    @JsonSubTypes.Type(value = StartEvent.class, name = "StartEvent"),
-
-    @JsonSubTypes.Type(value = Subprocess.class, name = "Subprocess")
-
-})
-public abstract class Node extends AbstractBaseEntity implements HasId, HasInformational, HasName, HasNodeCommon {
+public abstract class Node extends AbstractBaseEntity implements HasId, HasInformational, HasName, HasNodeCommon, NodeInterface {
 
   @Getter
   @Setter
@@ -90,6 +38,7 @@ public abstract class Node extends AbstractBaseEntity implements HasId, HasInfor
   @Getter
   @Setter
   @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  @Convert(converter = JsonNodeConverter.class, attributeName = "deserializeAs")
   private String deserializeAs = this.getClass().getSimpleName();
 
   public Node() {

--- a/components/src/main/java/org/folio/rest/workflow/model/NodeInterface.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/NodeInterface.java
@@ -1,0 +1,40 @@
+package org.folio.rest.workflow.model;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
+import org.folio.rest.workflow.model.resolver.DeserializeAsJsonResolver;
+
+@JsonTypeIdResolver(DeserializeAsJsonResolver.class)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "deserializeAs")
+@JsonSubTypes({
+  @JsonSubTypes.Type(value = CompressFileTask.class, name = "CompressFileTask"),
+  @JsonSubTypes.Type(value = Condition.class, name = "Condition"),
+  @JsonSubTypes.Type(value = ConnectTo.class, name = "ConnectTo"),
+  @JsonSubTypes.Type(value = DatabaseConnectionTask.class, name = "DatabaseConnectionTask"),
+  @JsonSubTypes.Type(value = DatabaseDisconnectTask.class, name = "DatabaseDisconnectTask"),
+  @JsonSubTypes.Type(value = DatabaseQueryTask.class, name = "DatabaseQueryTask"),
+  @JsonSubTypes.Type(value = DirectoryTask.class, name = "DirectoryTask"),
+  @JsonSubTypes.Type(value = EmailTask.class, name = "EmailTask"),
+  @JsonSubTypes.Type(value = EndEvent.class, name = "EndEvent"),
+  @JsonSubTypes.Type(value = EventSubprocess.class, name = "EventSubprocess"),
+  @JsonSubTypes.Type(value = ExclusiveGateway.class, name = "ExclusiveGateway"),
+  @JsonSubTypes.Type(value = FileTask.class, name = "FileTask"),
+  @JsonSubTypes.Type(value = FtpTask.class, name = "FtpTask"),
+  @JsonSubTypes.Type(value = InclusiveGateway.class, name = "InclusiveGateway"),
+  @JsonSubTypes.Type(value = InputTask.class, name = "InputTask"),
+  @JsonSubTypes.Type(value = MoveToLastGateway.class, name = "MoveToLastGateway"),
+  @JsonSubTypes.Type(value = MoveToNode.class, name = "MoveToNode"),
+  @JsonSubTypes.Type(value = ParallelGateway.class, name = "ParallelGateway"),
+  @JsonSubTypes.Type(value = ProcessorTask.class, name = "ProcessorTask"),
+  @JsonSubTypes.Type(value = ReceiveTask.class, name = "ReceiveTask"),
+  @JsonSubTypes.Type(value = RequestTask.class, name = "RequestTask"),
+  @JsonSubTypes.Type(value = ScriptTask.class, name = "ScriptTask"),
+  @JsonSubTypes.Type(value = StartEvent.class, name = "StartEvent"),
+  @JsonSubTypes.Type(value = Subprocess.class, name = "Subprocess")
+})
+public interface NodeInterface {
+
+  public String getDeserializeAs();
+
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/converter/AbstractConverter.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/converter/AbstractConverter.java
@@ -1,8 +1,12 @@
 package org.folio.rest.workflow.model.converter;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.StreamReadFeature;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import jakarta.persistence.AttributeConverter;
 
 /**
@@ -10,7 +14,12 @@ import jakarta.persistence.AttributeConverter;
  */
 public abstract class AbstractConverter<T> implements AttributeConverter<T, String> {
 
-  private ObjectMapper objectMapper = new ObjectMapper();
+  private ObjectMapper objectMapper = JsonMapper.builder()
+    .enable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION)
+    .disable(MapperFeature.REQUIRE_TYPE_ID_FOR_SUBTYPES)
+    .disable(DeserializationFeature.FAIL_ON_MISSING_EXTERNAL_TYPE_ID_PROPERTY)
+    .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+    .build();
 
   @Override
   public String convertToDatabaseColumn(T attribute) {

--- a/components/src/main/java/org/folio/rest/workflow/model/resolver/DeserializeAsJsonResolver.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/resolver/DeserializeAsJsonResolver.java
@@ -1,0 +1,41 @@
+package org.folio.rest.workflow.model.resolver;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.databind.DatabindContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.jsontype.impl.TypeIdResolverBase;
+
+public class DeserializeAsJsonResolver extends TypeIdResolverBase {
+
+  @Override
+  public String idFromValue(Object value) {
+    return value.getClass().getSimpleName();
+  }
+
+  @Override
+  public String idFromValueAndType(Object value, Class<?> suggestedType) {
+    return idFromValue(value);
+  }
+
+  @Override
+  public Id getMechanism() {
+    return Id.SIMPLE_NAME;
+  }
+
+  @Override
+  public JavaType typeFromId(DatabindContext context, String id) {
+    if (id.length() > 0) {
+      try {
+        Class<?> type = Class.forName("org.folio.rest.workflow.model." + id);
+        if (type != null) {
+          return context.getTypeFactory().constructType(type);
+        }
+      } catch (ClassNotFoundException e) {
+        e.printStackTrace();
+      }
+    }
+
+    return null;
+  }
+
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/resolver/DeserializeAsJsonResolver.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/resolver/DeserializeAsJsonResolver.java
@@ -4,8 +4,12 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import com.fasterxml.jackson.databind.DatabindContext;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.jsontype.impl.TypeIdResolverBase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DeserializeAsJsonResolver extends TypeIdResolverBase {
+
+  private static final Logger logger = LoggerFactory.getLogger(DeserializeAsJsonResolver.class);
 
   @Override
   public String idFromValue(Object value) {
@@ -31,7 +35,7 @@ public class DeserializeAsJsonResolver extends TypeIdResolverBase {
           return context.getTypeFactory().constructType(type);
         }
       } catch (ClassNotFoundException e) {
-        e.printStackTrace();
+        logger.debug("Unknown Workflow Model class " + id, e);
       }
     }
 

--- a/components/src/main/java/org/folio/rest/workflow/model/resolver/DeserializeAsJsonResolver.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/resolver/DeserializeAsJsonResolver.java
@@ -28,12 +28,9 @@ public class DeserializeAsJsonResolver extends TypeIdResolverBase {
 
   @Override
   public JavaType typeFromId(DatabindContext context, String id) {
-    if (id.length() > 0) {
+    if (id != null && id.length() > 0) {
       try {
-        Class<?> type = Class.forName("org.folio.rest.workflow.model." + id);
-        if (type != null) {
-          return context.getTypeFactory().constructType(type);
-        }
+        return context.getTypeFactory().constructType(Class.forName("org.folio.rest.workflow.model." + id));
       } catch (ClassNotFoundException e) {
         logger.debug("Unknown Workflow Model class " + id, e);
       }

--- a/components/src/test/java/org/folio/rest/workflow/model/resolver/DeserializeAsJsonResolverTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/resolver/DeserializeAsJsonResolverTest.java
@@ -1,0 +1,164 @@
+package org.folio.rest.workflow.model.resolver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.databind.DatabindContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.stream.Stream;
+import org.folio.rest.workflow.model.AbstractGateway;
+import org.folio.rest.workflow.model.AbstractProcess;
+import org.folio.rest.workflow.model.AbstractTask;
+import org.folio.rest.workflow.model.CompressFileTask;
+import org.folio.rest.workflow.model.Condition;
+import org.folio.rest.workflow.model.ConnectTo;
+import org.folio.rest.workflow.model.DatabaseConnectionTask;
+import org.folio.rest.workflow.model.DatabaseDisconnectTask;
+import org.folio.rest.workflow.model.DatabaseQueryTask;
+import org.folio.rest.workflow.model.DirectoryTask;
+import org.folio.rest.workflow.model.EmailTask;
+import org.folio.rest.workflow.model.EmbeddedInput;
+import org.folio.rest.workflow.model.EmbeddedLoopReference;
+import org.folio.rest.workflow.model.EmbeddedProcessor;
+import org.folio.rest.workflow.model.EmbeddedRequest;
+import org.folio.rest.workflow.model.EmbeddedVariable;
+import org.folio.rest.workflow.model.EndEvent;
+import org.folio.rest.workflow.model.EventSubprocess;
+import org.folio.rest.workflow.model.ExclusiveGateway;
+import org.folio.rest.workflow.model.FileTask;
+import org.folio.rest.workflow.model.FtpTask;
+import org.folio.rest.workflow.model.InclusiveGateway;
+import org.folio.rest.workflow.model.InputTask;
+import org.folio.rest.workflow.model.MoveToLastGateway;
+import org.folio.rest.workflow.model.MoveToNode;
+import org.folio.rest.workflow.model.Node;
+import org.folio.rest.workflow.model.ParallelGateway;
+import org.folio.rest.workflow.model.ProcessorTask;
+import org.folio.rest.workflow.model.ReceiveTask;
+import org.folio.rest.workflow.model.RequestTask;
+import org.folio.rest.workflow.model.ScriptTask;
+import org.folio.rest.workflow.model.Setup;
+import org.folio.rest.workflow.model.StartEvent;
+import org.folio.rest.workflow.model.Subprocess;
+import org.folio.rest.workflow.model.Workflow;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DeserializeAsJsonResolverTest {
+
+  private ObjectMapper mapper;
+
+  @Mock
+  private DatabindContext databindContext;
+
+  @InjectMocks
+  private DeserializeAsJsonResolver deserializeAsJsonResolver;
+
+  @BeforeEach
+  void beforeEach() {
+    mapper = new ObjectMapper();
+  }
+
+  @Test
+  void idFromValueWorksTest() {
+    String result = deserializeAsJsonResolver.idFromValue(new String());
+
+    assertEquals(String.class.getSimpleName(), result);
+  }
+
+  @Test
+  void idFromValueAndTypeWorksTest() {
+    String result = deserializeAsJsonResolver.idFromValueAndType(new String(), JsonNode.class);
+
+    assertEquals(String.class.getSimpleName(), result);
+  }
+
+  @Test
+  void getMechanismWorksTest() {
+    Id result = deserializeAsJsonResolver.getMechanism();
+
+    assertEquals(Id.SIMPLE_NAME, result);
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = { "doesNotExist", "12345" })
+  void typeFromIdWorksExpectNullTest(String id) {
+    JavaType result = deserializeAsJsonResolver.typeFromId(databindContext, id);
+
+    assertNull(result);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideClassNameFor")
+  void typeFromIdWorksWithKnownClassesTest(String className, String simpleName) {
+    when(databindContext.getTypeFactory()).thenReturn(mapper.getTypeFactory());
+
+    JavaType result = deserializeAsJsonResolver.typeFromId(databindContext, className);
+
+    assertEquals(simpleName, result.getRawClass().getSimpleName());
+  }
+
+  /**
+   * Helper function for parameterized test providing tests for the testingClasses.
+   *
+   * @return
+   *   The arguments array stream with the stream columns as:
+   *     - String className The name of the class.
+   *     - String simpleName The simple name returned by the class.
+   */
+  private static Stream<Arguments> provideClassNameFor() {
+    return Stream.of(
+      Arguments.of("AbstractGateway",        AbstractGateway.class.getSimpleName()),
+      Arguments.of("AbstractProcess",        AbstractProcess.class.getSimpleName()),
+      Arguments.of("AbstractTask",           AbstractTask.class.getSimpleName()),
+      Arguments.of("CompressFileTask",       CompressFileTask.class.getSimpleName()),
+      Arguments.of("Condition",              Condition.class.getSimpleName()),
+      Arguments.of("ConnectTo",              ConnectTo.class.getSimpleName()),
+      Arguments.of("DatabaseConnectionTask", DatabaseConnectionTask.class.getSimpleName()),
+      Arguments.of("DatabaseDisconnectTask", DatabaseDisconnectTask.class.getSimpleName()),
+      Arguments.of("DatabaseQueryTask",      DatabaseQueryTask.class.getSimpleName()),
+      Arguments.of("DirectoryTask",          DirectoryTask.class.getSimpleName()),
+      Arguments.of("EmailTask",              EmailTask.class.getSimpleName()),
+      Arguments.of("EmbeddedInput",          EmbeddedInput.class.getSimpleName()),
+      Arguments.of("EmbeddedLoopReference",  EmbeddedLoopReference.class.getSimpleName()),
+      Arguments.of("EmbeddedProcessor",      EmbeddedProcessor.class.getSimpleName()),
+      Arguments.of("EmbeddedRequest",        EmbeddedRequest.class.getSimpleName()),
+      Arguments.of("EmbeddedVariable",       EmbeddedVariable.class.getSimpleName()),
+      Arguments.of("EndEvent",               EndEvent.class.getSimpleName()),
+      Arguments.of("EventSubprocess",        EventSubprocess.class.getSimpleName()),
+      Arguments.of("ExclusiveGateway",       ExclusiveGateway.class.getSimpleName()),
+      Arguments.of("FileTask",               FileTask.class.getSimpleName()),
+      Arguments.of("FtpTask",                FtpTask.class.getSimpleName()),
+      Arguments.of("InclusiveGateway",       InclusiveGateway.class.getSimpleName()),
+      Arguments.of("InputTask",              InputTask.class.getSimpleName()),
+      Arguments.of("MoveToLastGateway",      MoveToLastGateway.class.getSimpleName()),
+      Arguments.of("MoveToNode",             MoveToNode.class.getSimpleName()),
+      Arguments.of("Node",                   Node.class.getSimpleName()),
+      Arguments.of("ParallelGateway",        ParallelGateway.class.getSimpleName()),
+      Arguments.of("ProcessorTask",          ProcessorTask.class.getSimpleName()),
+      Arguments.of("ReceiveTask",            ReceiveTask.class.getSimpleName()),
+      Arguments.of("RequestTask",            RequestTask.class.getSimpleName()),
+      Arguments.of("ScriptTask",             ScriptTask.class.getSimpleName()),
+      Arguments.of("Setup",                  Setup.class.getSimpleName()),
+      Arguments.of("StartEvent",             StartEvent.class.getSimpleName()),
+      Arguments.of("Subprocess",             Subprocess.class.getSimpleName()),
+      Arguments.of("Workflow",               Workflow.class.getSimpleName())
+    );
+  }
+
+}

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -18,7 +18,7 @@
 
   <properties>
     <openapi.server.port>9000</openapi.server.port>
-    <folio-spring.version>8.1.0</folio-spring.version>
+    <folio-spring.version>8.2.2</folio-spring.version>
   </properties>
 
   <dependencies>

--- a/service/src/main/java/org/folio/rest/workflow/controller/EventController.java
+++ b/service/src/main/java/org/folio/rest/workflow/controller/EventController.java
@@ -155,6 +155,7 @@ public class EventController {
         )
       );
     }
+
     return body;
   }
 
@@ -166,6 +167,7 @@ public class EventController {
 
   private void processEvent(TriggerDto trigger, Event event) throws EventPublishException {
     logger.debug("Publishing event: {}: {}", trigger.getName(), trigger.getDescription());
+
     try {
       eventProducer.send(event);
     } catch (Exception e) {

--- a/service/src/main/resources/openapi.yaml
+++ b/service/src/main/resources/openapi.yaml
@@ -52,10 +52,10 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/PagedModelEntityModelNode'
+                $ref: "#/components/schemas/PagedModelEntityModelNode"
             application/x-spring-data-compact+json:
               schema:
-                $ref: '#/components/schemas/PagedModelEntityModelNode'
+                $ref: "#/components/schemas/PagedModelEntityModelNode"
             text/uri-list:
               schema:
                 type: string
@@ -68,31 +68,7 @@ paths:
         content:
           application/json:
             schema:
-              oneOf:
-              - $ref: '#/components/schemas/CompressFileTaskRequestBody'
-              - $ref: '#/components/schemas/ConditionRequestBody'
-              - $ref: '#/components/schemas/ConnectToRequestBody'
-              - $ref: '#/components/schemas/DatabaseConnectionTaskRequestBody'
-              - $ref: '#/components/schemas/DatabaseDisconnectTaskRequestBody'
-              - $ref: '#/components/schemas/DatabaseQueryTaskRequestBody'
-              - $ref: '#/components/schemas/DirectoryTaskRequestBody'
-              - $ref: '#/components/schemas/EmailTaskRequestBody'
-              - $ref: '#/components/schemas/EndEventRequestBody'
-              - $ref: '#/components/schemas/EventSubprocessRequestBody'
-              - $ref: '#/components/schemas/ExclusiveGatewayRequestBody'
-              - $ref: '#/components/schemas/FileTaskRequestBody'
-              - $ref: '#/components/schemas/FtpTaskRequestBody'
-              - $ref: '#/components/schemas/InclusiveGatewayRequestBody'
-              - $ref: '#/components/schemas/InputTaskRequestBody'
-              - $ref: '#/components/schemas/MoveToLastGatewayRequestBody'
-              - $ref: '#/components/schemas/MoveToNodeRequestBody'
-              - $ref: '#/components/schemas/ParallelGatewayRequestBody'
-              - $ref: '#/components/schemas/ProcessorTaskRequestBody'
-              - $ref: '#/components/schemas/ReceiveTaskRequestBody'
-              - $ref: '#/components/schemas/RequestTaskRequestBody'
-              - $ref: '#/components/schemas/ScriptTaskRequestBody'
-              - $ref: '#/components/schemas/StartEventRequestBody'
-              - $ref: '#/components/schemas/SubprocessRequestBody'
+              $ref: "#/components/schemas/NodeRequestBody"
         required: true
       responses:
         "201":
@@ -100,7 +76,7 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/EntityModelNode'
+                $ref: "#/components/schemas/EntityModelNode"
   /nodes/{id}:
     get:
       tags:
@@ -119,7 +95,7 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/EntityModelNode'
+                $ref: "#/components/schemas/EntityModelNode"
         "404":
           description: Not Found
     put:
@@ -137,31 +113,7 @@ paths:
         content:
           application/json:
             schema:
-              oneOf:
-              - $ref: '#/components/schemas/CompressFileTaskRequestBody'
-              - $ref: '#/components/schemas/ConditionRequestBody'
-              - $ref: '#/components/schemas/ConnectToRequestBody'
-              - $ref: '#/components/schemas/DatabaseConnectionTaskRequestBody'
-              - $ref: '#/components/schemas/DatabaseDisconnectTaskRequestBody'
-              - $ref: '#/components/schemas/DatabaseQueryTaskRequestBody'
-              - $ref: '#/components/schemas/DirectoryTaskRequestBody'
-              - $ref: '#/components/schemas/EmailTaskRequestBody'
-              - $ref: '#/components/schemas/EndEventRequestBody'
-              - $ref: '#/components/schemas/EventSubprocessRequestBody'
-              - $ref: '#/components/schemas/ExclusiveGatewayRequestBody'
-              - $ref: '#/components/schemas/FileTaskRequestBody'
-              - $ref: '#/components/schemas/FtpTaskRequestBody'
-              - $ref: '#/components/schemas/InclusiveGatewayRequestBody'
-              - $ref: '#/components/schemas/InputTaskRequestBody'
-              - $ref: '#/components/schemas/MoveToLastGatewayRequestBody'
-              - $ref: '#/components/schemas/MoveToNodeRequestBody'
-              - $ref: '#/components/schemas/ParallelGatewayRequestBody'
-              - $ref: '#/components/schemas/ProcessorTaskRequestBody'
-              - $ref: '#/components/schemas/ReceiveTaskRequestBody'
-              - $ref: '#/components/schemas/RequestTaskRequestBody'
-              - $ref: '#/components/schemas/ScriptTaskRequestBody'
-              - $ref: '#/components/schemas/StartEventRequestBody'
-              - $ref: '#/components/schemas/SubprocessRequestBody'
+              $ref: "#/components/schemas/NodeRequestBody"
         required: true
       responses:
         "200":
@@ -169,13 +121,13 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/EntityModelNode'
+                $ref: "#/components/schemas/EntityModelNode"
         "201":
           description: Created
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/EntityModelNode'
+                $ref: "#/components/schemas/EntityModelNode"
         "204":
           description: No Content
     delete:
@@ -209,31 +161,7 @@ paths:
         content:
           application/json:
             schema:
-              oneOf:
-              - $ref: '#/components/schemas/CompressFileTaskRequestBody'
-              - $ref: '#/components/schemas/ConditionRequestBody'
-              - $ref: '#/components/schemas/ConnectToRequestBody'
-              - $ref: '#/components/schemas/DatabaseConnectionTaskRequestBody'
-              - $ref: '#/components/schemas/DatabaseDisconnectTaskRequestBody'
-              - $ref: '#/components/schemas/DatabaseQueryTaskRequestBody'
-              - $ref: '#/components/schemas/DirectoryTaskRequestBody'
-              - $ref: '#/components/schemas/EmailTaskRequestBody'
-              - $ref: '#/components/schemas/EndEventRequestBody'
-              - $ref: '#/components/schemas/EventSubprocessRequestBody'
-              - $ref: '#/components/schemas/ExclusiveGatewayRequestBody'
-              - $ref: '#/components/schemas/FileTaskRequestBody'
-              - $ref: '#/components/schemas/FtpTaskRequestBody'
-              - $ref: '#/components/schemas/InclusiveGatewayRequestBody'
-              - $ref: '#/components/schemas/InputTaskRequestBody'
-              - $ref: '#/components/schemas/MoveToLastGatewayRequestBody'
-              - $ref: '#/components/schemas/MoveToNodeRequestBody'
-              - $ref: '#/components/schemas/ParallelGatewayRequestBody'
-              - $ref: '#/components/schemas/ProcessorTaskRequestBody'
-              - $ref: '#/components/schemas/ReceiveTaskRequestBody'
-              - $ref: '#/components/schemas/RequestTaskRequestBody'
-              - $ref: '#/components/schemas/ScriptTaskRequestBody'
-              - $ref: '#/components/schemas/StartEventRequestBody'
-              - $ref: '#/components/schemas/SubprocessRequestBody'
+              $ref: "#/components/schemas/NodeRequestBody"
         required: true
       responses:
         "200":
@@ -241,7 +169,7 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/EntityModelNode'
+                $ref: "#/components/schemas/EntityModelNode"
         "204":
           description: No Content
   /profile:
@@ -255,7 +183,7 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/RepresentationModelObject'
+                $ref: "#/components/schemas/RepresentationModelObject"
   /profile/nodes:
     get:
       tags:
@@ -273,7 +201,7 @@ paths:
                 type: string
             application/schema+json:
               schema:
-                $ref: '#/components/schemas/JsonSchema'
+                $ref: "#/components/schemas/JsonSchema"
   /profile/triggers:
     get:
       tags:
@@ -291,7 +219,7 @@ paths:
                 type: string
             application/schema+json:
               schema:
-                $ref: '#/components/schemas/JsonSchema'
+                $ref: "#/components/schemas/JsonSchema"
   /profile/workflows:
     get:
       tags:
@@ -309,7 +237,7 @@ paths:
                 type: string
             application/schema+json:
               schema:
-                $ref: '#/components/schemas/JsonSchema'
+                $ref: "#/components/schemas/JsonSchema"
   /triggers:
     get:
       tags:
@@ -348,10 +276,10 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/PagedModelEntityModelTrigger'
+                $ref: "#/components/schemas/PagedModelEntityModelTrigger"
             application/x-spring-data-compact+json:
               schema:
-                $ref: '#/components/schemas/PagedModelEntityModelTrigger'
+                $ref: "#/components/schemas/PagedModelEntityModelTrigger"
             text/uri-list:
               schema:
                 type: string
@@ -364,7 +292,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TriggerRequestBody'
+              $ref: "#/components/schemas/TriggerRequestBody"
         required: true
       responses:
         "201":
@@ -372,7 +300,7 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/EntityModelTrigger'
+                $ref: "#/components/schemas/EntityModelTrigger"
   /triggers/search/findViewAllBy:
     get:
       tags:
@@ -5660,7 +5588,7 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/CollectionModelEntityModelTrigger'
+                $ref: "#/components/schemas/CollectionModelEntityModelTrigger"
         "404":
           description: Not Found
   /triggers/{id}:
@@ -5681,7 +5609,7 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/EntityModelTrigger'
+                $ref: "#/components/schemas/EntityModelTrigger"
         "404":
           description: Not Found
     put:
@@ -5699,7 +5627,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TriggerRequestBody'
+              $ref: "#/components/schemas/TriggerRequestBody"
         required: true
       responses:
         "200":
@@ -5707,13 +5635,13 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/EntityModelTrigger'
+                $ref: "#/components/schemas/EntityModelTrigger"
         "201":
           description: Created
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/EntityModelTrigger'
+                $ref: "#/components/schemas/EntityModelTrigger"
         "204":
           description: No Content
     delete:
@@ -5747,7 +5675,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TriggerRequestBody'
+              $ref: "#/components/schemas/TriggerRequestBody"
         required: true
       responses:
         "200":
@@ -5755,7 +5683,7 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/EntityModelTrigger'
+                $ref: "#/components/schemas/EntityModelTrigger"
         "204":
           description: No Content
   /workflows:
@@ -5796,10 +5724,10 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/PagedModelEntityModelWorkflow'
+                $ref: "#/components/schemas/PagedModelEntityModelWorkflow"
             application/x-spring-data-compact+json:
               schema:
-                $ref: '#/components/schemas/PagedModelEntityModelWorkflow'
+                $ref: "#/components/schemas/PagedModelEntityModelWorkflow"
             text/uri-list:
               schema:
                 type: string
@@ -5812,7 +5740,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/WorkflowRequestBody'
+              $ref: "#/components/schemas/WorkflowRequestBody"
         required: true
       responses:
         "201":
@@ -5820,7 +5748,7 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/EntityModelWorkflow'
+                $ref: "#/components/schemas/EntityModelWorkflow"
   /workflows/search/getViewById:
     get:
       tags:
@@ -11112,7 +11040,7 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/EntityModelWorkflow'
+                $ref: "#/components/schemas/EntityModelWorkflow"
         "404":
           description: Not Found
   /workflows/{id}:
@@ -11143,13 +11071,13 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "500":
           description: Internal Server Error
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "404":
           description: Not Found
         "403":
@@ -11157,22 +11085,22 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "204":
           description: No Content
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "200":
           description: OK
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/EntityModelWorkflow'
+                $ref: "#/components/schemas/EntityModelWorkflow"
             application/json:
               schema:
-                $ref: '#/components/schemas/Workflow'
+                $ref: "#/components/schemas/Workflow"
     put:
       tags:
       - workflow-entity-controller
@@ -11188,7 +11116,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/WorkflowRequestBody'
+              $ref: "#/components/schemas/WorkflowRequestBody"
         required: true
       responses:
         "200":
@@ -11196,13 +11124,13 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/EntityModelWorkflow'
+                $ref: "#/components/schemas/EntityModelWorkflow"
         "201":
           description: Created
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/EntityModelWorkflow'
+                $ref: "#/components/schemas/EntityModelWorkflow"
         "204":
           description: No Content
     patch:
@@ -11220,7 +11148,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/WorkflowRequestBody'
+              $ref: "#/components/schemas/WorkflowRequestBody"
         required: true
       responses:
         "200":
@@ -11228,7 +11156,7 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/EntityModelWorkflow'
+                $ref: "#/components/schemas/EntityModelWorkflow"
         "204":
           description: No Content
   /workflows/{id}/nodes:
@@ -11249,7 +11177,7 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/CollectionModelNode'
+                $ref: "#/components/schemas/CollectionModelNode"
             text/uri-list:
               schema:
                 type: string
@@ -11270,10 +11198,10 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CollectionModelObject'
+              $ref: "#/components/schemas/CollectionModelObject"
           application/x-spring-data-compact+json:
             schema:
-              $ref: '#/components/schemas/CollectionModelObject'
+              $ref: "#/components/schemas/CollectionModelObject"
           text/uri-list:
             schema:
               type: string
@@ -11284,13 +11212,13 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/CollectionModelNode'
+                $ref: "#/components/schemas/CollectionModelNode"
         "201":
           description: Created
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/CollectionModelNode'
+                $ref: "#/components/schemas/CollectionModelNode"
         "204":
           description: No Content
     patch:
@@ -11308,10 +11236,10 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CollectionModelObject'
+              $ref: "#/components/schemas/CollectionModelObject"
           application/x-spring-data-compact+json:
             schema:
-              $ref: '#/components/schemas/CollectionModelObject'
+              $ref: "#/components/schemas/CollectionModelObject"
           text/uri-list:
             schema:
               type: string
@@ -11322,7 +11250,7 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/CollectionModelNode'
+                $ref: "#/components/schemas/CollectionModelNode"
         "204":
           description: No Content
   /workflows/{id}/nodes/{propertyId}:
@@ -11348,7 +11276,7 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/CollectionModelNode'
+                $ref: "#/components/schemas/CollectionModelNode"
         "404":
           description: Not Found
   /workflows/{id}/deactivate:
@@ -11378,37 +11306,37 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "500":
           description: Internal Server Error
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "404":
           description: Not Found
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "403":
           description: Forbidden
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "204":
           description: No Content
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Workflow'
+                $ref: "#/components/schemas/Workflow"
   /workflows/{id}/activate:
     put:
       tags:
@@ -11436,37 +11364,37 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "500":
           description: Internal Server Error
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "404":
           description: Not Found
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "403":
           description: Forbidden
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "204":
           description: No Content
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Workflow'
+                $ref: "#/components/schemas/Workflow"
   /workflows/{id}/start:
     post:
       tags:
@@ -11489,7 +11417,7 @@ paths:
                 token:
                   type: string
                 context:
-                  $ref: '#/components/schemas/JsonNode'
+                  $ref: "#/components/schemas/JsonNode"
         required: true
       responses:
         "400":
@@ -11497,37 +11425,37 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "500":
           description: Internal Server Error
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "404":
           description: Not Found
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "403":
           description: Forbidden
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "204":
           description: No Content
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/JsonNode'
+                $ref: "#/components/schemas/JsonNode"
   /workflows/import:
     post:
       tags:
@@ -11554,31 +11482,31 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "500":
           description: Internal Server Error
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "404":
           description: Not Found
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "403":
           description: Forbidden
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "204":
           description: No Content
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "200":
           description: OK
           content:
@@ -11611,44 +11539,44 @@ paths:
                   type: string
           application/json:
             schema:
-              $ref: '#/components/schemas/JsonNode'
+              $ref: "#/components/schemas/JsonNode"
       responses:
         "400":
           description: Bad Request
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "500":
           description: Internal Server Error
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "404":
           description: Not Found
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "403":
           description: Forbidden
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "204":
           description: No Content
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/JsonNode'
+                $ref: "#/components/schemas/JsonNode"
   /_/tenant:
     post:
       tags:
@@ -11666,7 +11594,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/tenantAttributes'
+              $ref: "#/components/schemas/tenantAttributes"
         required: true
       responses:
         "400":
@@ -11674,7 +11602,7 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
             application/json:
               schema:
                 type: string
@@ -11686,7 +11614,7 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
             application/json:
               schema:
                 type: string
@@ -11698,19 +11626,19 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "403":
           description: Forbidden
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "204":
           description: Job completed
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "200":
           description: OK
           content:
@@ -11722,10 +11650,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/errors'
+                $ref: "#/components/schemas/errors"
             text/plain:
               schema:
-                $ref: '#/components/schemas/errors'
+                $ref: "#/components/schemas/errors"
     delete:
       tags:
       - tenant-controller
@@ -11747,31 +11675,31 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "500":
           description: Internal Server Error
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "404":
           description: Not Found
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "403":
           description: Forbidden
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "204":
           description: No Content
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "200":
           description: OK
   /workflows/{id}/history:
@@ -11801,37 +11729,37 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "500":
           description: Internal Server Error
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "404":
           description: Not Found
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "403":
           description: Forbidden
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "204":
           description: No Content
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/JsonNode'
+                $ref: "#/components/schemas/JsonNode"
   /workflows/search:
     get:
       tags:
@@ -11868,37 +11796,37 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "500":
           description: Internal Server Error
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "404":
           description: Not Found
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "403":
           description: Forbidden
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "204":
           description: No Content
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/JsonNode'
+                $ref: "#/components/schemas/JsonNode"
   /admin:
     get:
       tags:
@@ -11911,31 +11839,31 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "500":
           description: Internal Server Error
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "404":
           description: Not Found
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "403":
           description: Forbidden
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "204":
           description: No Content
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "200":
           description: OK
           content:
@@ -11945,21 +11873,21 @@ paths:
                 additionalProperties:
                   type: object
                   additionalProperties:
-                    $ref: '#/components/schemas/Link'
+                    $ref: "#/components/schemas/Link"
             application/vnd.spring-boot.actuator.v2+json:
               schema:
                 type: object
                 additionalProperties:
                   type: object
                   additionalProperties:
-                    $ref: '#/components/schemas/Link'
+                    $ref: "#/components/schemas/Link"
             application/json:
               schema:
                 type: object
                 additionalProperties:
                   type: object
                   additionalProperties:
-                    $ref: '#/components/schemas/Link'
+                    $ref: "#/components/schemas/Link"
   /admin/info:
     get:
       tags:
@@ -11972,31 +11900,31 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "500":
           description: Internal Server Error
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "404":
           description: Not Found
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "403":
           description: Forbidden
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "204":
           description: No Content
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "200":
           description: OK
           content:
@@ -12021,31 +11949,31 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "500":
           description: Internal Server Error
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "404":
           description: Not Found
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "403":
           description: Forbidden
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "204":
           description: No Content
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "200":
           description: OK
           content:
@@ -12070,31 +11998,31 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "500":
           description: Internal Server Error
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "404":
           description: Not Found
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "403":
           description: Forbidden
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "204":
           description: No Content
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "200":
           description: OK
           content:
@@ -12124,31 +12052,31 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "500":
           description: Internal Server Error
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "404":
           description: Not Found
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "403":
           description: Forbidden
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "204":
           description: No Content
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "200":
           description: OK
           content:
@@ -12156,7 +12084,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Action'
+                  $ref: "#/components/schemas/Action"
   /_/tenant/{operationId}:
     get:
       tags:
@@ -12176,7 +12104,7 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "500":
           description: Internal server error
           content:
@@ -12188,19 +12116,19 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "403":
           description: Forbidden
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "204":
           description: No Content
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "200":
           description: true or false indicator
           content:
@@ -12233,13 +12161,13 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "403":
           description: Forbidden
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "204":
           description: Delete succeeded
         "200":
@@ -12271,31 +12199,31 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "500":
           description: Internal Server Error
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "404":
           description: Not Found
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "403":
           description: Forbidden
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "204":
           description: No Content
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "200":
           description: OK
           content:
@@ -12329,31 +12257,31 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "500":
           description: Internal Server Error
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "404":
           description: Not Found
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "403":
           description: Forbidden
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "204":
           description: No Content
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "200":
           description: OK
           content:
@@ -12387,31 +12315,31 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "500":
           description: Internal Server Error
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "404":
           description: Not Found
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "403":
           description: Forbidden
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "204":
           description: No Content
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "200":
           description: OK
           content:
@@ -12434,7 +12362,7 @@ components:
         parameters:
           type: array
           items:
-            $ref: '#/components/schemas/Parameter'
+            $ref: "#/components/schemas/Parameter"
     Parameter:
       type: object
       properties:
@@ -12448,7 +12376,7 @@ components:
         errors:
           type: array
           items:
-            $ref: '#/components/schemas/Error'
+            $ref: "#/components/schemas/Error"
         total_records:
           type: integer
           format: int32
@@ -12467,7 +12395,7 @@ components:
         properties:
           type: object
           additionalProperties:
-            $ref: '#/components/schemas/AbstractJsonSchemaPropertyObject'
+            $ref: "#/components/schemas/AbstractJsonSchemaPropertyObject"
         requiredProperties:
           type: array
           items:
@@ -12482,7 +12410,7 @@ components:
         properties:
           type: object
           additionalProperties:
-            $ref: '#/components/schemas/AbstractJsonSchemaPropertyObject'
+            $ref: "#/components/schemas/AbstractJsonSchemaPropertyObject"
         requiredProperties:
           type: array
           items:
@@ -12490,7 +12418,7 @@ components:
         definitions:
           type: object
           additionalProperties:
-            $ref: '#/components/schemas/Item'
+            $ref: "#/components/schemas/Item"
         type:
           type: string
         $schema:
@@ -12498,196 +12426,32 @@ components:
     Links:
       type: object
       additionalProperties:
-        $ref: '#/components/schemas/Link'
+        $ref: "#/components/schemas/Link"
     RepresentationModelObject:
       type: object
       properties:
         _links:
-          $ref: '#/components/schemas/Links'
-    EmbeddedInput:
-      required:
-      - inputType
-      type: object
-      properties:
-        attributes:
-          type: array
-          items:
-            type: string
-            enum:
-            - MAX
-            - MAXLENGTH
-            - MIN
-            - PATTERN
-            - SIZE
-            - STEP
-        defaultValue:
-          type: string
-        fieldId:
-          type: string
-        fieldLabel:
-          type: string
-        inputType:
-          type: string
-          enum:
-          - BUTTON
-          - CHECKBOX
-          - COLOR
-          - DATE
-          - DATETIME
-          - EMAIL
-          - FILE
-          - HIDDEN
-          - IMAGE
-          - MONTH
-          - NUMBER
-          - PASSWORD
-          - RADIO
-          - RANGE
-          - SEARCH
-          - SELECT
-          - SUBMIT
-          - TELEPHONE
-          - TEXT
-          - TIME
-          - URL
-          - WEEK
-        options:
-          type: array
-          items:
-            type: string
-        required:
-          type: boolean
-    EmbeddedLoopReference:
-      required:
-      - parallel
-      type: object
-      properties:
-        cardinalityExpression:
-          type: string
-        completeConditionExpression:
-          type: string
-        dataInputRefExpression:
-          type: string
-        inputDataName:
-          type: string
-        parallel:
-          type: boolean
-    EmbeddedProcessor:
-      required:
-      - code
-      - functionName
-      - scriptType
-      type: object
-      properties:
-        buffer:
-          type: integer
-          format: int32
-        code:
-          type: string
-        delay:
-          type: integer
-          format: int32
-        functionName:
-          maxLength: 128
-          minLength: 4
-          type: string
-        scriptType:
-          type: string
-          enum:
-          - GROOVY
-          - JAVA
-          - JS
-          - PYTHON
-          - RUBY
-    EmbeddedRequest:
-      required:
-      - accept
-      - contentType
-      - method
-      - url
-      type: object
-      properties:
-        accept:
-          type: string
-        bodyTemplate:
-          type: string
-        contentType:
-          type: string
-        iterable:
-          type: boolean
-        iterableKey:
-          type: string
-        method:
-          type: string
-          enum:
-          - GET
-          - HEAD
-          - POST
-          - PUT
-          - PATCH
-          - DELETE
-          - OPTIONS
-          - TRACE
-        responseKey:
-          type: string
-        url:
-          type: string
-    EmbeddedVariable:
-      required:
-      - key
-      type: object
-      properties:
-        key:
-          maxLength: 64
-          minLength: 4
-          type: string
-        type:
-          type: string
-          enum:
-          - PROCESS
-          - LOCAL
-        spin:
-          type: boolean
-        asJson:
-          type: boolean
-        asTransient:
-          type: boolean
-    EntityModelWorkflow:
+          $ref: "#/components/schemas/Links"
+    EntityModelNode:
       required:
       - name
-      - versionTag
       type: object
       properties:
-        active:
-          type: boolean
-        deploymentId:
+        name:
+          maxLength: 64
+          minLength: 3
           type: string
         description:
           maxLength: 512
           minLength: 0
           type: string
-        historyTimeToLive:
-          minimum: 0
-          type: integer
-          format: int32
-        initialContext:
-          type: object
-          additionalProperties:
-            $ref: '#/components/schemas/JsonNode'
-        name:
-          maxLength: 64
-          minLength: 4
+        deserializeAs:
           type: string
-        setup:
-          $ref: '#/components/schemas/Setup'
-        versionTag:
-          maxLength: 64
-          minLength: 1
+          readOnly: true
+        identifier:
           type: string
         _links:
-          $ref: '#/components/schemas/Links'
-    JsonNode:
-      type: object
+          $ref: "#/components/schemas/Links"
     Node:
       required:
       - name
@@ -12708,8 +12472,6 @@ components:
           readOnly: true
         identifier:
           type: string
-      discriminator:
-        propertyName: deserializeAs
     PageMetadata:
       type: object
       properties:
@@ -12725,133 +12487,6 @@ components:
         number:
           type: integer
           format: int64
-    PagedModelEntityModelWorkflow:
-      type: object
-      properties:
-        _embedded:
-          type: object
-          properties:
-            workflows:
-              type: array
-              items:
-                $ref: '#/components/schemas/EntityModelWorkflow'
-        _links:
-          $ref: '#/components/schemas/Links'
-        page:
-          $ref: '#/components/schemas/PageMetadata'
-    Setup:
-      type: object
-      properties:
-        asyncAfter:
-          type: boolean
-        asyncBefore:
-          type: boolean
-    Workflow:
-      required:
-      - name
-      - versionTag
-      type: object
-      properties:
-        id:
-          type: string
-        active:
-          type: boolean
-        deploymentId:
-          type: string
-        description:
-          maxLength: 512
-          minLength: 0
-          type: string
-        historyTimeToLive:
-          minimum: 0
-          type: integer
-          format: int32
-        initialContext:
-          type: object
-          additionalProperties:
-            $ref: '#/components/schemas/JsonNode'
-        name:
-          maxLength: 64
-          minLength: 4
-          type: string
-        nodes:
-          type: array
-          items:
-            $ref: '#/components/schemas/Node'
-        setup:
-          $ref: '#/components/schemas/Setup'
-        versionTag:
-          maxLength: 64
-          minLength: 1
-          type: string
-    CollectionModelNode:
-      type: object
-      properties:
-        _embedded:
-          type: object
-          properties:
-            nodes:
-              type: array
-              items:
-                oneOf:
-                - $ref: '#/components/schemas/CompressFileTaskResponse'
-                - $ref: '#/components/schemas/ConditionResponse'
-                - $ref: '#/components/schemas/ConnectToResponse'
-                - $ref: '#/components/schemas/DatabaseConnectionTaskResponse'
-                - $ref: '#/components/schemas/DatabaseDisconnectTaskResponse'
-                - $ref: '#/components/schemas/DatabaseQueryTaskResponse'
-                - $ref: '#/components/schemas/DirectoryTaskResponse'
-                - $ref: '#/components/schemas/EmailTaskResponse'
-                - $ref: '#/components/schemas/EndEventResponse'
-                - $ref: '#/components/schemas/EventSubprocessResponse'
-                - $ref: '#/components/schemas/ExclusiveGatewayResponse'
-                - $ref: '#/components/schemas/FileTaskResponse'
-                - $ref: '#/components/schemas/FtpTaskResponse'
-                - $ref: '#/components/schemas/InclusiveGatewayResponse'
-                - $ref: '#/components/schemas/InputTaskResponse'
-                - $ref: '#/components/schemas/MoveToLastGatewayResponse'
-                - $ref: '#/components/schemas/MoveToNodeResponse'
-                - $ref: '#/components/schemas/ParallelGatewayResponse'
-                - $ref: '#/components/schemas/ProcessorTaskResponse'
-                - $ref: '#/components/schemas/ReceiveTaskResponse'
-                - $ref: '#/components/schemas/RequestTaskResponse'
-                - $ref: '#/components/schemas/ScriptTaskResponse'
-                - $ref: '#/components/schemas/StartEventResponse'
-                - $ref: '#/components/schemas/SubprocessResponse'
-        _links:
-          $ref: '#/components/schemas/Links'
-    CollectionModelObject:
-      type: object
-      properties:
-        _embedded:
-          type: object
-          properties:
-            objects:
-              type: array
-              items:
-                type: object
-        _links:
-          $ref: '#/components/schemas/Links'
-    EntityModelNode:
-      required:
-      - name
-      type: object
-      properties:
-        name:
-          maxLength: 64
-          minLength: 3
-          type: string
-        description:
-          maxLength: 512
-          minLength: 0
-          type: string
-        deserializeAs:
-          type: string
-          readOnly: true
-        identifier:
-          type: string
-        _links:
-          $ref: '#/components/schemas/Links'
     PagedModelEntityModelNode:
       type: object
       properties:
@@ -12861,11 +12496,11 @@ components:
             nodes:
               type: array
               items:
-                $ref: '#/components/schemas/EntityModelNode'
+                $ref: "#/components/schemas/EntityModelNode"
         _links:
-          $ref: '#/components/schemas/Links'
+          $ref: "#/components/schemas/Links"
         page:
-          $ref: '#/components/schemas/PageMetadata'
+          $ref: "#/components/schemas/PageMetadata"
     EntityModelTrigger:
       required:
       - method
@@ -12897,7 +12532,7 @@ components:
           - OPTIONS
           - TRACE
         _links:
-          $ref: '#/components/schemas/Links'
+          $ref: "#/components/schemas/Links"
     PagedModelEntityModelTrigger:
       type: object
       properties:
@@ -12907,11 +12542,11 @@ components:
             triggers:
               type: array
               items:
-                $ref: '#/components/schemas/EntityModelTrigger'
+                $ref: "#/components/schemas/EntityModelTrigger"
         _links:
-          $ref: '#/components/schemas/Links'
+          $ref: "#/components/schemas/Links"
         page:
-          $ref: '#/components/schemas/PageMetadata'
+          $ref: "#/components/schemas/PageMetadata"
     CollectionModelEntityModelTrigger:
       type: object
       properties:
@@ -12921,9 +12556,148 @@ components:
             triggers:
               type: array
               items:
-                $ref: '#/components/schemas/EntityModelTrigger'
+                $ref: "#/components/schemas/EntityModelTrigger"
         _links:
-          $ref: '#/components/schemas/Links'
+          $ref: "#/components/schemas/Links"
+    EntityModelWorkflow:
+      required:
+      - name
+      - versionTag
+      type: object
+      properties:
+        active:
+          type: boolean
+        deploymentId:
+          type: string
+        description:
+          maxLength: 512
+          minLength: 0
+          type: string
+        historyTimeToLive:
+          minimum: 0
+          type: integer
+          format: int32
+        initialContext:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/JsonNode"
+        name:
+          maxLength: 64
+          minLength: 4
+          type: string
+        setup:
+          $ref: "#/components/schemas/Setup"
+        versionTag:
+          maxLength: 64
+          minLength: 1
+          type: string
+        _links:
+          $ref: "#/components/schemas/Links"
+    JsonNode:
+      type: object
+    PagedModelEntityModelWorkflow:
+      type: object
+      properties:
+        _embedded:
+          type: object
+          properties:
+            workflows:
+              type: array
+              items:
+                $ref: "#/components/schemas/EntityModelWorkflow"
+        _links:
+          $ref: "#/components/schemas/Links"
+        page:
+          $ref: "#/components/schemas/PageMetadata"
+    Setup:
+      type: object
+      properties:
+        asyncAfter:
+          type: boolean
+        asyncBefore:
+          type: boolean
+    Workflow:
+      required:
+      - name
+      - versionTag
+      type: object
+      properties:
+        id:
+          type: string
+        active:
+          type: boolean
+        deploymentId:
+          type: string
+        description:
+          maxLength: 512
+          minLength: 0
+          type: string
+        historyTimeToLive:
+          minimum: 0
+          type: integer
+          format: int32
+        initialContext:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/JsonNode"
+        name:
+          maxLength: 64
+          minLength: 4
+          type: string
+        nodes:
+          type: array
+          items:
+            $ref: "#/components/schemas/Node"
+        setup:
+          $ref: "#/components/schemas/Setup"
+        versionTag:
+          maxLength: 64
+          minLength: 1
+          type: string
+    CollectionModelNode:
+      type: object
+      properties:
+        _embedded:
+          type: object
+          properties:
+            nodes:
+              type: array
+              items:
+                $ref: "#/components/schemas/NodeResponse"
+        _links:
+          $ref: "#/components/schemas/Links"
+    CollectionModelObject:
+      type: object
+      properties:
+        _embedded:
+          type: object
+          properties:
+            objects:
+              type: array
+              items:
+                type: object
+        _links:
+          $ref: "#/components/schemas/Links"
+    NodeRequestBody:
+      required:
+      - name
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          maxLength: 64
+          minLength: 3
+          type: string
+        description:
+          maxLength: 512
+          minLength: 0
+          type: string
+        deserializeAs:
+          type: string
+          readOnly: true
+        identifier:
+          type: string
     TriggerRequestBody:
       required:
       - method
@@ -12956,589 +12730,6 @@ components:
           - DELETE
           - OPTIONS
           - TRACE
-    CompressFileTaskRequestBody:
-      required:
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/NodeRequestBody'
-      - type: object
-        properties:
-          asyncAfter:
-            type: boolean
-          asyncBefore:
-            type: boolean
-          inputVariables:
-            uniqueItems: true
-            type: array
-            items:
-              $ref: '#/components/schemas/EmbeddedVariable'
-          outputVariable:
-            $ref: '#/components/schemas/EmbeddedVariable'
-          source:
-            type: string
-          destination:
-            type: string
-          format:
-            type: string
-            enum:
-            - BZIP2
-            - GZIP
-            - ZIP
-          container:
-            type: string
-            enum:
-            - NONE
-            - TAR
-    ConditionRequestBody:
-      required:
-      - answer
-      - expression
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/NodeRequestBody'
-      - type: object
-        properties:
-          answer:
-            maxLength: 64
-            minLength: 2
-            type: string
-          expression:
-            maxLength: 128
-            minLength: 4
-            type: string
-    ConnectToRequestBody:
-      required:
-      - name
-      - nodeId
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/NodeRequestBody'
-      - type: object
-        properties:
-          nodeId:
-            type: string
-    DatabaseConnectionTaskRequestBody:
-      required:
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/NodeRequestBody'
-      - type: object
-        properties:
-          asyncAfter:
-            type: boolean
-          asyncBefore:
-            type: boolean
-          inputVariables:
-            uniqueItems: true
-            type: array
-            items:
-              $ref: '#/components/schemas/EmbeddedVariable'
-          outputVariable:
-            $ref: '#/components/schemas/EmbeddedVariable'
-          designation:
-            type: string
-          password:
-            type: string
-          url:
-            type: string
-          username:
-            type: string
-    DatabaseDisconnectTaskRequestBody:
-      required:
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/NodeRequestBody'
-      - type: object
-        properties:
-          asyncAfter:
-            type: boolean
-          asyncBefore:
-            type: boolean
-          inputVariables:
-            uniqueItems: true
-            type: array
-            items:
-              $ref: '#/components/schemas/EmbeddedVariable'
-          outputVariable:
-            $ref: '#/components/schemas/EmbeddedVariable'
-          designation:
-            type: string
-    DatabaseQueryTaskRequestBody:
-      required:
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/NodeRequestBody'
-      - type: object
-        properties:
-          asyncAfter:
-            type: boolean
-          asyncBefore:
-            type: boolean
-          inputVariables:
-            uniqueItems: true
-            type: array
-            items:
-              $ref: '#/components/schemas/EmbeddedVariable'
-          outputVariable:
-            $ref: '#/components/schemas/EmbeddedVariable'
-          designation:
-            type: string
-          outputPath:
-            type: string
-          query:
-            type: string
-          resultType:
-            type: string
-            enum:
-            - CSV
-            - TSV
-            - JSON
-          includeHeader:
-            type: boolean
-    DirectoryTaskRequestBody:
-      required:
-      - action
-      - name
-      - path
-      - workflow
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/NodeRequestBody'
-      - type: object
-        properties:
-          asyncAfter:
-            type: boolean
-          asyncBefore:
-            type: boolean
-          inputVariables:
-            uniqueItems: true
-            type: array
-            items:
-              $ref: '#/components/schemas/EmbeddedVariable'
-          outputVariable:
-            $ref: '#/components/schemas/EmbeddedVariable'
-          path:
-            type: string
-          workflow:
-            type: string
-          action:
-            type: string
-            enum:
-            - READ_NEXT
-            - DELETE_NEXT
-            - LIST
-            - WRITE
-    EmailTaskRequestBody:
-      required:
-      - mailFrom
-      - mailSubject
-      - mailText
-      - mailTo
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/NodeRequestBody'
-      - type: object
-        properties:
-          asyncAfter:
-            type: boolean
-          asyncBefore:
-            type: boolean
-          inputVariables:
-            uniqueItems: true
-            type: array
-            items:
-              $ref: '#/components/schemas/EmbeddedVariable'
-          outputVariable:
-            $ref: '#/components/schemas/EmbeddedVariable'
-          attachmentPath:
-            type: string
-          includeAttachment:
-            type: string
-          mailBcc:
-            type: string
-          mailCc:
-            type: string
-          mailFrom:
-            maxLength: 256
-            minLength: 3
-            type: string
-          mailText:
-            maxLength: 2147483647
-            minLength: 2
-            type: string
-          mailTo:
-            maxLength: 256
-            minLength: 3
-            type: string
-          mailMarkup:
-            type: string
-          mailSubject:
-            maxLength: 256
-            minLength: 2
-            type: string
-    EndEventRequestBody:
-      required:
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/NodeRequestBody'
-    EventSubprocessRequestBody:
-      required:
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/NodeRequestBody'
-      - type: object
-        properties:
-          asyncAfter:
-            type: boolean
-          asyncBefore:
-            type: boolean
-    ExclusiveGatewayRequestBody:
-      required:
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/NodeRequestBody'
-      - type: object
-        properties:
-          direction:
-            type: string
-            enum:
-            - UNSPECIFIED
-            - CONVERGING
-            - DIVERGING
-            - MIXED
-    FileTaskRequestBody:
-      required:
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/NodeRequestBody'
-      - type: object
-        properties:
-          asyncAfter:
-            type: boolean
-          asyncBefore:
-            type: boolean
-          inputVariables:
-            uniqueItems: true
-            type: array
-            items:
-              $ref: '#/components/schemas/EmbeddedVariable'
-          outputVariable:
-            $ref: '#/components/schemas/EmbeddedVariable'
-          line:
-            type: string
-          op:
-            type: string
-            enum:
-            - LIST
-            - READ
-            - WRITE
-            - COPY
-            - MOVE
-            - DELETE
-            - LINE_COUNT
-            - READ_LINE
-            - PUSH
-            - POP
-          path:
-            type: string
-          target:
-            type: string
-    FtpTaskRequestBody:
-      required:
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/NodeRequestBody'
-      - type: object
-        properties:
-          asyncAfter:
-            type: boolean
-          asyncBefore:
-            type: boolean
-          inputVariables:
-            uniqueItems: true
-            type: array
-            items:
-              $ref: '#/components/schemas/EmbeddedVariable'
-          outputVariable:
-            $ref: '#/components/schemas/EmbeddedVariable'
-          destinationPath:
-            type: string
-          host:
-            type: string
-          op:
-            type: string
-            enum:
-            - GET
-            - PUT
-          originPath:
-            type: string
-          password:
-            type: string
-          port:
-            type: integer
-            format: int32
-          scheme:
-            type: string
-          username:
-            type: string
-          basePath:
-            type: string
-    InclusiveGatewayRequestBody:
-      required:
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/NodeRequestBody'
-      - type: object
-        properties:
-          direction:
-            type: string
-            enum:
-            - UNSPECIFIED
-            - CONVERGING
-            - DIVERGING
-            - MIXED
-    InputTaskRequestBody:
-      required:
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/NodeRequestBody'
-      - type: object
-        properties:
-          asyncAfter:
-            type: boolean
-          asyncBefore:
-            type: boolean
-          inputVariables:
-            uniqueItems: true
-            type: array
-            items:
-              $ref: '#/components/schemas/EmbeddedVariable'
-          outputVariable:
-            $ref: '#/components/schemas/EmbeddedVariable'
-          inputs:
-            uniqueItems: true
-            type: array
-            items:
-              $ref: '#/components/schemas/EmbeddedInput'
-    MoveToLastGatewayRequestBody:
-      required:
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/NodeRequestBody'
-      - type: object
-        properties:
-          direction:
-            type: string
-            enum:
-            - UNSPECIFIED
-            - CONVERGING
-            - DIVERGING
-            - MIXED
-    MoveToNodeRequestBody:
-      required:
-      - gatewayId
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/NodeRequestBody'
-      - type: object
-        properties:
-          gatewayId:
-            type: string
-    NodeRequestBody:
-      required:
-      - name
-      type: object
-      properties:
-        id:
-          type: string
-        name:
-          maxLength: 64
-          minLength: 3
-          type: string
-        description:
-          maxLength: 512
-          minLength: 0
-          type: string
-        deserializeAs:
-          type: string
-          readOnly: true
-        identifier:
-          type: string
-      discriminator:
-        propertyName: deserializeAs
-    ParallelGatewayRequestBody:
-      required:
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/NodeRequestBody'
-      - type: object
-        properties:
-          direction:
-            type: string
-            enum:
-            - UNSPECIFIED
-            - CONVERGING
-            - DIVERGING
-            - MIXED
-    ProcessorTaskRequestBody:
-      required:
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/NodeRequestBody'
-      - type: object
-        properties:
-          asyncAfter:
-            type: boolean
-          asyncBefore:
-            type: boolean
-          inputVariables:
-            uniqueItems: true
-            type: array
-            items:
-              $ref: '#/components/schemas/EmbeddedVariable'
-          outputVariable:
-            $ref: '#/components/schemas/EmbeddedVariable'
-          processor:
-            $ref: '#/components/schemas/EmbeddedProcessor'
-    ReceiveTaskRequestBody:
-      required:
-      - message
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/NodeRequestBody'
-      - type: object
-        properties:
-          asyncAfter:
-            type: boolean
-          asyncBefore:
-            type: boolean
-          inputVariables:
-            uniqueItems: true
-            type: array
-            items:
-              $ref: '#/components/schemas/EmbeddedVariable'
-          outputVariable:
-            $ref: '#/components/schemas/EmbeddedVariable'
-          message:
-            maxLength: 256
-            minLength: 4
-            type: string
-    RequestTaskRequestBody:
-      required:
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/NodeRequestBody'
-      - type: object
-        properties:
-          asyncAfter:
-            type: boolean
-          asyncBefore:
-            type: boolean
-          inputVariables:
-            uniqueItems: true
-            type: array
-            items:
-              $ref: '#/components/schemas/EmbeddedVariable'
-          outputVariable:
-            $ref: '#/components/schemas/EmbeddedVariable'
-          headerOutputVariables:
-            uniqueItems: true
-            type: array
-            items:
-              $ref: '#/components/schemas/EmbeddedVariable'
-          request:
-            $ref: '#/components/schemas/EmbeddedRequest'
-    ScriptTaskRequestBody:
-      required:
-      - code
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/NodeRequestBody'
-      - type: object
-        properties:
-          asyncAfter:
-            type: boolean
-          asyncBefore:
-            type: boolean
-          inputVariables:
-            uniqueItems: true
-            type: array
-            items:
-              $ref: '#/components/schemas/EmbeddedVariable'
-          outputVariable:
-            $ref: '#/components/schemas/EmbeddedVariable'
-          code:
-            type: string
-          resultVariable:
-            type: string
-          scriptFormat:
-            type: string
-    StartEventRequestBody:
-      required:
-      - name
-      - type
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/NodeRequestBody'
-      - type: object
-        properties:
-          asyncBefore:
-            type: boolean
-          expression:
-            maxLength: 256
-            minLength: 4
-            type: string
-          interrupting:
-            type: boolean
-          type:
-            type: string
-            enum:
-            - MESSAGE_CORRELATION
-            - SCHEDULED
-            - SIGNAL
-            - NONE
-    SubprocessRequestBody:
-      required:
-      - name
-      - type
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/NodeRequestBody'
-      - type: object
-        properties:
-          asyncAfter:
-            type: boolean
-          asyncBefore:
-            type: boolean
-          loopRef:
-            $ref: '#/components/schemas/EmbeddedLoopReference'
-          type:
-            type: string
-            enum:
-            - EMBEDDED
-            - TRANSACTION
-          multiInstance:
-            type: boolean
     WorkflowRequestBody:
       required:
       - name
@@ -13562,7 +12753,7 @@ components:
         initialContext:
           type: object
           additionalProperties:
-            $ref: '#/components/schemas/JsonNode'
+            $ref: "#/components/schemas/JsonNode"
         name:
           maxLength: 64
           minLength: 4
@@ -13572,10 +12763,28 @@ components:
           items:
             type: string
         setup:
-          $ref: '#/components/schemas/Setup'
+          $ref: "#/components/schemas/Setup"
         versionTag:
           maxLength: 64
           minLength: 1
+          type: string
+    NodeResponse:
+      required:
+      - name
+      type: object
+      properties:
+        name:
+          maxLength: 64
+          minLength: 3
+          type: string
+        description:
+          maxLength: 512
+          minLength: 0
+          type: string
+        deserializeAs:
+          type: string
+          readOnly: true
+        identifier:
           type: string
     error:
       required:
@@ -13595,7 +12804,7 @@ components:
           type: array
           description: List of key/value parameters
           items:
-            $ref: '#/components/schemas/parameter'
+            $ref: "#/components/schemas/parameter"
       description: An error message
     errors:
       type: object
@@ -13604,7 +12813,7 @@ components:
           type: array
           description: List of error messages
           items:
-            $ref: '#/components/schemas/error'
+            $ref: "#/components/schemas/error"
         total_records:
           type: integer
           description: Total number of errors
@@ -13639,7 +12848,7 @@ components:
           type: array
           description: List of key/value parameters
           items:
-            $ref: '#/components/schemas/parameter'
+            $ref: "#/components/schemas/parameter"
       description: "Configuration how to install, upgrade or delete a module for a\
         \ tenant"
     Link:

--- a/service/src/test/resources/application.yaml
+++ b/service/src/test/resources/application.yaml
@@ -10,7 +10,7 @@ logging:
       folio: WARN
       hibernate: WARN
       springframework: WARN
-      springframework.test: INFO
+      springframework.test: WARN
 
       # Uncomment to enable MockMvc unit test logging.
       #springframework.test.web.servlet.result: DEBUG


### PR DESCRIPTION
Resolves [MODWRKFLOW-43](https://folio-org.atlassian.net/browse/MODWRKFLOW-43)

This also resolves [MODWRKFLOW-44](https://folio-org.atlassian.net/browse/MODWRKFLOW-44) given that the version is already being bumped to the 8.2.x versions.

Switch to JDK21 which has better spring-boot 3.3.x support.

The `folio-spring-base` now must be an 8.2.x version, such as `8.2.1`, or tests will fail (and probably runtime too).

Change the default `springframework.test` setting.

Using a builder is now the expected way to initialize the ObjectMapper.

Relocate the `JsonTypeInfo` and `JsonSubTypes` into a separate interface.
This appears to reduce problems following the upgrade to `3.3.7`.

The `DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES` must be disabled.

The following error is received:
```
Could not resolve subtype of [simple type, class org.folio.rest.workflow.model.Node]: missing type id property 'deserializeAs' (for POJO property 'nodes')\n" +
        ' at [Source: (org.springframework.util.StreamUtils$NonClosingInputStream); line: 1, column: 275] (through reference chain: org.folio.rest.workflow.model.Workflow["nodes"]->java.util.ArrayList[0])'
```

Using a converter `JsonNodeConverter` for `deserializeAs` appears to help resolve this.
