### PR TITLE
MODWRKFLOW-59: Remove ActiveMQ.

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -64,22 +64,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.activemq</groupId>
-      <artifactId>activemq-kahadb-store</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.activemq</groupId>
-      <artifactId>activemq-broker</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.activemq</groupId>
-          <artifactId>activemq-client</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
       <groupId>org.springframework.data</groupId>
       <artifactId>spring-data-rest-hal-explorer</artifactId>
     </dependency>


### PR DESCRIPTION
[MODWRKFLOW-59](https://folio-org.atlassian.net/browse/MODWRKFLOW-59)

Completely remove **ActiveMQ**.

**Kafka** is now in full use and **ActiveMQ** is no longer supported.