### PR TITLE
Add dependabot configuration.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope
+    groups:
+      dev-deps:
+        dependency-type: "development"
+      prod-deps:
+        dependency-type: "production"


### PR DESCRIPTION
[MODWRKFLOW-52](https://folio-org.atlassian.net/browse/MODWRKFLOW-52)

This is a direct copy of  https://github.com/folio-org/folio-spring-support/blob/master/.github/dependabot.yml . That configuration looks perfectly fine to copy as-is.