### PR TITLE
MODWRKFLOW-47: Upgrade commons-compress to 1.26.2.

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -117,7 +117,7 @@
     <dependency>
        <groupId>org.apache.commons</groupId>
        <artifactId>commons-compress</artifactId>
-       <version>1.26.1</version>
+       <version>1.26.2</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Resolves [MODWRKFLOW-47](https://folio-org.atlassian.net/browse/MODWRKFLOW-47).

I first attempted upgrading to `1.27.1` and the following errors were observed during the unit tests:
```
[ERROR] Errors:
[ERROR]   WorkflowImportServiceTest.importFileWorksForBzip2AsBz2Test:264 » NoSuchMethod 'org.apache.commons.io.input.BoundedInputStream$Builder org.apache.commons.io.input.BoundedInputStream.builder()'
[ERROR]   WorkflowImportServiceTest.importFileWorksForBzip2Test:257 » NoSuchMethod 'org.apache.commons.io.input.BoundedInputStream$Builder org.apache.commons.io.input.BoundedInputStream.builder()'
[ERROR]   WorkflowImportServiceTest.importFileWorksForGzipAsGzTest:278 » NoSuchMethod 'org.apache.commons.io.input.BoundedInputStream$Builder org.apache.commons.io.input.BoundedInputStream.builder()'
[ERROR]   WorkflowImportServiceTest.importFileWorksForGzipTest:271 » NoSuchMethod 'org.apache.commons.io.input.BoundedInputStream$Builder org.apache.commons.io.input.BoundedInputStream.builder()'
[ERROR]   WorkflowImportServiceTest.importFileWorksForGzipWithBadVersionTest:285 » NoSuchMethod 'org.apache.commons.io.input.BoundedInputStream$Builder org.apache.commons.io.input.BoundedInputStream.builder()'
[ERROR]   WorkflowImportServiceTest.importFileWorksForGzipWithJavaTest:292 » NoSuchMethod 'org.apache.commons.io.input.BoundedInputStream$Builder org.apache.commons.io.input.BoundedInputStream.builder()'
[ERROR]   WorkflowImportServiceTest.importFileWorksForGzipWithMissingVersionTest:320 » NoSuchMethod 'org.apache.commons.io.input.BoundedInputStream$Builder org.apache.commons.io.input.BoundedInputStream.builder()'
[ERROR]   WorkflowImportServiceTest.importFileWorksForGzipWithOddFilesTest:299 » NoSuchMethod 'org.apache.commons.io.input.BoundedInputStream$Builder org.apache.commons.io.input.BoundedInputStream.builder()'
[ERROR]   WorkflowImportServiceTest.importFileWorksForGzipWithPythonTest:306 » NoSuchMethod 'org.apache.commons.io.input.BoundedInputStream$Builder org.apache.commons.io.input.BoundedInputStream.builder()'
[ERROR]   WorkflowImportServiceTest.importFileWorksForGzipWithRubyTest:313 » NoSuchMethod 'org.apache.commons.io.input.BoundedInputStream$Builder org.apache.commons.io.input.BoundedInputStream.builder()'
[ERROR]   WorkflowImportServiceTest.importFileWorksForGzipWithUnknownVersionTest:327 » NoSuchMethod 'org.apache.commons.io.input.BoundedInputStream$Builder org.apache.commons.io.input.BoundedInputStream.builder()'
```

Upgrading to `1.26.2` is still acceptable.