### PR TITLE
MODWRKFLOW-54: Migrate to Spring-Boot 4.0.

### DIFF
--- a/components/pom.xml
+++ b/components/pom.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>mod-workflow</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>workflow-components</artifactId>

--- a/components/src/main/java/org/folio/rest/workflow/model/EmailTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/EmailTask.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.folio.rest.workflow.model.components.DelegateTask;
 import org.folio.rest.workflow.model.has.common.HasEmailTaskCommon;
-import org.springframework.lang.NonNull;
+import org.jspecify.annotations.NonNull;
 
 @Entity
 public class EmailTask extends AbstractTask implements DelegateTask, HasEmailTaskCommon {

--- a/components/src/main/java/org/folio/rest/workflow/model/NodeInterface.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/NodeInterface.java
@@ -2,8 +2,8 @@ package org.folio.rest.workflow.model;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
 import org.folio.rest.workflow.model.resolver.DeserializeAsNodeJsonResolver;
+import tools.jackson.databind.annotation.JsonTypeIdResolver;
 
 @JsonTypeIdResolver(DeserializeAsNodeJsonResolver.class)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "deserializeAs")

--- a/components/src/main/java/org/folio/rest/workflow/model/Workflow.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/Workflow.java
@@ -1,7 +1,6 @@
 package org.folio.rest.workflow.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.JsonNode;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
@@ -33,6 +32,7 @@ import org.folio.rest.workflow.model.has.common.HasWorkflowCommon;
 import org.folio.spring.domain.model.AbstractBaseEntity;
 import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.annotation.Version;
+import tools.jackson.databind.JsonNode;
 
 @Entity
 @JsonIgnoreProperties({ "hibernateLazyInitializer", "handler" })

--- a/components/src/main/java/org/folio/rest/workflow/model/converter/AbstractConverter.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/converter/AbstractConverter.java
@@ -1,16 +1,19 @@
 package org.folio.rest.workflow.model.converter;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.StreamReadFeature;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.MapperFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
 import jakarta.persistence.AttributeConverter;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.StreamReadFeature;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.MapperFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
- * This converts the value into a JSON representation stored as a single string tin the database.
+ * This converts the value into a JSON representation stored as a single string in the database.
+ *
+ * Implementations need only provide the T.
+ * Each implementation is expected to be used as-is as a JSON string value without needing the type details.
  */
 public abstract class AbstractConverter<T> implements AttributeConverter<T, String> {
 
@@ -27,7 +30,7 @@ public abstract class AbstractConverter<T> implements AttributeConverter<T, Stri
 
     try {
       return objectMapper.writeValueAsString(attribute);
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       throw new RuntimeException(e.getMessage());
     }
   }
@@ -38,11 +41,13 @@ public abstract class AbstractConverter<T> implements AttributeConverter<T, Stri
 
     try {
       return objectMapper.readValue(dbData, getTypeReference());
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       throw new RuntimeException(e.getMessage());
     }
   }
 
-  public abstract TypeReference<T> getTypeReference();
+  public TypeReference<T> getTypeReference() {
+    return new TypeReference<T>() {};
+  }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/converter/ComparisonListConverter.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/converter/ComparisonListConverter.java
@@ -1,16 +1,13 @@
 package org.folio.rest.workflow.model.converter;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import jakarta.persistence.Converter;
 import java.util.List;
 import org.folio.rest.workflow.dto.Comparison;
 
