### PR TITLE
MODWRKFLOW-46: Make compatible with spring-boot 3.4 upgrades.

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -18,7 +18,7 @@
 
   <properties>
     <openapi.server.port>9000</openapi.server.port>
-    <folio-spring.version>8.2.2</folio-spring.version>
+    <folio-spring.version>8.3.0-SNAPSHOT</folio-spring.version>
   </properties>
 
   <dependencies>

--- a/service/src/main/java/org/folio/rest/workflow/config/FolioSpringLiquibaseConfig.java
+++ b/service/src/main/java/org/folio/rest/workflow/config/FolioSpringLiquibaseConfig.java
@@ -1,0 +1,15 @@
+package org.folio.rest.workflow.config;
+
+import org.folio.spring.liquibase.FolioSpringLiquibase;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FolioSpringLiquibaseConfig {
+
+  @Bean
+  public FolioSpringLiquibase folioSpringLiquibase() {
+    return new FolioSpringLiquibase();
+  }
+
+}

--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -137,20 +137,18 @@ okapi:
 # https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html
 management:
   endpoints:
-    enabled-by-default: false
+    access.default: none
     web:
       base-path: /admin
       exposure:
         include: flyway,health,info
   endpoint:
-    flyway:
-      enabled: true
+    flyway.access: read-only
     health:
-      enabled: true
+      access: read-only
       show-details: always
       show-components: always
-    info:
-      enabled: true
+    info.access: read-only
   health:
     defaults:
       enabled: true