+/**
+ * Comparison list converter.
+ */
 @Converter
 public class ComparisonListConverter extends AbstractConverter<List<Comparison>> {
-
-  @Override
-  public TypeReference<List<Comparison>> getTypeReference() {
-    return new TypeReference<List<Comparison>>() {};
-  }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/converter/EmbeddedVariableConverter.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/converter/EmbeddedVariableConverter.java
@@ -1,6 +1,5 @@
 package org.folio.rest.workflow.model.converter;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import jakarta.persistence.Converter;
 import org.folio.rest.workflow.model.EmbeddedVariable;
 
@@ -9,10 +8,5 @@ import org.folio.rest.workflow.model.EmbeddedVariable;
  */
 @Converter
 public class EmbeddedVariableConverter extends AbstractConverter<EmbeddedVariable> {
-
-  @Override
-  public TypeReference<EmbeddedVariable> getTypeReference() {
-    return new TypeReference<EmbeddedVariable>() {};
-  }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/converter/InputAttributeListConverter.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/converter/InputAttributeListConverter.java
@@ -1,6 +1,5 @@
 package org.folio.rest.workflow.model.converter;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import jakarta.persistence.Converter;
 import java.util.List;
 import org.folio.rest.workflow.enums.InputAttribute;
@@ -10,10 +9,5 @@ import org.folio.rest.workflow.enums.InputAttribute;
  */
 @Converter
 public class InputAttributeListConverter extends AbstractConverter<List<InputAttribute>> {
-
-  @Override
-  public TypeReference<List<InputAttribute>> getTypeReference() {
-    return new TypeReference<List<InputAttribute>>() {};
-  }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/converter/JsonNodeConverter.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/converter/JsonNodeConverter.java
@@ -1,15 +1,12 @@
 package org.folio.rest.workflow.model.converter;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
 import jakarta.persistence.Converter;
+import tools.jackson.databind.JsonNode;
 
+/**
+ * JSON Node converted.
+ */
 @Converter
 public class JsonNodeConverter extends AbstractConverter<JsonNode> {
-
-  @Override
-  public TypeReference<JsonNode> getTypeReference() {
-    return new TypeReference<JsonNode>() {};
-  }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/converter/MappingListConverter.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/converter/MappingListConverter.java
@@ -1,16 +1,13 @@
 package org.folio.rest.workflow.model.converter;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import jakarta.persistence.Converter;
 import java.util.List;
 import org.folio.rest.workflow.dto.Mapping;
 
+/**
+ * Mapping list converter.
+ */
 @Converter
 public class MappingListConverter extends AbstractConverter<List<Mapping>> {
-
-  @Override
-  public TypeReference<List<Mapping>> getTypeReference() {
-    return new TypeReference<List<Mapping>>() {};
-  }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/converter/RequestConverter.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/converter/RequestConverter.java
@@ -1,15 +1,12 @@
 package org.folio.rest.workflow.model.converter;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import jakarta.persistence.Converter;
 import org.folio.rest.workflow.dto.Request;
 
+/**
+ * Request converter.
+ */
 @Converter
 public class RequestConverter extends AbstractConverter<Request> {
-
-  @Override
-  public TypeReference<Request> getTypeReference() {
-    return new TypeReference<Request>() {};
-  }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/converter/StringListConverter.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/converter/StringListConverter.java
@@ -1,6 +1,5 @@
 package org.folio.rest.workflow.model.converter;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import jakarta.persistence.Converter;
 import java.util.List;
 
@@ -9,10 +8,5 @@ import java.util.List;
  */
 @Converter
 public class StringListConverter extends AbstractConverter<List<String>> {
-
-  @Override
-  public TypeReference<List<String>> getTypeReference() {
-    return new TypeReference<List<String>>() {};
-  }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/has/common/HasWorkflowCommon.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/common/HasWorkflowCommon.java
@@ -1,8 +1,8 @@
 package org.folio.rest.workflow.model.has.common;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import java.util.Map;
 import org.folio.rest.workflow.model.Setup;
+import tools.jackson.databind.JsonNode;
 
 /**
  * This interface provides common methods for {@link org.folio.rest.workflow.model.Workflow Workflow}.

--- a/components/src/main/java/org/folio/rest/workflow/model/resolver/DeserializeAsNodeJsonResolver.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/resolver/DeserializeAsNodeJsonResolver.java
@@ -3,9 +3,6 @@ package org.folio.rest.workflow.model.resolver;
 import static java.util.Map.entry;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
-import com.fasterxml.jackson.databind.DatabindContext;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.jsontype.impl.TypeIdResolverBase;
 import java.util.Map;
 import org.folio.rest.workflow.model.CompressFileTask;
 import org.folio.rest.workflow.model.Condition;
@@ -34,11 +31,17 @@ import org.folio.rest.workflow.model.StartEvent;
 import org.folio.rest.workflow.model.Subprocess;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.DatabindContext;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.jsontype.impl.TypeIdResolverBase;
 
 /**
  * Resolve the type from the `deserializeAs` field from a `Node`.
  */
 public class DeserializeAsNodeJsonResolver extends TypeIdResolverBase {
+
+  private static final long serialVersionUID = 30422936630293L;
 
   /**
    * A map of classes that are allowed to be deserialized.
@@ -73,13 +76,13 @@ public class DeserializeAsNodeJsonResolver extends TypeIdResolverBase {
   private static final Logger logger = LoggerFactory.getLogger(DeserializeAsNodeJsonResolver.class);
 
   @Override
-  public String idFromValue(Object value) {
+  public String idFromValue(DatabindContext ctxt, Object value) throws JacksonException {
     return value.getClass().getSimpleName();
   }
 
   @Override
-  public String idFromValueAndType(Object value, Class<?> suggestedType) {
-    return idFromValue(value);
+  public String idFromValueAndType(DatabindContext ctxt, Object value, Class<?> suggestedType) throws JacksonException {
+    return idFromValue(ctxt, value);
   }
 
   @Override

--- a/components/src/test/java/org/folio/rest/workflow/model/WorkflowTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/WorkflowTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.util.ReflectionTestUtils.getField;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -20,6 +19,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.JsonNode;
 
 @ExtendWith(MockitoExtension.class)
 class WorkflowTest {

--- a/components/src/test/java/org/folio/rest/workflow/model/converter/AbstractConverterTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/converter/AbstractConverterTest.java
@@ -5,10 +5,10 @@ import static org.folio.spring.test.mock.MockMvcConstant.STRING_LIST_AS_JSON;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.type.TypeReference;
 
 class AbstractConverterTest {
 

--- a/components/src/test/java/org/folio/rest/workflow/model/resolver/DeserializeAsNodeJsonResolverTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/resolver/DeserializeAsNodeJsonResolverTest.java
@@ -5,10 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
-import com.fasterxml.jackson.databind.DatabindContext;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.stream.Stream;
 import java.util.stream.Stream.Builder;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,6 +18,11 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import tools.jackson.databind.DatabindContext;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 @ExtendWith(MockitoExtension.class)
 class DeserializeAsNodeJsonResolverTest {
@@ -36,19 +37,19 @@ class DeserializeAsNodeJsonResolverTest {
 
   @BeforeEach
   void beforeEach() {
-    mapper = new ObjectMapper();
+    mapper = JsonMapper.builder().build();
   }
 
   @Test
   void idFromValueWorksTest() {
-    String result = deserializeAsJsonResolver.idFromValue(new String());
+    String result = deserializeAsJsonResolver.idFromValue(null, new String());
 
     assertEquals(String.class.getSimpleName(), result);
   }
 
   @Test
   void idFromValueAndTypeWorksTest() {
-    String result = deserializeAsJsonResolver.idFromValueAndType(new String(), JsonNode.class);
+    String result = deserializeAsJsonResolver.idFromValueAndType(null, new String(), JsonNode.class);
 
     assertEquals(String.class.getSimpleName(), result);
   }

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>mod-workflow</artifactId>
-  <version>1.2.0-SNAPSHOT</version>
+  <version>1.3.0-SNAPSHOT</version>
 
   <name>Okapi Workflow Module</name>
   <description>Okapi workflow module using Spring Boot</description>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <spring-module-core.version>2.1.0-SNAPSHOT</spring-module-core.version>
+    <spring-module-core.version>2.2.0-SNAPSHOT</spring-module-core.version>
     <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>spring-module-core</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>mod-workflow</artifactId>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -18,7 +18,7 @@
 
   <properties>
     <openapi.server.port>9000</openapi.server.port>
-    <folio-spring.version>8.3.0-SNAPSHOT</folio-spring.version>
+    <folio-spring.version>10.0.0</folio-spring.version>
   </properties>
 
   <dependencies>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>mod-workflow</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>workflow-service</artifactId>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 
@@ -83,12 +82,12 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.springframework.boot</groupId>
-          <artifactId>spring-boot-starter-logging</artifactId>
-        </exclusion>
-      </exclusions>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-webmvc-test</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -116,8 +115,8 @@
       </plugin>
 
       <plugin>
-        <groupId>org.hibernate.orm.tooling</groupId>
-        <artifactId>hibernate-enhance-maven-plugin</artifactId>
+        <groupId>org.hibernate.orm</groupId>
+        <artifactId>hibernate-maven-plugin</artifactId>
         <executions>
           <execution>
             <id>enhance</id>
@@ -126,7 +125,6 @@
               <goal>enhance</goal>
             </goals>
             <configuration>
-              <failOnError>true</failOnError>
               <enableLazyInitialization>true</enableLazyInitialization>
               <enableDirtyTracking>true</enableDirtyTracking>
               <enableAssociationManagement>true</enableAssociationManagement>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -18,7 +18,7 @@
 
   <properties>
     <openapi.server.port>9000</openapi.server.port>
-    <folio-spring.version>8.3.0-SNAPSHOT</folio-spring.version>
+    <folio-spring.version>10.0.0</folio-spring.version>
   </properties>
 
   <dependencies>
@@ -101,7 +101,7 @@
     <dependency>
        <groupId>org.apache.commons</groupId>
        <artifactId>commons-compress</artifactId>
-       <version>1.26.2</version>
+       <version>1.28.0</version>
     </dependency>
   </dependencies>
 

--- a/service/src/main/java/org/folio/rest/workflow/config/FolioSpringLiquibaseConfig.java
+++ b/service/src/main/java/org/folio/rest/workflow/config/FolioSpringLiquibaseConfig.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Configuration;
 public class FolioSpringLiquibaseConfig {
 
   @Bean
-  public FolioSpringLiquibase folioSpringLiquibase() {
+  FolioSpringLiquibase folioSpringLiquibase() {
     return new FolioSpringLiquibase();
   }
 

--- a/service/src/main/java/org/folio/rest/workflow/config/KafkaProducerConfig.java
+++ b/service/src/main/java/org/folio/rest/workflow/config/KafkaProducerConfig.java
@@ -33,7 +33,7 @@ public class KafkaProducerConfig {
   }
 
   @Bean
-  public KafkaTemplate<String, Event> eventKafkaTemplate() {
+  KafkaTemplate<String, Event> eventKafkaTemplate() {
     return new KafkaTemplate<>(eventProducerFactory());
   }
 

--- a/service/src/main/java/org/folio/rest/workflow/config/KafkaProducerConfig.java
+++ b/service/src/main/java/org/folio/rest/workflow/config/KafkaProducerConfig.java
@@ -2,7 +2,6 @@ package org.folio.rest.workflow.config;
 
 import java.util.HashMap;
 import java.util.Map;
-
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.folio.spring.messaging.model.Event;
@@ -13,7 +12,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
-import org.springframework.kafka.support.serializer.JsonSerializer;
+import org.springframework.kafka.support.serializer.JacksonJsonSerializer;
 
 @Configuration
 @Profile({ "messaging", "!test" })
@@ -27,7 +26,7 @@ public class KafkaProducerConfig {
     Map<String, Object> configProps = new HashMap<>();
     configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapAddress);
     configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-    configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+    configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JacksonJsonSerializer.class);
 
     return new DefaultKafkaProducerFactory<>(configProps);
   }

--- a/service/src/main/java/org/folio/rest/workflow/config/OkHttpConfig.java
+++ b/service/src/main/java/org/folio/rest/workflow/config/OkHttpConfig.java
@@ -1,22 +1,8 @@
 package org.folio.rest.workflow.config;
 
-import feign.okhttp.OkHttpClient;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class OkHttpConfig {
-
-  /**
-   * Add feignOkHttpClient to prevent issues introduced when using folio-spring-base.
-   *
-   * The issue involves enrichUrlAndHeadersClient, FeignClientConfiguration, and okhttp3.OkHttpClient.
-   *
-   * This defines a bean of type 'okhttp3.OkHttpClient' to prevent the error.
-   */
-  @Bean
-  public OkHttpClient feignOkHttpClient() {
-    return new OkHttpClient();
-  }
 
 }

--- a/service/src/main/java/org/folio/rest/workflow/controller/EventController.java
+++ b/service/src/main/java/org/folio/rest/workflow/controller/EventController.java
@@ -1,8 +1,5 @@
 package org.folio.rest.workflow.controller;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.File;
 import java.io.IOException;
@@ -35,6 +32,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.HandlerMapping;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ObjectNode;
 
 @RestController
 @RequestMapping("/events")

--- a/service/src/main/java/org/folio/rest/workflow/controller/WorkflowController.java
+++ b/service/src/main/java/org/folio/rest/workflow/controller/WorkflowController.java
@@ -1,6 +1,5 @@
 package org.folio.rest.workflow.controller;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -30,6 +29,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+import tools.jackson.databind.JsonNode;
 
 @Slf4j
 @RestController

--- a/service/src/main/java/org/folio/rest/workflow/controller/WorkflowController.java
+++ b/service/src/main/java/org/folio/rest/workflow/controller/WorkflowController.java
@@ -4,8 +4,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.compress.archivers.ArchiveException;
-import org.apache.commons.compress.compressors.CompressorException;
 import org.folio.rest.workflow.exception.WorkflowEngineServiceException;
 import org.folio.rest.workflow.exception.WorkflowImportException;
 import org.folio.rest.workflow.exception.WorkflowNotFoundException;
@@ -56,7 +54,7 @@ public class WorkflowController {
       @RequestPart(name = "file") MultipartFile fwz,
       @TenantHeader String tenant,
       @TokenHeader String token
-    ) throws URISyntaxException, IOException, CompressorException, ArchiveException, WorkflowImportException {
+    ) throws URISyntaxException, IOException, WorkflowImportException {
 
     log.debug("Importing FWZ");
 

--- a/service/src/main/java/org/folio/rest/workflow/controller/advice/AbstractAdvice.java
+++ b/service/src/main/java/org/folio/rest/workflow/controller/advice/AbstractAdvice.java
@@ -1,11 +1,12 @@
 package org.folio.rest.workflow.controller.advice;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.folio.spring.web.utility.ErrorUtility;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 abstract class AbstractAdvice extends RequestMappingHandlerMapping {
 
@@ -46,7 +47,7 @@ abstract class AbstractAdvice extends RequestMappingHandlerMapping {
     // Catch the exceptions and report it, then fall back to a plain text error message.
     try {
       message = getObjectMapper().writeValueAsString(ErrorUtility.buildError(ex, code));
-    } catch (JsonProcessingException e) {
+    } catch (JacksonException e) {
       logger.error("Mapping error to JSON Object failed.", e);
 
       type = MediaType.TEXT_PLAIN;

--- a/service/src/main/java/org/folio/rest/workflow/controller/advice/EventControllerAdvice.java
+++ b/service/src/main/java/org/folio/rest/workflow/controller/advice/EventControllerAdvice.java
@@ -1,5 +1,4 @@
 package org.folio.rest.workflow.controller.advice;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.file.FileSystemException;
 import org.folio.rest.workflow.exception.EventPublishException;
 import org.springframework.http.HttpStatus;
@@ -7,6 +6,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 @RestControllerAdvice
 public class EventControllerAdvice extends AbstractAdvice {
@@ -14,7 +15,7 @@ public class EventControllerAdvice extends AbstractAdvice {
   ObjectMapper objectMapper;
 
   public EventControllerAdvice() {
-    this.objectMapper = new ObjectMapper();
+    this.objectMapper = JsonMapper.builder().build();
   }
 
   @Override

--- a/service/src/main/java/org/folio/rest/workflow/controller/advice/GlobalAdvice.java
+++ b/service/src/main/java/org/folio/rest/workflow/controller/advice/GlobalAdvice.java
@@ -1,11 +1,12 @@
 package org.folio.rest.workflow.controller.advice;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.TransactionSystemException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 @RestControllerAdvice
 public class GlobalAdvice extends AbstractAdvice {
@@ -13,7 +14,7 @@ public class GlobalAdvice extends AbstractAdvice {
   ObjectMapper objectMapper;
 
   public GlobalAdvice() {
-    this.objectMapper = new ObjectMapper();
+    this.objectMapper = JsonMapper.builder().build();
   }
 
   @Override

--- a/service/src/main/java/org/folio/rest/workflow/controller/advice/WorkflowControllerAdvice.java
+++ b/service/src/main/java/org/folio/rest/workflow/controller/advice/WorkflowControllerAdvice.java
@@ -1,6 +1,5 @@
 package org.folio.rest.workflow.controller.advice;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.EntityNotFoundException;
 import org.folio.rest.workflow.exception.WorkflowAlreadyActiveException;
 import org.folio.rest.workflow.exception.WorkflowCreateAlreadyExistsException;
@@ -13,6 +12,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 @RestControllerAdvice
 public class WorkflowControllerAdvice extends AbstractAdvice {
@@ -20,7 +21,7 @@ public class WorkflowControllerAdvice extends AbstractAdvice {
   ObjectMapper objectMapper;
 
   public WorkflowControllerAdvice() {
-    this.objectMapper = new ObjectMapper();
+    this.objectMapper = JsonMapper.builder().build();
   }
 
   @Override

--- a/service/src/main/java/org/folio/rest/workflow/controller/advice/WorkflowControllerAdvice.java
+++ b/service/src/main/java/org/folio/rest/workflow/controller/advice/WorkflowControllerAdvice.java
@@ -48,7 +48,7 @@ public class WorkflowControllerAdvice extends AbstractAdvice {
 
   @ResponseStatus(HttpStatus.FORBIDDEN)
   @ExceptionHandler(WorkflowAlreadyActiveException.class)
-  public ResponseEntity<String> handleWorkflowAlreadyActivrException(WorkflowAlreadyActiveException exception) {
+  public ResponseEntity<String> handleWorkflowAlreadyActiveException(WorkflowAlreadyActiveException exception) {
     return buildError(exception, HttpStatus.FORBIDDEN);
   }
 
@@ -66,7 +66,7 @@ public class WorkflowControllerAdvice extends AbstractAdvice {
 
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   @ExceptionHandler(WorkflowImportException.class)
-  public ResponseEntity<String> handleWorkflowImportExceptionException(WorkflowImportException exception) {
+  public ResponseEntity<String> handleWorkflowImportException(WorkflowImportException exception) {
     return buildError(exception, HttpStatus.BAD_REQUEST);
   }
 

--- a/service/src/main/java/org/folio/rest/workflow/model/ExtractedWorkflow.java
+++ b/service/src/main/java/org/folio/rest/workflow/model/ExtractedWorkflow.java
@@ -1,12 +1,12 @@
 package org.folio.rest.workflow.model;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 import lombok.Getter;
+import tools.jackson.databind.JsonNode;
 
 /**
  * A collection of Workflow Nodes for use during import.

--- a/service/src/main/java/org/folio/rest/workflow/model/repo/WorkflowRepo.java
+++ b/service/src/main/java/org/folio/rest/workflow/model/repo/WorkflowRepo.java
@@ -2,6 +2,7 @@ package org.folio.rest.workflow.model.repo;
 
 import org.folio.rest.workflow.model.Workflow;
 import org.folio.spring.cql.JpaCqlRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import org.springframework.data.rest.core.annotation.RestResource;
 
@@ -19,4 +20,7 @@ public interface WorkflowRepo extends JpaCqlRepository<Workflow, String> {
   @Override
   @RestResource(exported = false)
   public void deleteById(String id);
+
+  @Query("SELECT COUNT(*) FROM Workflow")
+  public long countAll();
 }

--- a/service/src/main/java/org/folio/rest/workflow/service/AbstractCqlService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/AbstractCqlService.java
@@ -1,9 +1,9 @@
 package org.folio.rest.workflow.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.List;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 
 /**
  * Provide common CQL-specific service functionality.

--- a/service/src/main/java/org/folio/rest/workflow/service/OkapiDiscoveryService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/OkapiDiscoveryService.java
@@ -62,7 +62,7 @@ public class OkapiDiscoveryService {
     return actions;
   }
 
-  public List<Action> getActionsByTenantAndModuleId(String tenant, String id) throws IOException {
+  public List<Action> getActionsByTenantAndModuleId(String tenant, String id) {
     Map<String, List<Handler>> handlerMap = getHandlers(tenant, id);
     List<Action> actions = new ArrayList<>();
     for (Map.Entry<String, List<Handler>> entry : handlerMap.entrySet()) {
@@ -73,7 +73,7 @@ public class OkapiDiscoveryService {
     return actions;
   }
 
-  public Map<String, List<Handler>> getHandlers(String tenant, String id) throws IOException {
+  public Map<String, List<Handler>> getHandlers(String tenant, String id) {
     JsonNode moduleDescriptorNode = getModuleDescriptor(tenant, id);
 
     Map<String, List<Handler>> handlerMap = new HashMap<>();

--- a/service/src/main/java/org/folio/rest/workflow/service/OkapiDiscoveryService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/OkapiDiscoveryService.java
@@ -2,7 +2,6 @@ package org.folio.rest.workflow.service;
 
 import static org.springframework.http.HttpMethod.GET;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -52,7 +51,7 @@ public class OkapiDiscoveryService {
     this.objectMapper = objectMapper;
   }
 
-  public List<Action> getActionsByTenant(String tenant) throws IOException {
+  public List<Action> getActionsByTenant(String tenant) {
     List<Action> actions = new ArrayList<>();
     JsonNode modulesNode = getModules(tenant);
     for (JsonNode moduleNode : modulesNode) {

--- a/service/src/main/java/org/folio/rest/workflow/service/OkapiDiscoveryService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/OkapiDiscoveryService.java
@@ -2,8 +2,6 @@ package org.folio.rest.workflow.service;
 
 import static org.springframework.http.HttpMethod.GET;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -20,6 +18,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 @Service
 public class OkapiDiscoveryService {
@@ -56,7 +56,7 @@ public class OkapiDiscoveryService {
     List<Action> actions = new ArrayList<>();
     JsonNode modulesNode = getModules(tenant);
     for (JsonNode moduleNode : modulesNode) {
-      String id = moduleNode.get("id").asText();
+      String id = moduleNode.get("id").asString();
       actions.addAll(getActionsByTenantAndModuleId(tenant, id));
     }
     return actions;
@@ -81,7 +81,7 @@ public class OkapiDiscoveryService {
     if (moduleDescriptorNode.get(PROVIDES) != null) {
       for (JsonNode interfaceNode : moduleDescriptorNode.get(PROVIDES)) {
         List<Handler> handlers = new ArrayList<>();
-        String interfaceName = interfaceNode.get(ID).asText();
+        String interfaceName = interfaceNode.get(ID).asString();
         for (JsonNode handlersNode : interfaceNode.get(HANDLERS)) {
           handlers.add(objectMapper.readValue(handlersNode.toString(), Handler.class));
         }

--- a/service/src/main/java/org/folio/rest/workflow/service/WorkflowCqlService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/WorkflowCqlService.java
@@ -1,13 +1,13 @@
 package org.folio.rest.workflow.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.rest.workflow.model.Workflow;
 import org.folio.rest.workflow.model.repo.WorkflowRepo;
 import org.folio.spring.data.OffsetRequest;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ObjectNode;
 
 @Service
 public class WorkflowCqlService extends AbstractCqlService<Workflow> {

--- a/service/src/main/java/org/folio/rest/workflow/service/WorkflowCqlService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/WorkflowCqlService.java
@@ -20,24 +20,24 @@ public class WorkflowCqlService extends AbstractCqlService<Workflow> {
   }
 
   @Override
-  protected String getTypeName() {
-    return Workflow.class.getSimpleName().toLowerCase() + "s";
-  }
-
-  @Override
   public ObjectNode findByCql(String query, Long offset, Integer limit) {
     Page<Workflow> page = null;
     long total = 0;
 
     if (StringUtils.isBlank(query)) {
       page = repo.findAll(new OffsetRequest(offset, limit));
-      total = repo.count();
+      total = repo.countAll();
     } else {
       page = repo.findByCql(query, new OffsetRequest(offset, limit));
-      total = repo.count(query);
+      total = repo.countByCql(query);
     }
 
     return toJson(page.toList(), total);
+  }
+
+  @Override
+  protected String getTypeName() {
+    return Workflow.class.getSimpleName().toLowerCase() + "s";
   }
 
 }

--- a/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
@@ -1,9 +1,5 @@
 package org.folio.rest.workflow.service;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Iterator;
 import lombok.extern.slf4j.Slf4j;
 import org.folio.rest.workflow.dto.WorkflowDto;
@@ -14,7 +10,7 @@ import org.folio.rest.workflow.model.Workflow;
 import org.folio.rest.workflow.model.repo.WorkflowRepo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.boot.restclient.RestTemplateBuilder;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -22,6 +18,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 
 @Slf4j
 @Service
@@ -121,7 +121,7 @@ public class WorkflowEngineService {
     String version = workflow.getVersionTag();
 
     JsonNode definition = fetchDeploymentDefinition(id, version, tenant, token);
-    String definitionId = definition.get("id").asText();
+    String definitionId = definition.get("id").asString();
 
     HttpEntity<JsonNode> contextHttpEntity = new HttpEntity<>(context, headers(tenant, token));
 
@@ -141,7 +141,7 @@ public class WorkflowEngineService {
     String version = workflow.getVersionTag();
 
     JsonNode processDefinition = fetchDeploymentDefinition(deploymentId, version, tenant, token);
-    String processDefinitionId = processDefinition.get("id").asText();
+    String processDefinitionId = processDefinition.get("id").asString();
 
     ArrayNode instances = fetchProcessInstanceHistory(processDefinitionId, tenant, token);
 
@@ -149,7 +149,7 @@ public class WorkflowEngineService {
 
     while (iter.hasNext()) {
       JsonNode instance = iter.next();
-      String processInstanceId = instance.get("id").asText();
+      String processInstanceId = instance.get("id").asString();
 
       ((ObjectNode) instance).withArray("incidents")
         .addAll(fetchIncidentsHistory(processInstanceId, tenant, token));

--- a/service/src/main/java/org/folio/rest/workflow/service/WorkflowImportService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/WorkflowImportService.java
@@ -31,12 +31,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.compress.archivers.ArchiveException;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarFile;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipFile;
-import org.apache.commons.compress.compressors.CompressorException;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.commons.compress.utils.SeekableInMemoryByteChannel;
@@ -90,12 +88,10 @@ public class WorkflowImportService {
    *
    * @return The created Workflow.
    *
-   * @throws ArchiveException On archive error.
-   * @throws CompressorException On compressor error.
    * @throws IOException On error reading the file stream, extracting the JSON, or other such errors.
    * @throws WorkflowImportException On import failure.
    */
-  public Workflow importFile(Resource fwz) throws IOException, CompressorException, ArchiveException, WorkflowImportException {
+  public Workflow importFile(Resource fwz) throws IOException, WorkflowImportException {
     CompressFileFormat format = CompressFileMagic.detectFormat(fwz.getInputStream());
 
     if (format != null) {
@@ -210,10 +206,8 @@ public class WorkflowImportService {
    *
    * @param nodes The Nodes to iterate over.
    * @param expanded An array of IDs of nodes representing the top-down order of creation.
-   *
-   * @throws JsonProcessingException On JSON parse failure.
    */
-  private void createNodes(Map<String, JsonNode> nodes, List<String> expanded) throws JsonProcessingException {
+  private void createNodes(Map<String, JsonNode> nodes, List<String> expanded) {
     for (String uuid : expanded) {
       Node node = objectMapper.readValue(nodes.get(uuid).toString(), Node.class);
       nodeRepo.save(node);
@@ -224,10 +218,8 @@ public class WorkflowImportService {
    * Create the Triggers in the database.
    *
    * @param triggers The Triggers to iterate over.
-   *
-   * @throws JsonProcessingException On JSON parse failure.
    */
-  private void createTriggers(Map<String, JsonNode> triggers) throws JsonProcessingException {
+  private void createTriggers(Map<String, JsonNode> triggers) {
     for (JsonNode triggerNode : triggers.values()) {
       Trigger trigger = objectMapper.readValue(triggerNode.toString(), Trigger.class);
       triggerRepo.save(trigger);
@@ -240,10 +232,8 @@ public class WorkflowImportService {
    * @param workflowJson The Workflow JSON to save.
    *
    * @return The created Workflow.
-   *
-   * @throws JsonProcessingException On JSON parse failure.
    */
-  private Workflow createWorkflow(JsonNode workflowJson) throws JsonProcessingException {
+  private Workflow createWorkflow(JsonNode workflowJson) {
     Workflow workflow = objectMapper.readValue(workflowJson.toString(), Workflow.class);
     return workflowRepo.save(workflow);
   }

--- a/service/src/main/java/org/folio/rest/workflow/service/WorkflowImportService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/WorkflowImportService.java
@@ -21,11 +21,6 @@ import static org.folio.rest.workflow.model.ExtractedWorkflow.VERSION_PATTERN_1_
 import static org.folio.rest.workflow.model.ExtractedWorkflow.WORKFLOW_JSON;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeType;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.jknack.handlebars.internal.Files;
 import java.io.BufferedInputStream;
 import java.io.IOException;
@@ -61,6 +56,11 @@ import org.folio.rest.workflow.model.repo.WorkflowRepo;
 import org.folio.rest.workflow.utility.CompressFileMagic;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.JsonNodeType;
+import tools.jackson.databind.node.ObjectNode;
 
 @Slf4j
 @Service
@@ -150,8 +150,8 @@ public class WorkflowImportService {
         continue;
       }
 
-      String scriptFormat = entry.getValue().get(SCRIPT_FORMAT).asText();
-      String fileName = entry.getValue().get(CODE).asText();
+      String scriptFormat = entry.getValue().get(SCRIPT_FORMAT).asString();
+      String fileName = entry.getValue().get(CODE).asString();
       String extension = scriptFormat.toLowerCase().trim();
 
       switch (scriptFormat) {
@@ -189,7 +189,7 @@ public class WorkflowImportService {
    * @throws WorkflowImportInvalidOrMissingProperty If a property is missing.
    */
   private boolean collapseNodeScriptsContinue(Entry<String, JsonNode> entry) throws WorkflowImportInvalidOrMissingProperty {
-    String deserializeAs = entry.getValue().get(DESERIALIZE_AS).asText();
+    String deserializeAs = entry.getValue().get(DESERIALIZE_AS).asString();
     if (!SCRIPT_TASK.equalsIgnoreCase(deserializeAs)) {
       return true;
     }
@@ -340,9 +340,9 @@ public class WorkflowImportService {
     }
 
     if (pathParts[0].equalsIgnoreCase(NODES)) {
-      extracted.getNodes().put(json.get(ID).asText(), json);
+      extracted.getNodes().put(json.get(ID).asString(), json);
     } else {
-      extracted.getTriggers().put(json.get(ID).asText(), json);
+      extracted.getTriggers().put(json.get(ID).asString(), json);
     }
   }
 
@@ -362,7 +362,7 @@ public class WorkflowImportService {
     }
 
     JsonNode workflowNode = extracted.getRequired().get(WORKFLOW_JSON);
-    String workflowId = workflowNode.get(ID).asText();
+    String workflowId = workflowNode.get(ID).asString();
 
     // The expandNode() method requires the Workflow to be on the getNodes(), so temporarily add it.
     extracted.getNodes().put(workflowId, extracted.getRequired().get(WORKFLOW_JSON));
@@ -386,7 +386,7 @@ public class WorkflowImportService {
    * @throws WorkflowImportInvalidOrMissingProperty On invalid property.
    */
   private void expandNode(Map<String, JsonNode> nodes, JsonNode node, List<String> expanded) throws JsonProcessingException, WorkflowImportInvalidOrMissingProperty {
-    String nodeId = node.get(ID).asText();
+    String nodeId = node.get(ID).asString();
     if (expanded.contains(nodeId)) {
       return;
     }
@@ -493,7 +493,7 @@ public class WorkflowImportService {
       throw new WorkflowImportInvalidOrMissingProperty(null, ID);
     }
 
-    String id = json.get(ID).asText();
+    String id = json.get(ID).asString();
 
     if (workflowRepo.existsById(id)) {
       throw new WorkflowImportAlreadyImported(id);
@@ -539,7 +539,7 @@ public class WorkflowImportService {
    */
   private void verifyVersion(JsonNode json) {
     if (json.has(VERSION)) {
-      String version = json.get(VERSION).asText();
+      String version = json.get(VERSION).asString();
 
       if (!VERSION_PATTERN_1_0.matcher(version).find()) {
         log.warn("Unknown version '{}', attempting import anyway.", version);

--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -15,9 +15,6 @@ server:
   port: 8081
   servlet:
     context-path: /
-    encoding:
-      charset: UTF-8
-      enabled: true
 
 spring:
   application.name: mod-workflow
@@ -37,6 +34,11 @@ spring:
     allow-circular-references: false
     banner-mode: console
     log-startup-info: true
+
+  servlet:
+    encoding:
+      charset: UTF-8
+      enabled: true
 
   sql:
     init:

--- a/service/src/test/java/org/folio/rest/workflow/config/JunitHelperWebMvcConfig.java
+++ b/service/src/test/java/org/folio/rest/workflow/config/JunitHelperWebMvcConfig.java
@@ -1,10 +1,11 @@
 package org.folio.rest.workflow.config;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.TestConfiguration;
 import org.springframework.test.context.ActiveProfiles;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Provide custom web MVC settings for use during unit tests.
@@ -15,9 +16,10 @@ public class JunitHelperWebMvcConfig {
 
   @Bean
   ObjectMapper objectMapper() {
-    final ObjectMapper mapper = new ObjectMapper();
-
-    mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    final ObjectMapper mapper = JsonMapper
+      .builder()
+      .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+      .build();
 
     return mapper;
   }

--- a/service/src/test/java/org/folio/rest/workflow/config/JunitHelperWebMvcConfig.java
+++ b/service/src/test/java/org/folio/rest/workflow/config/JunitHelperWebMvcConfig.java
@@ -16,11 +16,9 @@ public class JunitHelperWebMvcConfig {
 
   @Bean
   ObjectMapper objectMapper() {
-    final ObjectMapper mapper = JsonMapper
+    return JsonMapper
       .builder()
       .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
       .build();
-
-    return mapper;
   }
 }

--- a/service/src/test/java/org/folio/rest/workflow/config/JunitHelperWebMvcConfig.java
+++ b/service/src/test/java/org/folio/rest/workflow/config/JunitHelperWebMvcConfig.java
@@ -1,0 +1,24 @@
+package org.folio.rest.workflow.config;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.TestConfiguration;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Provide custom web MVC settings for use during unit tests.
+ */
+@TestConfiguration
+@ActiveProfiles("test")
+public class JunitHelperWebMvcConfig {
+
+  @Bean
+  ObjectMapper objectMapper() {
+    final ObjectMapper mapper = new ObjectMapper();
+
+    mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+    return mapper;
+  }
+}

--- a/service/src/test/java/org/folio/rest/workflow/controller/ActionControllerTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/controller/ActionControllerTest.java
@@ -33,7 +33,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
@@ -48,7 +47,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -57,6 +56,7 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.util.MultiValueMap;
+import tools.jackson.databind.ObjectMapper;
 
 @WebMvcTest(ActionController.class)
 @ExtendWith(MockitoExtension.class)

--- a/service/src/test/java/org/folio/rest/workflow/controller/EventControllerTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/controller/EventControllerTest.java
@@ -121,7 +121,7 @@ class EventControllerTest {
         arguments("diku", "a", join(separator,"..", "..", "..", "..", "x.txt")));
   }
 
-  MockMultipartHttpServletRequestBuilder upload(String tenant, String dir, String file) throws Exception {
+  MockMultipartHttpServletRequestBuilder upload(String tenant, String dir, String file) {
     var sampleFile = new MockMultipartFile(
         "file",
         file,

--- a/service/src/test/java/org/folio/rest/workflow/controller/EventControllerTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/controller/EventControllerTest.java
@@ -24,21 +24,24 @@ import org.folio.rest.workflow.model.repo.TriggerRepo;
 import org.folio.spring.tenant.properties.TenantProperties;
 import org.folio.spring.tenant.resolver.TenantHeaderResolver;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 @WebMvcTest(EventController.class)
+@ExtendWith(MockitoExtension.class)
 class EventControllerTest {
 
   private MockMvc mockMvc;
@@ -118,7 +121,7 @@ class EventControllerTest {
         arguments("diku", "a", join(separator,"..", "..", "..", "..", "x.txt")));
   }
 
-  MockHttpServletRequestBuilder upload(String tenant, String dir, String file) throws Exception {
+  MockMultipartHttpServletRequestBuilder upload(String tenant, String dir, String file) throws Exception {
     var sampleFile = new MockMultipartFile(
         "file",
         file,

--- a/service/src/test/java/org/folio/rest/workflow/controller/WorkflowControllerTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/controller/WorkflowControllerTest.java
@@ -23,8 +23,11 @@ import static org.folio.spring.test.mock.MockMvcReflection.PATCH;
 import static org.folio.spring.test.mock.MockMvcReflection.POST;
 import static org.folio.spring.test.mock.MockMvcReflection.PUT;
 import static org.folio.spring.test.mock.MockMvcRequest.appendBody;
+import static org.folio.spring.test.mock.MockMvcRequest.appendBodyMultipart;
 import static org.folio.spring.test.mock.MockMvcRequest.appendHeaders;
+import static org.folio.spring.test.mock.MockMvcRequest.appendHeadersMultipart;
 import static org.folio.spring.test.mock.MockMvcRequest.appendParameters;
+import static org.folio.spring.test.mock.MockMvcRequest.appendParametersMultipart;
 import static org.folio.spring.test.mock.MockMvcRequest.buildArguments1;
 import static org.folio.spring.test.mock.MockMvcRequest.buildArguments2;
 import static org.folio.spring.test.mock.MockMvcRequest.invokeRequestBuilder;
@@ -43,8 +46,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
@@ -65,7 +66,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -74,9 +75,12 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.MultiValueMap;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ObjectNode;
 
 @WebMvcTest(WorkflowController.class)
 @ExtendWith(MockitoExtension.class)
@@ -391,10 +395,10 @@ class WorkflowControllerTest {
 
     lenient().when(workflowImportService.importFile(any(Resource.class))).thenReturn(workflow);
 
-    MockHttpServletRequestBuilder request = appendHeaders(multipart(PATH_IMPORT).file(exampleFwz), headers, contentType, accept);
-    request = appendParameters(request, parameters);
+    MockMultipartHttpServletRequestBuilder request = appendHeadersMultipart(multipart(PATH_IMPORT).file(exampleFwz), headers, contentType, accept);
+    request = appendParametersMultipart(request, parameters);
 
-    MvcResult result = mvc.perform(appendBody(request, body))
+    MvcResult result = mvc.perform(appendBodyMultipart(request, body))
       .andDo(log()).andExpect(status().is(status)).andReturn();
 
     if (status == 200) {

--- a/service/src/test/java/org/folio/rest/workflow/controller/advice/AbstractAdviceTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/controller/advice/AbstractAdviceTest.java
@@ -4,30 +4,31 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 @ExtendWith(MockitoExtension.class)
 class AbstractAdviceTest {
 
   private static final RuntimeException runtimeException = new RuntimeException("A runtime failure.");
 
-  @Mock
   private ObjectMapper objectMapper;
 
   private MockAdvice abstractAdvice;
 
   @BeforeEach
   void beforeEach() {
+    objectMapper = Mockito.spy(JsonMapper.builder().build());
     abstractAdvice = new MockAdvice();
   }
 
@@ -40,8 +41,8 @@ class AbstractAdviceTest {
   }
 
   @Test
-  void handleBuildErrorThrowsJsonProcessingExceptionTest() throws JsonProcessingException {
-    when(objectMapper.writeValueAsString(any())).thenThrow(new MockJsonProcessingException());
+  void handleBuildErrorThrowsJsonProcessingExceptionTest() throws JacksonException {
+    when(objectMapper.writeValueAsString(any())).thenThrow(new MockJacksonException());
 
     ResponseEntity<String> response = abstractAdvice.handleException(runtimeException);
 
@@ -69,15 +70,15 @@ class AbstractAdviceTest {
   }
 
   /**
-   * Provide a way to throw a type of JsonProcessingException.
+   * Provide a way to throw a type of JacksonException.
    *
    * The JsonProcessingException does not have a public initializer.
    */
-  private class MockJsonProcessingException extends JsonProcessingException {
+  private class MockJacksonException extends JacksonException {
 
     private static final long serialVersionUID = 812355666324245L;
 
-    public MockJsonProcessingException() {
+    public MockJacksonException() {
       super("mock");
     }
 

--- a/service/src/test/java/org/folio/rest/workflow/controller/advice/EventControllerAdviceTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/controller/advice/EventControllerAdviceTest.java
@@ -1,98 +1,82 @@
 package org.folio.rest.workflow.controller.advice;
 
-import static org.folio.spring.test.mock.MockMvcConstant.APP_JSON;
-import static org.folio.spring.test.mock.MockMvcConstant.JSON_OBJECT;
-import static org.folio.spring.test.mock.MockMvcConstant.OKAPI_HEAD;
 import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
-import static org.folio.spring.test.mock.MockMvcRequest.appendBody;
-import static org.folio.spring.test.mock.MockMvcRequest.appendHeaders;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.nio.file.FileSystemException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Stream;
-import org.folio.rest.workflow.controller.EventController;
 import org.folio.rest.workflow.exception.EventPublishException;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
-import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
-@SpringBootTest(webEnvironment = WebEnvironment.MOCK)
-@AutoConfigureMockMvc
 @ExtendWith(MockitoExtension.class)
 @ActiveProfiles("test")
 class EventControllerAdviceTest {
 
-  private static final String PATH = "/events";
+  private static final Exception RUNTIME_EXC = new RuntimeException("Runtime failure.");
 
-  private static final String PATH_HANDLE = PATH + "/handle";
+  private static final EventPublishException EP_EXC = new EventPublishException(VALUE, RUNTIME_EXC);
 
-  @Autowired
-  private EventControllerAdvice eventControllerAdvice;
+  private static final FileSystemException FS_EXC = new FileSystemException(VALUE);
 
-  @Autowired
-  @Mock
-  private EventController eventController;
-
-  private MockMvc mvc;
+  private EventControllerAdvice advice;
 
   @BeforeEach
   void beforeEach() {
-    mvc = MockMvcBuilders.standaloneSetup(eventController)
-      .setControllerAdvice(eventControllerAdvice)
-      .build();
+    advice = new EventControllerAdvice();
   }
 
-  @ParameterizedTest
-  @MethodSource("provideExceptionsToMatchForActivateWorkflow")
-  void exceptionsThrownForActivateWorkflowTest(Exception exception, String simpleName, int status) throws Exception {
-    given(eventController.postHandleEvents(any(), any())).willAnswer(invocation -> { throw exception; });
+  @Test
+  void handleEventPublishExceptionTest() {
 
-    MockHttpServletRequestBuilder request = appendHeaders(post(PATH_HANDLE), OKAPI_HEAD, APP_JSON, APP_JSON);
+    final String simpleName = EventPublishException.class.getSimpleName();
+    final ResponseEntity<String> response = advice.handleEventPublishException(EP_EXC);
 
-    MvcResult result = mvc.perform(appendBody(request, JSON_OBJECT))
-      .andDo(log()).andExpect(status().is(status)).andReturn();
+    assertNotNull(response);
+    assertNotNull(response.getBody());
 
-    Pattern pattern = Pattern.compile("\"type\":\"" + simpleName + "\"");
-    Matcher matcher = pattern.matcher(result.getResponse().getContentAsString());
-    assertTrue(matcher.find());
+    assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+    assertEquals(MediaType.APPLICATION_JSON, response.getHeaders().getContentType());
+    assertTrue(matchBody(response, simpleName));
+  }
+
+  @Test
+  void handleFileSystemExceptionTest() {
+
+    final String simpleName = FileSystemException.class.getSimpleName();
+    final ResponseEntity<String> response = advice.handleFileSystemException(FS_EXC);
+
+    assertNotNull(response);
+    assertNotNull(response.getBody());
+
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    assertEquals(MediaType.APPLICATION_JSON, response.getHeaders().getContentType());
+    assertTrue(matchBody(response, simpleName));
   }
 
   /**
-   * Helper function for parameterized test providing the exceptions to be matched for activate workflow.
+   * Match the class simple name in the response.
    *
-   * @return
-   *   The arguments array stream with the stream columns as:
-   *     - Exception exception.
-   *     - String simpleName (exception name to match).
-   *     - int status (response HTTP status code for the exception).
+   * @param response The response to search.
+   * @param simpleName The class name to match.
+   *
+   * @return TRUE on match; FALSE otherwise.
    */
-  private static Stream<Arguments> provideExceptionsToMatchForActivateWorkflow() {
-    Exception runtime = new RuntimeException("Runtime failure.");
+  private boolean matchBody(ResponseEntity<String> response, String simpleName) {
 
-    return Stream.of(
-      Arguments.of(new EventPublishException(VALUE, runtime), EventPublishException.class.getSimpleName(), 500),
-      Arguments.of(new FileSystemException(VALUE), FileSystemException.class.getSimpleName(), 400)
-    );
+    final Pattern pattern = Pattern.compile("\"type\":\"" + simpleName + "\"");
+    final Matcher matcher = pattern.matcher(response.getBody());
+
+    return matcher.find();
   }
 
 }

--- a/service/src/test/java/org/folio/rest/workflow/controller/advice/WorkflowControllerAdviceTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/controller/advice/WorkflowControllerAdviceTest.java
@@ -1,24 +1,14 @@
 package org.folio.rest.workflow.controller.advice;
 
-import static org.folio.spring.test.mock.MockMvcConstant.APP_JSON;
-import static org.folio.spring.test.mock.MockMvcConstant.JSON_OBJECT;
-import static org.folio.spring.test.mock.MockMvcConstant.OKAPI_HEAD;
-import static org.folio.spring.test.mock.MockMvcConstant.UUID;
 import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
-import static org.folio.spring.test.mock.MockMvcRequest.appendBody;
-import static org.folio.spring.test.mock.MockMvcRequest.appendHeaders;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import jakarta.persistence.EntityNotFoundException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
-import org.folio.rest.workflow.controller.WorkflowController;
 import org.folio.rest.workflow.exception.WorkflowAlreadyActiveException;
 import org.folio.rest.workflow.exception.WorkflowDeploymentException;
 import org.folio.rest.workflow.exception.WorkflowEngineServiceException;
@@ -29,85 +19,166 @@ import org.folio.rest.workflow.exception.WorkflowImportJsonFileIsDirectory;
 import org.folio.rest.workflow.exception.WorkflowImportRequiredFileMissing;
 import org.folio.rest.workflow.exception.WorkflowNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
-import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
-@SpringBootTest(webEnvironment = WebEnvironment.MOCK)
-@AutoConfigureMockMvc
 @ExtendWith(MockitoExtension.class)
 @ActiveProfiles("test")
 class WorkflowControllerAdviceTest {
 
-  private static final String PATH = "/workflows";
+  private static final EntityNotFoundException ENF_EXC = new EntityNotFoundException(VALUE);
 
-  private static final String PATH_ACTIVATE = PATH + "/{id}/activate";
+  private static final WorkflowNotFoundException WNF_EXC = new WorkflowNotFoundException(VALUE);
 
-  @Autowired
-  private WorkflowControllerAdvice workflowControllerAdvice;
+  private static final WorkflowAlreadyActiveException WAA_EXC = new WorkflowAlreadyActiveException(VALUE);
 
-  @Autowired
-  @Mock
-  private WorkflowController workflowController;
+  private static final WorkflowDeploymentException WD_EXC = new WorkflowDeploymentException();
 
-  private MockMvc mvc;
+  private static final WorkflowEngineServiceException WES_EXC = new WorkflowEngineServiceException(VALUE);
+
+  private static final WorkflowImportException WI_EXC = new WorkflowImportException(VALUE);
+
+  private static final WorkflowImportAlreadyImported WIAI_EXC = new WorkflowImportAlreadyImported(VALUE);
+
+  private static final WorkflowImportInvalidOrMissingProperty WIIOMP_EXC = new WorkflowImportInvalidOrMissingProperty(VALUE, VALUE);
+
+  private static final WorkflowImportJsonFileIsDirectory WIJFID_EXC = new WorkflowImportJsonFileIsDirectory(VALUE);
+
+  private static final WorkflowImportRequiredFileMissing WIRFM_EXC = new WorkflowImportRequiredFileMissing(VALUE);
+
+  private WorkflowControllerAdvice advice;
 
   @BeforeEach
   void beforeEach() {
-    mvc = MockMvcBuilders.standaloneSetup(workflowController)
-      .setControllerAdvice(workflowControllerAdvice)
-      .build();
+    advice = new WorkflowControllerAdvice();
+  }
+
+  @Test
+  void handleEntityNotFoundExceptionTest() {
+
+    final String simpleName = EntityNotFoundException.class.getSimpleName();
+    final ResponseEntity<String> response = advice.handleEntityNotFoundException(ENF_EXC);
+
+    assertNotNull(response);
+    assertNotNull(response.getBody());
+
+    assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+    assertEquals(MediaType.APPLICATION_JSON, response.getHeaders().getContentType());
+
+    assertTrue(matchBody(response, simpleName));
+  }
+
+  @Test
+  void handleWorkflowNotFoundExceptionTest() {
+
+    final String simpleName = WorkflowNotFoundException.class.getSimpleName();
+    final ResponseEntity<String> response = advice.handleWorkflowNotFoundException(WNF_EXC);
+
+    assertNotNull(response);
+    assertNotNull(response.getBody());
+
+    assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+    assertEquals(MediaType.APPLICATION_JSON, response.getHeaders().getContentType());
+    assertTrue(matchBody(response, simpleName));
+  }
+
+  @Test
+  void handleWorkflowAlreadyActiveExceptionTest() {
+
+    final String simpleName = WorkflowAlreadyActiveException.class.getSimpleName();
+    final ResponseEntity<String> response = advice.handleWorkflowAlreadyActiveException(WAA_EXC);
+
+    assertNotNull(response);
+    assertNotNull(response.getBody());
+
+    assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
+    assertEquals(MediaType.APPLICATION_JSON, response.getHeaders().getContentType());
+    assertTrue(matchBody(response, simpleName));
+  }
+
+  @Test
+  void handleWorkflowDeploymentExceptionTest() {
+
+    final String simpleName = WorkflowDeploymentException.class.getSimpleName();
+    final ResponseEntity<String> response = advice.handleWorkflowDeploymentException(WD_EXC);
+
+    assertNotNull(response);
+    assertNotNull(response.getBody());
+
+    assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+    assertEquals(MediaType.APPLICATION_JSON, response.getHeaders().getContentType());
+    assertTrue(matchBody(response, simpleName));
+  }
+
+  @Test
+  void handleWorkflowEngineServiceExceptionTest() {
+
+    final String simpleName = WorkflowEngineServiceException.class.getSimpleName();
+    final ResponseEntity<String> response = advice.handleWorkflowEngineServiceException(WES_EXC);
+
+    assertNotNull(response);
+    assertNotNull(response.getBody());
+
+    assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+    assertEquals(MediaType.APPLICATION_JSON, response.getHeaders().getContentType());
+    assertTrue(matchBody(response, simpleName));
   }
 
   @ParameterizedTest
-  @MethodSource("provideExceptionsToMatchForActivateWorkflow")
-  void exceptionsThrownForActivateWorkflowTest(Exception exception, String simpleName, int status) throws Exception {
-    given(workflowController.activateWorkflow(any(), any(), any())).willAnswer(invocation -> { throw exception; });
+  @MethodSource("provideWorkflowImportExceptions")
+  void handleWorkflowImportExceptionTest(WorkflowImportException exception, String simpleName) {
 
-    MockHttpServletRequestBuilder request = appendHeaders(put(PATH_ACTIVATE, UUID), OKAPI_HEAD, APP_JSON, APP_JSON);
+    final ResponseEntity<String> response = advice.handleWorkflowImportException(exception);
 
-    MvcResult result = mvc.perform(appendBody(request, JSON_OBJECT))
-      .andDo(log()).andExpect(status().is(status)).andReturn();
+    assertNotNull(response);
+    assertNotNull(response.getBody());
 
-    Pattern pattern = Pattern.compile("\"type\":\"" + simpleName + "\"");
-    Matcher matcher = pattern.matcher(result.getResponse().getContentAsString());
-    assertTrue(matcher.find());
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    assertEquals(MediaType.APPLICATION_JSON, response.getHeaders().getContentType());
+    assertTrue(matchBody(response, simpleName));
   }
 
   /**
-   * Helper function for parameterized test providing the exceptions to be matched for activate workflow.
+   * Match the class simple name in the response.
+   *
+   * @param response The response to search.
+   * @param simpleName The class name to match.
+   *
+   * @return TRUE on match; FALSE otherwise.
+   */
+  private boolean matchBody(ResponseEntity<String> response, String simpleName) {
+
+    final Pattern pattern = Pattern.compile("\"type\":\"" + simpleName + "\"");
+    final Matcher matcher = pattern.matcher(response.getBody());
+
+    return matcher.find();
+  }
+
+  /**
+   * Helper function for parameterized test providing different types of WorkflowImportException.
    *
    * @return
    *   The arguments array stream with the stream columns as:
    *     - Exception exception.
    *     - String simpleName (exception name to match).
-   *     - int status (response HTTP status code for the exception).
    */
-  private static Stream<Arguments> provideExceptionsToMatchForActivateWorkflow() {
+  private static Stream<Arguments> provideWorkflowImportExceptions() {
+
     return Stream.of(
-      Arguments.of(new WorkflowNotFoundException(VALUE), WorkflowNotFoundException.class.getSimpleName(), 404),
-      Arguments.of(new EntityNotFoundException(), EntityNotFoundException.class.getSimpleName(), 404),
-      Arguments.of(new WorkflowAlreadyActiveException(VALUE), WorkflowAlreadyActiveException.class.getSimpleName(), 403),
-      Arguments.of(new WorkflowDeploymentException(), WorkflowDeploymentException.class.getSimpleName(), 500),
-      Arguments.of(new WorkflowEngineServiceException(VALUE), WorkflowEngineServiceException.class.getSimpleName(), 500),
-      Arguments.of(new WorkflowImportException(VALUE), WorkflowImportException.class.getSimpleName(), 400),
-      Arguments.of(new WorkflowImportAlreadyImported(VALUE), WorkflowImportAlreadyImported.class.getSimpleName(), 400),
-      Arguments.of(new WorkflowImportInvalidOrMissingProperty(VALUE, VALUE), WorkflowImportInvalidOrMissingProperty.class.getSimpleName(), 400),
-      Arguments.of(new WorkflowImportJsonFileIsDirectory(VALUE), WorkflowImportJsonFileIsDirectory.class.getSimpleName(), 400),
-      Arguments.of(new WorkflowImportRequiredFileMissing(VALUE), WorkflowImportRequiredFileMissing.class.getSimpleName(), 400)
+      Arguments.of(WIAI_EXC,   WorkflowImportAlreadyImported.class.getSimpleName()),
+      Arguments.of(WIIOMP_EXC, WorkflowImportInvalidOrMissingProperty.class.getSimpleName()),
+      Arguments.of(WIJFID_EXC, WorkflowImportJsonFileIsDirectory.class.getSimpleName()),
+      Arguments.of(WIRFM_EXC,  WorkflowImportRequiredFileMissing.class.getSimpleName())
     );
   }
+
 
 }

--- a/service/src/test/java/org/folio/rest/workflow/controller/advice/WorkflowControllerAdviceTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/controller/advice/WorkflowControllerAdviceTest.java
@@ -44,8 +44,6 @@ class WorkflowControllerAdviceTest {
 
   private static final WorkflowEngineServiceException WES_EXC = new WorkflowEngineServiceException(VALUE);
 
-  private static final WorkflowImportException WI_EXC = new WorkflowImportException(VALUE);
-
   private static final WorkflowImportAlreadyImported WIAI_EXC = new WorkflowImportAlreadyImported(VALUE);
 
   private static final WorkflowImportInvalidOrMissingProperty WIIOMP_EXC = new WorkflowImportInvalidOrMissingProperty(VALUE, VALUE);

--- a/service/src/test/java/org/folio/rest/workflow/model/ExtractedWorkflowTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/model/ExtractedWorkflowTest.java
@@ -4,7 +4,6 @@ import static org.folio.rest.workflow.model.ExtractedWorkflow.VERSION_PATTERN_1_
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -14,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import tools.jackson.databind.JsonNode;
 
 class ExtractedWorkflowTest {
 

--- a/service/src/test/java/org/folio/rest/workflow/service/OkapiDiscoveryServiceWithCustomPropertiesTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/service/OkapiDiscoveryServiceWithCustomPropertiesTest.java
@@ -5,8 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -15,7 +13,6 @@ import org.springframework.test.util.ReflectionTestUtils;
  *
  * This is expected to be empty as the OkapiDiscoveryServiceWithDefaultConfigTest() contains all of the tests.
  */
-@SpringBootTest(webEnvironment = WebEnvironment.MOCK)
 @TestPropertySource(properties = {
   "logging.level.org.folio.rest.workflow.service.OkapiDiscoveryService = DEBUG",
   "tenant.headerName = X-Okapi-Tenant",

--- a/service/src/test/java/org/folio/rest/workflow/service/OkapiDiscoveryServiceWithCustomPropertiesTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/service/OkapiDiscoveryServiceWithCustomPropertiesTest.java
@@ -3,10 +3,10 @@ package org.folio.rest.workflow.service;
 import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.util.ReflectionTestUtils;
+import tools.jackson.databind.JsonNode;
 
 /**
  * This runs the OkapiDiscoveryService tests when special application.yml settings need to be tested.

--- a/service/src/test/java/org/folio/rest/workflow/service/OkapiDiscoveryServiceWithDefaultPropertiesTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/service/OkapiDiscoveryServiceWithDefaultPropertiesTest.java
@@ -6,8 +6,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
@@ -25,6 +23,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.web.SpringJUnitWebConfig;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * This runs the OkapiDiscoveryService tests for when there is no properly configuration application.yml.

--- a/service/src/test/java/org/folio/rest/workflow/service/OkapiDiscoveryServiceWithDefaultPropertiesTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/service/OkapiDiscoveryServiceWithDefaultPropertiesTest.java
@@ -6,7 +6,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -60,7 +59,7 @@ class OkapiDiscoveryServiceWithDefaultPropertiesTest {
   protected Iterator<JsonNode> mockProvidesIter;
 
   @Test
-  void getHandlersWorksWithNoProvidesTest() throws IOException {
+  void getHandlersWorksWithNoProvidesTest() {
     mockJsonResponseEntity(mockJsonNode, 200);
 
     when(mockJsonNode.get(PROVIDES)).thenReturn(mockInterfaceNode);
@@ -73,7 +72,7 @@ class OkapiDiscoveryServiceWithDefaultPropertiesTest {
   }
 
   @Test
-  void getHandlersWorksWithNullProvidesTest() throws IOException {
+  void getHandlersWorksWithNullProvidesTest() {
     mockJsonResponseEntity(mockJsonNode, 200);
     when(mockJsonNode.get(PROVIDES)).thenReturn(null);
 

--- a/service/src/test/java/org/folio/rest/workflow/service/OkapiDiscoveryServiceWithDefaultPropertiesTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/service/OkapiDiscoveryServiceWithDefaultPropertiesTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
@@ -21,15 +22,21 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.junit.jupiter.web.SpringJUnitWebConfig;
 
 /**
  * This runs the OkapiDiscoveryService tests for when there is no properly configuration application.yml.
  *
  * Do no add additional settings loading or alterations to this test (such as @TestPropertySource).
  */
-@ExtendWith(SpringExtension.class)
+@ActiveProfiles("test")
+@SpringJUnitWebConfig({
+  ObjectMapper.class,
+  OkapiDiscoveryService.class,
+  HttpService.class
+})
 @ExtendWith(MockitoExtension.class)
 class OkapiDiscoveryServiceWithDefaultPropertiesTest {
 

--- a/service/src/test/java/org/folio/rest/workflow/service/WorkflowCqlServiceTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/service/WorkflowCqlServiceTest.java
@@ -6,8 +6,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.stream.Stream;
@@ -28,6 +26,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ObjectNode;
 
 @ExtendWith(SpringExtension.class)
 @ExtendWith(MockitoExtension.class)
@@ -56,7 +57,7 @@ class WorkflowCqlServiceTest {
 
     @Bean
     ObjectMapper objectMapper() {
-      return new ObjectMapper();
+      return JsonMapper.builder().build();
     }
   }
 

--- a/service/src/test/java/org/folio/rest/workflow/service/WorkflowEngineServiceTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/service/WorkflowEngineServiceTest.java
@@ -16,10 +16,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.folio.rest.workflow.dto.WorkflowDto;
 import org.folio.rest.workflow.dto.WorkflowOperationalDto;
@@ -33,13 +29,18 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.boot.restclient.RestTemplateBuilder;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.client.RestTemplate;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 
 @ExtendWith(SpringExtension.class)
 @ExtendWith(MockitoExtension.class)
@@ -62,7 +63,7 @@ class WorkflowEngineServiceTest {
   @BeforeEach
   void beforeEach() {
     workflowEngineService = new WorkflowEngineService(new RestTemplateBuilder());
-    mapper = new ObjectMapper();
+    mapper = JsonMapper.builder().build();
 
     workflow = new WorkflowAsDto();
     workflow.setId(UUID);

--- a/service/src/test/java/org/folio/rest/workflow/service/WorkflowImportServiceTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/service/WorkflowImportServiceTest.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import org.apache.commons.compress.archivers.ArchiveException;
 import org.apache.commons.compress.compressors.CompressorException;
+import org.folio.rest.workflow.config.JunitHelperWebMvcConfig;
 import org.folio.rest.workflow.exception.WorkflowImportAlreadyImported;
 import org.folio.rest.workflow.exception.WorkflowImportException;
 import org.folio.rest.workflow.exception.WorkflowImportInvalidOrMissingProperty;
@@ -26,17 +27,21 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.core.io.Resource;
 import org.springframework.data.domain.Page;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.junit.jupiter.web.SpringJUnitWebConfig;
 
-@SpringBootTest(webEnvironment = WebEnvironment.MOCK)
-@ExtendWith(MockitoExtension.class)
 @ActiveProfiles("test")
+@SpringJUnitWebConfig({
+  JunitHelperWebMvcConfig.class,
+  WorkflowImportService.class
+})
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(SpringExtension.class)
 class WorkflowImportServiceTest {
 
   private static final String WORKFLOW_UUID = "7dcd302f-a438-4ca5-a7eb-21653610d46f";

--- a/service/src/test/java/org/folio/rest/workflow/service/WorkflowImportServiceTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/service/WorkflowImportServiceTest.java
@@ -8,8 +8,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
-import org.apache.commons.compress.archivers.ArchiveException;
-import org.apache.commons.compress.compressors.CompressorException;
 import org.folio.rest.workflow.config.JunitHelperWebMvcConfig;
 import org.folio.rest.workflow.exception.WorkflowImportAlreadyImported;
 import org.folio.rest.workflow.exception.WorkflowImportException;
@@ -257,91 +255,91 @@ class WorkflowImportServiceTest {
   }
 
   @Test
-  void importFileWorksForBzip2Test() throws IOException, CompressorException, ArchiveException, WorkflowImportException {
+  void importFileWorksForBzip2Test() throws IOException, WorkflowImportException {
     Workflow imported = workflowImportService.importFile(fwzBzip2Resource);
     assertNotNull(imported);
     assertEquals(workflow.getId(), imported.getId());
   }
 
   @Test
-  void importFileWorksForBzip2AsBz2Test() throws IOException, CompressorException, ArchiveException, WorkflowImportException {
+  void importFileWorksForBzip2AsBz2Test() throws IOException, WorkflowImportException {
     Workflow imported = workflowImportService.importFile(fwzBzip2AsBz2Resource);
     assertNotNull(imported);
     assertEquals(workflow.getId(), imported.getId());
   }
 
   @Test
-  void importFileWorksForGzipTest() throws IOException, CompressorException, ArchiveException, WorkflowImportException {
+  void importFileWorksForGzipTest() throws IOException, WorkflowImportException {
     Workflow imported = workflowImportService.importFile(fwzGzipResource);
     assertNotNull(imported);
     assertEquals(workflow.getId(), imported.getId());
   }
 
   @Test
-  void importFileWorksForGzipAsGzTest() throws IOException, CompressorException, ArchiveException, WorkflowImportException {
+  void importFileWorksForGzipAsGzTest() throws IOException, WorkflowImportException {
     Workflow imported = workflowImportService.importFile(fwzGzipAsGzResource);
     assertNotNull(imported);
     assertEquals(workflow.getId(), imported.getId());
   }
 
   @Test
-  void importFileWorksForGzipWithBadVersionTest() throws IOException, CompressorException, ArchiveException, WorkflowImportException {
+  void importFileWorksForGzipWithBadVersionTest() throws IOException, WorkflowImportException {
     Workflow imported = workflowImportService.importFile(fwzGzipBadVersionResource);
     assertNotNull(imported);
     assertEquals(workflow.getId(), imported.getId());
   }
 
   @Test
-  void importFileWorksForGzipWithJavaTest() throws IOException, CompressorException, ArchiveException, WorkflowImportException {
+  void importFileWorksForGzipWithJavaTest() throws IOException, WorkflowImportException {
     Workflow imported = workflowImportService.importFile(fwzGzipJavaResource);
     assertNotNull(imported);
     assertEquals(workflow.getId(), imported.getId());
   }
 
   @Test
-  void importFileWorksForGzipWithOddFilesTest() throws IOException, CompressorException, ArchiveException, WorkflowImportException {
+  void importFileWorksForGzipWithOddFilesTest() throws IOException, WorkflowImportException {
     Workflow imported = workflowImportService.importFile(fwzGzipOddFilesResource);
     assertNotNull(imported);
     assertEquals(workflow.getId(), imported.getId());
   }
 
   @Test
-  void importFileWorksForGzipWithPythonTest() throws IOException, CompressorException, ArchiveException, WorkflowImportException {
+  void importFileWorksForGzipWithPythonTest() throws IOException, WorkflowImportException {
     Workflow imported = workflowImportService.importFile(fwzGzipPythonResource);
     assertNotNull(imported);
     assertEquals(workflow.getId(), imported.getId());
   }
 
   @Test
-  void importFileWorksForGzipWithRubyTest() throws IOException, CompressorException, ArchiveException, WorkflowImportException {
+  void importFileWorksForGzipWithRubyTest() throws IOException, WorkflowImportException {
     Workflow imported = workflowImportService.importFile(fwzGzipRubyResource);
     assertNotNull(imported);
     assertEquals(workflow.getId(), imported.getId());
   }
 
   @Test
-  void importFileWorksForGzipWithMissingVersionTest() throws IOException, CompressorException, ArchiveException, WorkflowImportException {
+  void importFileWorksForGzipWithMissingVersionTest() throws IOException, WorkflowImportException {
     Workflow imported = workflowImportService.importFile(fwzGzipMisVersionResource);
     assertNotNull(imported);
     assertEquals(workflow.getId(), imported.getId());
   }
 
   @Test
-  void importFileWorksForGzipWithUnknownVersionTest() throws IOException, CompressorException, ArchiveException, WorkflowImportException {
+  void importFileWorksForGzipWithUnknownVersionTest() throws IOException, WorkflowImportException {
     Workflow imported = workflowImportService.importFile(fwzGzipUnVerResource);
     assertNotNull(imported);
     assertEquals(workflow.getId(), imported.getId());
   }
 
   @Test
-  void importFileWorksForZipTest() throws IOException, CompressorException, ArchiveException, WorkflowImportException {
+  void importFileWorksForZipTest() throws IOException, WorkflowImportException {
     Workflow imported = workflowImportService.importFile(fwzZipResource);
     assertNotNull(imported);
     assertEquals(workflow.getId(), imported.getId());
   }
 
   @Test
-  void importFileWorksForZipAsZipTest() throws IOException, CompressorException, ArchiveException, WorkflowImportException {
+  void importFileWorksForZipAsZipTest() throws IOException, WorkflowImportException {
     Workflow imported = workflowImportService.importFile(fwzZipAsZipResource);
     assertNotNull(imported);
     assertEquals(workflow.getId(), imported.getId());

--- a/service/src/test/java/org/folio/rest/workflow/service/WorkflowImportServiceTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/service/WorkflowImportServiceTest.java
@@ -7,7 +7,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import org.apache.commons.compress.archivers.ArchiveException;
 import org.apache.commons.compress.compressors.CompressorException;
@@ -34,6 +33,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.junit.jupiter.web.SpringJUnitWebConfig;
+import tools.jackson.databind.ObjectMapper;
 
 @ActiveProfiles("test")
 @SpringJUnitWebConfig({

--- a/service/src/test/resources/application.yaml
+++ b/service/src/test/resources/application.yaml
@@ -19,9 +19,6 @@ server:
   port: 9101
   servlet:
     context-path: /
-    encoding:
-      charset: UTF-8
-      enabled: true
 
 spring:
   application.name: mod-workflow
@@ -42,6 +39,11 @@ spring:
     allow-circular-references: false
     banner-mode: console
     log-startup-info: true
+
+  servlet:
+    encoding:
+      charset: UTF-8
+      enabled: true
 
   sql:
     init:


### PR DESCRIPTION
Resolves [MODWRKFLOW-54](https://folio-org.atlassian.net/browse/MODWRKFLOW-54) .

This requires the updates spring-module-core.

This has been tested to work with current version of mod-camunda (before any Spring-Boot 4 changes).

The mod-camunda is not yet updated and there could potentially be follow up changes.

The CI will not pass due to dependencies to spring-module-core.
Once spring-module-core changes are updated and merged to main/master, then the CI can be re-run.