--- a/service/src/test/java/org/folio/rest/workflow/controller/ActionControllerTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/controller/ActionControllerTest.java
@@ -49,9 +49,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -72,10 +72,10 @@ class ActionControllerTest {
   @Autowired
   private ActionController actionController;
 
-  @MockBean
+  @MockitoBean
   private OkapiDiscoveryService okapiDiscoveryService;
 
-  @MockBean
+  @MockitoBean
   private TenantProperties tenantProperties;
 
   @BeforeEach

--- a/service/src/test/java/org/folio/rest/workflow/controller/EventControllerTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/controller/EventControllerTest.java
@@ -30,9 +30,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -46,16 +46,16 @@ class EventControllerTest {
   @Autowired
   private EventController eventController;
 
-  @MockBean
+  @MockitoBean
   private EventProducer eventProducer;
 
-  @MockBean
+  @MockitoBean
   private TriggerRepo triggerRepo;
 
   @Mock
   private TriggerDto trigger;
 
-  @MockBean
+  @MockitoBean
   private TenantProperties tenantProperties;
 
   private List<TriggerDto> triggers;

--- a/service/src/test/java/org/folio/rest/workflow/controller/WorkflowControllerTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/controller/WorkflowControllerTest.java
@@ -66,11 +66,11 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -161,19 +161,19 @@ class WorkflowControllerTest {
   @Autowired
   private WorkflowController workflowController;
 
-  @MockBean
+  @MockitoBean
   private WorkflowCqlService workflowCqlService;
 
-  @MockBean
+  @MockitoBean
   private WorkflowEngineService workflowEngineService;
 
-  @MockBean
+  @MockitoBean
   private WorkflowImportService workflowImportService;
 
-  @MockBean
+  @MockitoBean
   private WorkflowRepo workflowRepo;
 
-  @MockBean
+  @MockitoBean
   private TenantProperties tenantProperties;
 
   @BeforeEach

--- a/service/src/test/java/org/folio/rest/workflow/kafka/EventProducerTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/kafka/EventProducerTest.java
@@ -16,8 +16,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.verification.VerificationMode;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -25,7 +25,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 @ExtendWith(MockitoExtension.class)
 class EventProducerTest {
 
-  @MockBean
+  @MockitoBean
   private KafkaTemplate<String, Event> eventTemplate;
 
   @InjectMocks

--- a/service/src/test/java/org/folio/rest/workflow/service/OkapiDiscoveryServiceWithDefaultPropertiesTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/service/OkapiDiscoveryServiceWithDefaultPropertiesTest.java
@@ -18,10 +18,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /**
@@ -40,7 +40,7 @@ class OkapiDiscoveryServiceWithDefaultPropertiesTest {
   @InjectMocks
   protected OkapiDiscoveryService okapiDiscoveryService;
 
-  @MockBean
+  @MockitoBean
   protected HttpService mockHttpService;
 
   @Mock

--- a/service/src/test/java/org/folio/rest/workflow/service/WorkflowCqlServiceTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/service/WorkflowCqlServiceTest.java
@@ -22,9 +22,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.data.domain.Page;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
@@ -38,11 +38,11 @@ class WorkflowCqlServiceTest {
   @InjectMocks
   private WorkflowCqlService workflowCqlService;
 
-  @MockBean
+  @MockitoBean
   private WorkflowRepo repo;
 
   // Work-around to get ObjectMapper to be loaded in AbstractCqlService.
-  @SpyBean
+  @MockitoSpyBean
   protected ObjectMapper mapper;
 
   @Mock

--- a/service/src/test/java/org/folio/rest/workflow/service/WorkflowCqlServiceTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/service/WorkflowCqlServiceTest.java
@@ -22,6 +22,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.Page;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
@@ -47,6 +49,16 @@ class WorkflowCqlServiceTest {
 
   @Mock
   private Page<Workflow> page;
+
+  // Provide a bean for `@MockitoSpyBean` above to work without requiring a full spring boot runner.
+  @Configuration
+  static class Config {
+
+    @Bean
+    ObjectMapper objectMapper() {
+      return new ObjectMapper();
+    }
+  }
 
   @Test
   void getTypeNameWorksTest() throws IOException {

--- a/service/src/test/java/org/folio/rest/workflow/service/WorkflowImportServiceTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/service/WorkflowImportServiceTest.java
@@ -7,9 +7,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
 import org.apache.commons.compress.archivers.ArchiveException;
 import org.apache.commons.compress.compressors.CompressorException;
 import org.folio.rest.workflow.exception.WorkflowImportAlreadyImported;
@@ -29,11 +28,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.core.io.Resource;
 import org.springframework.data.domain.Page;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 @SpringBootTest(webEnvironment = WebEnvironment.MOCK)
 @ExtendWith(MockitoExtension.class)
@@ -45,16 +44,16 @@ class WorkflowImportServiceTest {
   @InjectMocks
   private WorkflowImportService workflowImportService;
 
-  @MockBean
+  @MockitoBean
   private NodeRepo nodeRepo;
 
-  @MockBean
+  @MockitoBean
   private TriggerRepo triggerRepo;
 
-  @MockBean
+  @MockitoBean
   private WorkflowRepo workflowRepo;
 
-  @SpyBean
+  @MockitoSpyBean
   private ObjectMapper objectMapper;
 
   @Mock

--- a/service/src/test/resources/application.yaml
+++ b/service/src/test/resources/application.yaml
@@ -134,20 +134,18 @@ okapi:
 # https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html
 management:
   endpoints:
-    enabled-by-default: false
+    access.default: none
     web:
       base-path: /admin
       exposure:
         include: flyway,health,info
   endpoint:
-    flyway:
-      enabled: false
+    flyway.access: none
     health:
-      enabled: false
+      access: none
       show-details: always
       show-components: always
-    info:
-      enabled: false
+    info.access: none
   health:
     defaults:
       enabled: true
@@ -157,6 +155,7 @@ management:
     env.enabled: false
     java.enabled: false
     os.enabled: false
+
 
 info:
   build:

--- a/service/src/test/resources/application.yaml
+++ b/service/src/test/resources/application.yaml
@@ -156,7 +156,6 @@ management:
     java.enabled: false
     os.enabled: false
 
-
 info:
   build:
     artifact: "@project.artifactId@"


### PR DESCRIPTION
Resolves [MODWRKFLOW-46](https://folio-org.atlassian.net/browse/MODWRKFLOW-46).

The `ObjectMapper` bean is provided because the `@MockitoSpyBean` no longer instantiates when there is no bean found in the way that no available or deprecated `@SpyBean` does.

Appease this error:
```
Description:

Parameter 2 of constructor in org.folio.spring.service.TenantService required a bean of type 'org.folio.spring.liquibase.FolioSpringLiquibase' that could not be found.

Action:

Consider defining a bean of type 'org.folio.spring.liquibase.FolioSpringLiquibase' in your configuration.
```

Switch `folio-spring-support` dependency to `8.3.0-SNAPSHOT` because this is needed for the Spring Boot 3.4 support. Prior versions do not work under Spring-Boot 3.4.

Update the Controlling Access to Actuator Endpoints settings.
The settings changed from `enabled` to access` and `enabled-by-default` to `access.default`.

The `access` values are no longer boolean and are instead one of `read-only`, `none`, and `unrestricted`.
I decided to use `read-only` for values that were previously `true`.

Replace `@MockBean` and `@SpyBean`.
  - `@MockitoBean` and `MockitoSpyBean` are the replacemenets to the deprecated or removed `@MockBean` and `@SpyBean`.

Address failing bean problems.
  - The `ObjectMapper` bean is provided because the `@MockitoSpyBean` no longer instantiates when there is no bean found in the way that no available or deprecated `@SpyBean` does.
  - see: https://github.com/spring-projects/spring-framework/issues/33935

This requires the changes from [Spring Module Core PR 74](https://github.com/folio-org/spring-module-core/pull/74) for [SPRNGCORE-6](https://folio-org.atlassian.net/browse/SPRNGCORE-6).
