### PR TITLE
MODWRKFLOW-60: Use and support Java 25.

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,6 +17,7 @@ jobs:
 
     # Set settings due to this maven project acting as a library or dependency to other FOLIO modules.
     with:
+      java-version: '25'
 
       # The spring-module-core dependency currently only has snapshot releases.
       allow-snapshots-release: true

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,7 +17,6 @@ jobs:
 
     # Set settings due to this maven project acting as a library or dependency to other FOLIO modules.
     with:
-      java-version: '25'
 
       # The spring-module-core dependency currently only has snapshot releases.
       allow-snapshots-release: true

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -31,12 +31,6 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-rest</artifactId>
     </dependency>
-
-    <dependency>
-      <groupId>org.projectlombok</groupId>
-      <artifactId>lombok</artifactId>
-      <scope>provided</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/components/src/main/java/org/folio/rest/workflow/dto/Comparison.java
+++ b/components/src/main/java/org/folio/rest/workflow/dto/Comparison.java
@@ -1,11 +1,7 @@
 package org.folio.rest.workflow.dto;
 
 import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
-import lombok.Setter;
 
-@Getter
-@Setter
 public class Comparison {
 
   @NotNull
@@ -16,6 +12,34 @@ public class Comparison {
 
   public Comparison() {
     super();
+  }
+
+  /**
+   * @return the sourceProperty
+   */
+  public String getSourceProperty() {
+    return sourceProperty;
+  }
+
+  /**
+   * @return the targetProperty
+   */
+  public String getTargetProperty() {
+    return targetProperty;
+  }
+
+  /**
+   * @param sourceProperty the sourceProperty to set
+   */
+  public void setSourceProperty(String sourceProperty) {
+    this.sourceProperty = sourceProperty;
+  }
+
+  /**
+   * @param targetProperty the targetProperty to set
+   */
+  public void setTargetProperty(String targetProperty) {
+    this.targetProperty = targetProperty;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/dto/Mapping.java
+++ b/components/src/main/java/org/folio/rest/workflow/dto/Mapping.java
@@ -1,11 +1,7 @@
 package org.folio.rest.workflow.dto;
 
 import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
-import lombok.Setter;
 
-@Getter
-@Setter
 public class Mapping {
 
   @NotNull
@@ -21,6 +17,48 @@ public class Mapping {
     super();
 
     multiple = false;
+  }
+
+  /**
+   * @return the toProperty
+   */
+  public String getToProperty() {
+    return toProperty;
+  }
+
+  /**
+   * @return the fromProperty
+   */
+  public String getFromProperty() {
+    return fromProperty;
+  }
+
+  /**
+   * @return the multiple
+   */
+  public boolean isMultiple() {
+    return multiple;
+  }
+
+  /**
+   * @param toProperty the toProperty to set
+   */
+  public void setToProperty(String toProperty) {
+    this.toProperty = toProperty;
+  }
+
+  /**
+   * @param fromProperty the fromProperty to set
+   */
+  public void setFromProperty(String fromProperty) {
+    this.fromProperty = fromProperty;
+  }
+
+  /**
+   * @param multiple the multiple to set
+   */
+  public void setMultiple(boolean multiple) {
+    this.multiple = multiple;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/dto/Request.java
+++ b/components/src/main/java/org/folio/rest/workflow/dto/Request.java
@@ -1,13 +1,9 @@
 package org.folio.rest.workflow.dto;
 
 import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
-import lombok.Setter;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 
-@Getter
-@Setter
 public class Request {
 
   @NotNull
@@ -36,6 +32,118 @@ public class Request {
     accept = MediaType.APPLICATION_JSON_VALUE;
     bodyTemplate = "{}";
     iterable = false;
+  }
+
+  /**
+   * @return the url
+   */
+  public String getUrl() {
+    return url;
+  }
+
+  /**
+   * @return the method
+   */
+  public HttpMethod getMethod() {
+    return method;
+  }
+
+  /**
+   * @return the contentType
+   */
+  public String getContentType() {
+    return contentType;
+  }
+
+  /**
+   * @return the accept
+   */
+  public String getAccept() {
+    return accept;
+  }
+
+  /**
+   * @return the bodyTemplate
+   */
+  public String getBodyTemplate() {
+    return bodyTemplate;
+  }
+
+  /**
+   * @return the iterable
+   */
+  public boolean isIterable() {
+    return iterable;
+  }
+
+  /**
+   * @return the iterableKey
+   */
+  public String getIterableKey() {
+    return iterableKey;
+  }
+
+  /**
+   * @return the responseKey
+   */
+  public String getResponseKey() {
+    return responseKey;
+  }
+
+  /**
+   * @param url the url to set
+   */
+  public void setUrl(String url) {
+    this.url = url;
+  }
+
+  /**
+   * @param method the method to set
+   */
+  public void setMethod(HttpMethod method) {
+    this.method = method;
+  }
+
+  /**
+   * @param contentType the contentType to set
+   */
+  public void setContentType(String contentType) {
+    this.contentType = contentType;
+  }
+
+  /**
+   * @param accept the accept to set
+   */
+  public void setAccept(String accept) {
+    this.accept = accept;
+  }
+
+  /**
+   * @param bodyTemplate the bodyTemplate to set
+   */
+  public void setBodyTemplate(String bodyTemplate) {
+    this.bodyTemplate = bodyTemplate;
+  }
+
+  /**
+   * @param iterable the iterable to set
+   */
+  public void setIterable(boolean iterable) {
+    this.iterable = iterable;
+  }
+
+  /**
+   * @param iterableKey the iterableKey to set
+   */
+  public void setIterableKey(String iterableKey) {
+    this.iterableKey = iterableKey;
+  }
+
+  /**
+   * @param responseKey the responseKey to set
+   */
+  public void setResponseKey(String responseKey) {
+    this.responseKey = responseKey;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/AbstractGateway.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/AbstractGateway.java
@@ -9,8 +9,6 @@ import jakarta.persistence.OrderColumn;
 import jakarta.persistence.PrePersist;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.Getter;
-import lombok.Setter;
 import org.folio.rest.workflow.enums.Direction;
 import org.folio.rest.workflow.model.components.Gateway;
 import org.folio.rest.workflow.model.has.HasNodes;
@@ -18,14 +16,10 @@ import org.folio.rest.workflow.model.has.HasNodes;
 @MappedSuperclass
 public abstract class AbstractGateway extends Node implements Gateway, HasNodes {
 
-  @Getter
-  @Setter
   @Column(nullable = false)
   @Enumerated(EnumType.STRING)
   private Direction direction;
 
-  @Getter
-  @Setter
   @OneToMany
   @OrderColumn
   private List<Node> nodes;
@@ -49,6 +43,26 @@ public abstract class AbstractGateway extends Node implements Gateway, HasNodes 
     if (nodes == null) {
       nodes = new ArrayList<>();
     }
+  }
+
+  @Override
+  public Direction getDirection() {
+    return direction;
+  }
+
+  @Override
+  public void setDirection(Direction direction) {
+    this.direction = direction;
+  }
+
+  @Override
+  public List<Node> getNodes() {
+    return nodes;
+  }
+
+  @Override
+  public void setNodes(List<Node> nodes) {
+    this.nodes = nodes;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/AbstractProcess.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/AbstractProcess.java
@@ -7,8 +7,6 @@ import jakarta.persistence.OrderColumn;
 import jakarta.persistence.PrePersist;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.Getter;
-import lombok.Setter;
 import org.folio.rest.workflow.model.has.HasAsync;
 import org.folio.rest.workflow.model.has.HasNodes;
 import org.hibernate.annotations.ColumnDefault;
@@ -21,20 +19,14 @@ import org.hibernate.annotations.ColumnDefault;
 @MappedSuperclass
 public abstract class AbstractProcess extends Node implements HasAsync, HasNodes {
 
-  @Getter
-  @Setter
   @Column(nullable = false)
   @ColumnDefault("false")
   private Boolean asyncAfter;
 
-  @Getter
-  @Setter
   @Column(nullable = false)
   @ColumnDefault("false")
   private Boolean asyncBefore;
 
-  @Getter
-  @Setter
   @OneToMany
   @OrderColumn
   private List<Node> nodes;
@@ -63,6 +55,36 @@ public abstract class AbstractProcess extends Node implements HasAsync, HasNodes
     if (nodes == null) {
       nodes = new ArrayList<>();
     }
+  }
+
+  @Override
+  public List<Node> getNodes() {
+    return nodes;
+  }
+
+  @Override
+  public void setNodes(List<Node> nodes) {
+    this.nodes = nodes;
+  }
+
+  @Override
+  public Boolean getAsyncAfter() {
+    return asyncAfter;
+  }
+
+  @Override
+  public Boolean getAsyncBefore() {
+    return asyncBefore;
+  }
+
+  @Override
+  public void setAsyncAfter(Boolean asyncAfter) {
+    this.asyncAfter = asyncAfter;
+  }
+
+  @Override
+  public void setAsyncBefore(Boolean asyncBefore) {
+    this.asyncBefore = asyncBefore;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/AbstractTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/AbstractTask.java
@@ -7,8 +7,6 @@ import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.PrePersist;
 import java.util.HashSet;
 import java.util.Set;
-import lombok.Getter;
-import lombok.Setter;
 import org.folio.rest.workflow.model.components.Task;
 import org.folio.rest.workflow.model.converter.EmbeddedVariableConverter;
 import org.folio.rest.workflow.model.has.HasInputOutput;
@@ -22,25 +20,17 @@ import org.hibernate.annotations.ColumnDefault;
 @MappedSuperclass
 public abstract class AbstractTask extends Node implements HasInputOutput, Task {
 
-  @Getter
-  @Setter
   @Column(nullable = false)
   @ColumnDefault("false")
   private Boolean asyncAfter;
 
-  @Getter
-  @Setter
   @Column(nullable = false)
   @ColumnDefault("false")
   private Boolean asyncBefore;
 
-  @Getter
-  @Setter
   @ElementCollection
   private Set<EmbeddedVariable> inputVariables;
 
-  @Getter
-  @Setter
   @Column(columnDefinition = "TEXT", nullable = true)
   @Convert(converter = EmbeddedVariableConverter.class)
   private EmbeddedVariable outputVariable;
@@ -69,6 +59,46 @@ public abstract class AbstractTask extends Node implements HasInputOutput, Task 
     if (inputVariables == null) {
       inputVariables = new HashSet<>();
     }
+  }
+
+  @Override
+  public Boolean getAsyncAfter() {
+    return asyncAfter;
+  }
+
+  @Override
+  public Boolean getAsyncBefore() {
+    return asyncBefore;
+  }
+
+  @Override
+  public void setAsyncAfter(Boolean asyncAfter) {
+    this.asyncAfter = asyncAfter;
+  }
+
+  @Override
+  public void setAsyncBefore(Boolean asyncBefore) {
+    this.asyncBefore = asyncBefore;
+  }
+
+  @Override
+  public Set<EmbeddedVariable> getInputVariables() {
+    return inputVariables;
+  }
+
+  @Override
+  public EmbeddedVariable getOutputVariable() {
+    return outputVariable;
+  }
+
+  @Override
+  public void setInputVariables(Set<EmbeddedVariable> inputVariables) {
+    this.inputVariables = inputVariables;
+  }
+
+  @Override
+  public void setOutputVariable(EmbeddedVariable outputVariable) {
+    this.outputVariable = outputVariable;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/CompressFileTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/CompressFileTask.java
@@ -5,8 +5,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.PrePersist;
-import lombok.Getter;
-import lombok.Setter;
 import org.folio.rest.workflow.enums.CompressFileContainer;
 import org.folio.rest.workflow.enums.CompressFileFormat;
 import org.folio.rest.workflow.model.components.DelegateTask;
@@ -15,24 +13,16 @@ import org.folio.rest.workflow.model.has.common.HasCompressFileTaskCommon;
 @Entity
 public class CompressFileTask extends AbstractTask implements DelegateTask, HasCompressFileTaskCommon {
 
-  @Getter
-  @Setter
   @Column(nullable = false)
   private String source;
 
-  @Getter
-  @Setter
   @Column(nullable = false)
   private String destination;
 
-  @Getter
-  @Setter
   @Enumerated(EnumType.STRING)
   @Column(nullable = false)
   private CompressFileFormat format;
 
-  @Getter
-  @Setter
   @Enumerated(EnumType.STRING)
   @Column(nullable = false)
   private CompressFileContainer container;
@@ -66,6 +56,46 @@ public class CompressFileTask extends AbstractTask implements DelegateTask, HasC
     if (container == null) {
       container = CompressFileContainer.NONE;
     }
+  }
+
+  @Override
+  public CompressFileContainer getContainer() {
+    return container;
+  }
+
+  @Override
+  public String getDestination() {
+    return destination;
+  }
+
+  @Override
+  public CompressFileFormat getFormat() {
+    return format;
+  }
+
+  @Override
+  public String getSource() {
+    return source;
+  }
+
+  @Override
+  public void setContainer(CompressFileContainer container) {
+    this.container = container;
+  }
+
+  @Override
+  public void setDestination(String destination) {
+    this.destination = destination;
+  }
+
+  @Override
+  public void setFormat(CompressFileFormat format) {
+    this.format = format;
+  }
+
+  @Override
+  public void setSource(String source) {
+    this.source = source;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/Condition.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/Condition.java
@@ -5,22 +5,16 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.PrePersist;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import lombok.Getter;
-import lombok.Setter;
 import org.folio.rest.workflow.model.components.Conditional;
 
 @Entity
 public class Condition extends Node implements Conditional {
 
-  @Getter
-  @Setter
   @NotNull
   @Size(min = 2, max = 64)
   @Column(nullable = false)
   private String answer;
 
-  @Getter
-  @Setter
   @NotNull
   @Size(min = 4, max = 128)
   @Column(nullable = false)
@@ -45,6 +39,26 @@ public class Condition extends Node implements Conditional {
     if (expression == null) {
       expression = "";
     }
+  }
+
+  @Override
+  public String getAnswer() {
+    return answer;
+  }
+
+  @Override
+  public void setAnswer(String answer) {
+    this.answer = answer;
+  }
+
+  @Override
+  public String getExpression() {
+    return expression;
+  }
+
+  @Override
+  public void setExpression(String expression) {
+    this.expression = expression;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/ConnectTo.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/ConnectTo.java
@@ -4,15 +4,11 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.PrePersist;
 import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
-import lombok.Setter;
 import org.folio.rest.workflow.model.components.Navigation;
 
 @Entity
 public class ConnectTo extends Node implements Navigation {
 
-  @Getter
-  @Setter
   @NotNull
   @Column(nullable = false)
   private String nodeId;
@@ -31,6 +27,16 @@ public class ConnectTo extends Node implements Navigation {
     if (nodeId == null) {
       nodeId = "";
     }
+  }
+
+  @Override
+  public String getNodeId() {
+    return nodeId;
+  }
+
+  @Override
+  public void setNodeId(String nodeId) {
+    this.nodeId = nodeId;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/DatabaseConnectionTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/DatabaseConnectionTask.java
@@ -3,8 +3,6 @@ package org.folio.rest.workflow.model;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.PrePersist;
-import lombok.Getter;
-import lombok.Setter;
 import org.folio.rest.workflow.model.components.DelegateTask;
 import org.folio.rest.workflow.model.has.HasDesignation;
 import org.folio.rest.workflow.model.has.HasPassword;
@@ -14,23 +12,15 @@ import org.folio.rest.workflow.model.has.HasUsername;
 @Entity
 public class DatabaseConnectionTask extends AbstractTask implements DelegateTask, HasDesignation, HasPassword, HasUrl, HasUsername {
 
-  @Getter
-  @Setter
   @Column(nullable = false)
   private String designation;
 
-  @Getter
-  @Setter
   @Column(nullable = true)
   private String password;
 
-  @Getter
-  @Setter
   @Column(nullable = false)
   private String url;
 
-  @Getter
-  @Setter
   @Column(nullable = true)
   private String username;
 
@@ -53,6 +43,46 @@ public class DatabaseConnectionTask extends AbstractTask implements DelegateTask
     if (url == null) {
       url = "";
     }
+  }
+
+  @Override
+  public String getUsername() {
+    return username;
+  }
+
+  @Override
+  public void setUsername(String username) {
+    this.username = username;
+  }
+
+  @Override
+  public String getUrl() {
+    return url;
+  }
+
+  @Override
+  public void setUrl(String url) {
+    this.url = url;
+  }
+
+  @Override
+  public String getPassword() {
+    return password;
+  }
+
+  @Override
+  public void setPassword(String password) {
+    this.password = password;
+  }
+
+  @Override
+  public String getDesignation() {
+    return designation;
+  }
+
+  @Override
+  public void setDesignation(String designation) {
+    this.designation = designation;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/DatabaseDisconnectTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/DatabaseDisconnectTask.java
@@ -3,16 +3,12 @@ package org.folio.rest.workflow.model;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.PrePersist;
-import lombok.Getter;
-import lombok.Setter;
 import org.folio.rest.workflow.model.components.DelegateTask;
 import org.folio.rest.workflow.model.has.HasDesignation;
 
 @Entity
 public class DatabaseDisconnectTask extends AbstractTask implements DelegateTask, HasDesignation {
 
-  @Getter
-  @Setter
   @Column(nullable = false)
   private String designation;
 
@@ -30,6 +26,16 @@ public class DatabaseDisconnectTask extends AbstractTask implements DelegateTask
     if (designation == null) {
       designation = "";
     }
+  }
+
+  @Override
+  public String getDesignation() {
+    return designation;
+  }
+
+  @Override
+  public void setDesignation(String designation) {
+    this.designation = designation;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/DatabaseQueryTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/DatabaseQueryTask.java
@@ -5,8 +5,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.PrePersist;
-import lombok.Getter;
-import lombok.Setter;
 import org.folio.rest.workflow.enums.DatabaseResultType;
 import org.folio.rest.workflow.model.components.DelegateTask;
 import org.folio.rest.workflow.model.has.HasDesignation;
@@ -16,29 +14,19 @@ import org.hibernate.annotations.ColumnDefault;
 @Entity
 public class DatabaseQueryTask extends AbstractTask implements DelegateTask, HasDatabaseQueryTaskCommon, HasDesignation {
 
-  @Getter
-  @Setter
   @Column(nullable = false)
   private String designation;
 
-  @Getter
-  @Setter
   @Column(nullable = true)
   private String outputPath;
 
-  @Getter
-  @Setter
   @Column(columnDefinition = "TEXT", nullable = false)
   private String query;
 
-  @Getter
-  @Setter
   @Enumerated(EnumType.STRING)
   @Column(nullable = true)
   private DatabaseResultType resultType;
 
-  @Getter
-  @Setter
   @Column(nullable = true)
   @ColumnDefault("false")
   private Boolean includeHeader;
@@ -67,6 +55,56 @@ public class DatabaseQueryTask extends AbstractTask implements DelegateTask, Has
     if (includeHeader == null) {
       includeHeader = false;
     }
+  }
+
+  @Override
+  public String getDesignation() {
+    return designation;
+  }
+
+  @Override
+  public void setDesignation(String designation) {
+    this.designation = designation;
+  }
+
+  @Override
+  public Boolean getIncludeHeader() {
+    return includeHeader;
+  }
+
+  @Override
+  public String getOutputPath() {
+    return outputPath;
+  }
+
+  @Override
+  public String getQuery() {
+    return query;
+  }
+
+  @Override
+  public DatabaseResultType getResultType() {
+    return resultType;
+  }
+
+  @Override
+  public void setIncludeHeader(Boolean includeHeader) {
+    this.includeHeader = includeHeader;
+  }
+
+  @Override
+  public void setOutputPath(String outputPath) {
+    this.outputPath = outputPath;
+  }
+
+  @Override
+  public void setQuery(String query) {
+    this.query = query;
+  }
+
+  @Override
+  public void setResultType(DatabaseResultType resultType) {
+    this.resultType = resultType;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/DirectoryTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/DirectoryTask.java
@@ -6,29 +6,22 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.PrePersist;
 import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
-import lombok.Setter;
 import org.folio.rest.workflow.enums.DirectoryAction;
 import org.folio.rest.workflow.model.components.DelegateTask;
+import org.folio.rest.workflow.model.has.HasPath;
 import org.folio.rest.workflow.model.has.common.HasDirectoryTaskCommon;
 
 @Entity
-public class DirectoryTask extends AbstractTask implements DelegateTask, HasDirectoryTaskCommon {
+public class DirectoryTask extends AbstractTask implements DelegateTask, HasDirectoryTaskCommon, HasPath {
 
-  @Getter
-  @Setter
   @NotNull
   @Column(nullable = false)
   private String path;
 
-  @Getter
-  @Setter
   @NotNull
   @Column(nullable = false)
   private String workflow;
 
-  @Getter
-  @Setter
   @NotNull
   @Column(nullable = false)
   @Enumerated(EnumType.STRING)
@@ -58,6 +51,36 @@ public class DirectoryTask extends AbstractTask implements DelegateTask, HasDire
     if (action == null) {
       action = DirectoryAction.LIST;
     }
+  }
+
+  @Override
+  public DirectoryAction getAction() {
+    return action;
+  }
+
+  @Override
+  public String getWorkflow() {
+    return workflow;
+  }
+
+  @Override
+  public void setAction(DirectoryAction action) {
+    this.action = action;
+  }
+
+  @Override
+  public void setWorkflow(String workflow) {
+    this.workflow = workflow;
+  }
+
+  @Override
+  public String getPath() {
+    return path;
+  }
+
+  @Override
+  public void setPath(String path) {
+    this.path = path;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/EmailTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/EmailTask.java
@@ -4,8 +4,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.PrePersist;
 import jakarta.validation.constraints.Size;
-import lombok.Getter;
-import lombok.Setter;
 import org.folio.rest.workflow.model.components.DelegateTask;
 import org.folio.rest.workflow.model.has.common.HasEmailTaskCommon;
 import org.jspecify.annotations.NonNull;
@@ -13,54 +11,36 @@ import org.jspecify.annotations.NonNull;
 @Entity
 public class EmailTask extends AbstractTask implements DelegateTask, HasEmailTaskCommon {
 
-  @Getter
-  @Setter
   @Column(nullable = true)
   private String attachmentPath;
 
-  @Getter
-  @Setter
   @Column(nullable = true)
   private String includeAttachment;
 
-  @Getter
-  @Setter
   @Column(nullable = true)
   private String mailBcc;
 
-  @Getter
-  @Setter
   @Column(nullable = true)
   private String mailCc;
 
-  @Getter
-  @Setter
   @NonNull
   @Size(min = 3, max = 256)
   @Column(nullable = false)
   private String mailFrom;
 
-  @Getter
-  @Setter
   @NonNull
   @Size(min = 2)
   @Column(columnDefinition = "TEXT", nullable = false)
   private String mailText;
 
-  @Getter
-  @Setter
   @NonNull
   @Size(min = 3, max = 256)
   @Column(nullable = false)
   private String mailTo;
 
-  @Getter
-  @Setter
   @Column(columnDefinition = "TEXT", nullable = true)
   private String mailMarkup;
 
-  @Getter
-  @Setter
   @NonNull
   @Size(min = 2, max = 256)
   @Column(nullable = false)
@@ -95,6 +75,96 @@ public class EmailTask extends AbstractTask implements DelegateTask, HasEmailTas
     if (mailSubject == null) {
       mailSubject = "";
     }
+  }
+
+  @Override
+  public String getAttachmentPath() {
+    return attachmentPath;
+  }
+
+  @Override
+  public String getIncludeAttachment() {
+    return includeAttachment;
+  }
+
+  @Override
+  public String getMailBcc() {
+    return mailBcc;
+  }
+
+  @Override
+  public String getMailCc() {
+    return mailCc;
+  }
+
+  @Override
+  public String getMailFrom() {
+    return mailFrom;
+  }
+
+  @Override
+  public String getMailMarkup() {
+    return mailMarkup;
+  }
+
+  @Override
+  public String getMailSubject() {
+    return mailSubject;
+  }
+
+  @Override
+  public String getMailText() {
+    return mailText;
+  }
+
+  @Override
+  public String getMailTo() {
+    return mailTo;
+  }
+
+  @Override
+  public void setAttachmentPath(String attachmentPath) {
+    this.attachmentPath = attachmentPath;
+  }
+
+  @Override
+  public void setIncludeAttachment(String includeAttachment) {
+    this.includeAttachment = includeAttachment;
+  }
+
+  @Override
+  public void setMailBcc(String mailBcc) {
+    this.mailBcc = mailBcc;
+  }
+
+  @Override
+  public void setMailCc(String mailCc) {
+    this.mailCc = mailCc;
+  }
+
+  @Override
+  public void setMailFrom(String mailFrom) {
+    this.mailFrom = mailFrom;
+  }
+
+  @Override
+  public void setMailMarkup(String mailMarkup) {
+    this.mailMarkup = mailMarkup;
+  }
+
+  @Override
+  public void setMailSubject(String mailSubject) {
+    this.mailSubject = mailSubject;
+  }
+
+  @Override
+  public void setMailText(String mailText) {
+    this.mailText = mailText;
+  }
+
+  @Override
+  public void setMailTo(String mailTo) {
+    this.mailTo = mailTo;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/EmbeddedInput.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/EmbeddedInput.java
@@ -8,8 +8,6 @@ import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.Getter;
-import lombok.Setter;
 import org.folio.rest.workflow.enums.InputAttribute;
 import org.folio.rest.workflow.enums.InputType;
 import org.folio.rest.workflow.model.converter.InputAttributeListConverter;
@@ -20,42 +18,28 @@ import org.hibernate.annotations.ColumnDefault;
 @Embeddable
 public class EmbeddedInput implements HasEmbeddedInputCommon {
 
-  @Getter
-  @Setter
   @Column(columnDefinition = "TEXT", nullable = false)
   @Convert(converter = InputAttributeListConverter.class)
   private List<InputAttribute> attributes;
 
-  @Getter
-  @Setter
   @Column(nullable = true)
   private String defaultValue;
 
-  @Getter
-  @Setter
   @Column(nullable = false)
   private String fieldId;
 
-  @Getter
-  @Setter
   @Column(nullable = false)
   private String fieldLabel;
 
-  @Getter
-  @Setter
   @NotNull
   @Column(nullable = false)
   @Enumerated(EnumType.STRING)
   private InputType inputType;
 
-  @Getter
-  @Setter
   @Column(columnDefinition = "TEXT", nullable = false)
   @Convert(converter = StringListConverter.class)
   private List<String> options;
 
-  @Getter
-  @Setter
   @Column(nullable = false)
   @ColumnDefault("false")
   private Boolean required;
@@ -95,6 +79,76 @@ public class EmbeddedInput implements HasEmbeddedInputCommon {
     if (required == null) {
       required = false;
     }
+  }
+
+  @Override
+  public List<InputAttribute> getAttributes() {
+    return attributes;
+  }
+
+  @Override
+  public String getDefaultValue() {
+    return defaultValue;
+  }
+
+  @Override
+  public String getFieldId() {
+    return fieldId;
+  }
+
+  @Override
+  public String getFieldLabel() {
+    return fieldLabel;
+  }
+
+  @Override
+  public InputType getInputType() {
+    return inputType;
+  }
+
+  @Override
+  public List<String> getOptions() {
+    return options;
+  }
+
+  @Override
+  public Boolean getRequired() {
+    return required;
+  }
+
+  @Override
+  public void setAttributes(List<InputAttribute> attributes) {
+    this.attributes = attributes;
+  }
+
+  @Override
+  public void setDefaultValue(String defaultValue) {
+    this.defaultValue = defaultValue;
+  }
+
+  @Override
+  public void setFieldId(String fieldId) {
+    this.fieldId = fieldId;
+  }
+
+  @Override
+  public void setFieldLabel(String fieldLabel) {
+    this.fieldLabel = fieldLabel;
+  }
+
+  @Override
+  public void setInputType(InputType inputType) {
+    this.inputType = inputType;
+  }
+
+  @Override
+  public void setOptions(List<String> options) {
+    this.options = options;
+  }
+
+  @Override
+  public void setRequired(Boolean required) {
+    this.required = required;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/EmbeddedLoopReference.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/EmbeddedLoopReference.java
@@ -4,36 +4,24 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.PrePersist;
 import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
-import lombok.Setter;
 import org.folio.rest.workflow.model.has.common.HasEmbeddedLoopReferenceCommon;
 import org.hibernate.annotations.ColumnDefault;
 
 @Embeddable
 public class EmbeddedLoopReference implements HasEmbeddedLoopReferenceCommon {
 
-  @Getter
-  @Setter
   @Column(nullable = true)
   private String cardinalityExpression;
 
-  @Getter
-  @Setter
   @Column(nullable = true)
   private String completeConditionExpression;
 
-  @Getter
-  @Setter
   @Column(nullable = true)
   private String dataInputRefExpression;
 
-  @Getter
-  @Setter
   @Column(nullable = true)
   private String inputDataName;
 
-  @Getter
-  @Setter
   @NotNull
   @Column(nullable = false)
   @ColumnDefault("false")
@@ -65,6 +53,56 @@ public class EmbeddedLoopReference implements HasEmbeddedLoopReferenceCommon {
   @Override
   public boolean hasDataInput() {
     return dataInputRefExpression != null && inputDataName != null;
+  }
+
+  @Override
+  public String getCardinalityExpression() {
+    return cardinalityExpression;
+  }
+
+  @Override
+  public String getCompleteConditionExpression() {
+    return completeConditionExpression;
+  }
+
+  @Override
+  public String getDataInputRefExpression() {
+    return dataInputRefExpression;
+  }
+
+  @Override
+  public String getInputDataName() {
+    return inputDataName;
+  }
+
+  @Override
+  public Boolean getParallel() {
+    return parallel;
+  }
+
+  @Override
+  public void setCardinalityExpression(String cardinalityExpression) {
+    this.cardinalityExpression = cardinalityExpression;
+  }
+
+  @Override
+  public void setCompleteConditionExpression(String completeConditionExpression) {
+    this.completeConditionExpression = completeConditionExpression;
+  }
+
+  @Override
+  public void setDataInputRefExpression(String dataInputRefExpression) {
+    this.dataInputRefExpression = dataInputRefExpression;
+  }
+
+  @Override
+  public void setInputDataName(String inputDataName) {
+    this.inputDataName = inputDataName;
+  }
+
+  @Override
+  public void setParallel(Boolean parallel) {
+    this.parallel = parallel;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/EmbeddedProcessor.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/EmbeddedProcessor.java
@@ -7,39 +7,27 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.PrePersist;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import lombok.Getter;
-import lombok.Setter;
 import org.folio.rest.workflow.enums.ScriptType;
 import org.folio.rest.workflow.model.has.common.HasEmbeddedProcessorCommon;
 
 @Embeddable
 public class EmbeddedProcessor implements HasEmbeddedProcessorCommon {
 
-  @Getter
-  @Setter
   @Column(nullable = false)
   private Integer buffer;
 
-  @Getter
-  @Setter
   @NotNull
   @Column(columnDefinition = "TEXT", nullable = false)
   private String code;
 
-  @Getter
-  @Setter
   @Column(nullable = false)
   private Integer delay;
 
-  @Getter
-  @Setter
   @NotNull
   @Size(min = 4, max = 128)
   @Column(nullable = false)
   private String functionName;
 
-  @Getter
-  @Setter
   @NotNull
   @Column(nullable = false)
   @Enumerated(EnumType.STRING)
@@ -71,6 +59,56 @@ public class EmbeddedProcessor implements HasEmbeddedProcessorCommon {
     if (functionName == null) {
       functionName = "";
     }
+  }
+
+  @Override
+  public Integer getBuffer() {
+    return buffer;
+  }
+
+  @Override
+  public String getCode() {
+    return code;
+  }
+
+  @Override
+  public Integer getDelay() {
+    return delay;
+  }
+
+  @Override
+  public String getFunctionName() {
+    return functionName;
+  }
+
+  @Override
+  public ScriptType getScriptType() {
+    return scriptType;
+  }
+
+  @Override
+  public void setBuffer(Integer buffer) {
+    this.buffer = buffer;
+  }
+
+  @Override
+  public void setCode(String code) {
+    this.code = code;
+  }
+
+  @Override
+  public void setDelay(Integer delay) {
+    this.delay = delay;
+  }
+
+  @Override
+  public void setFunctionName(String functionName) {
+    this.functionName = functionName;
+  }
+
+  @Override
+  public void setScriptType(ScriptType scriptType) {
+    this.scriptType = scriptType;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/EmbeddedRequest.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/EmbeddedRequest.java
@@ -6,53 +6,36 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.PrePersist;
 import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
-import lombok.Setter;
 import org.folio.rest.workflow.enums.HttpMethod;
+import org.folio.rest.workflow.model.has.HasUrl;
 import org.folio.rest.workflow.model.has.common.HasEmbeddedRequestCommon;
 import org.springframework.http.MediaType;
 
 @Embeddable
-public class EmbeddedRequest implements HasEmbeddedRequestCommon {
+public class EmbeddedRequest implements HasEmbeddedRequestCommon, HasUrl {
 
-  @Getter
-  @Setter
   @NotNull
   @Column(nullable = false)
   private String accept;
 
-  @Getter
-  @Setter
   @Column(columnDefinition = "TEXT", nullable = false)
   private String bodyTemplate;
 
-  @Getter
-  @Setter
   @NotNull
   @Column(nullable = false)
   private String contentType;
 
-  @Getter
-  @Setter
   private boolean iterable;
 
-  @Getter
-  @Setter
   private String iterableKey;
 
-  @Getter
-  @Setter
   @NotNull
   @Column(nullable = false)
   @Enumerated(EnumType.STRING)
   private HttpMethod method;
 
-  @Getter
-  @Setter
   private String responseKey;
 
-  @Getter
-  @Setter
   @NotNull
   @Column(nullable = false)
   private String url;
@@ -89,6 +72,86 @@ public class EmbeddedRequest implements HasEmbeddedRequestCommon {
     if (url == null) {
       url = "";
     }
+  }
+
+  @Override
+  public String getAccept() {
+    return accept;
+  }
+
+  @Override
+  public String getBodyTemplate() {
+    return bodyTemplate;
+  }
+
+  @Override
+  public String getContentType() {
+    return contentType;
+  }
+
+  @Override
+  public boolean getIterable() {
+    return iterable;
+  }
+
+  @Override
+  public String getIterableKey() {
+    return iterableKey;
+  }
+
+  @Override
+  public void setAccept(String accept) {
+    this.accept = accept;
+  }
+
+  @Override
+  public void setBodyTemplate(String bodyTemplate) {
+    this.bodyTemplate = bodyTemplate;
+  }
+
+  @Override
+  public void setContentType(String contentType) {
+    this.contentType = contentType;
+  }
+
+  @Override
+  public void setIterable(boolean iterable) {
+    this.iterable = iterable;
+  }
+
+  @Override
+  public void setIterableKey(String iterableKey) {
+    this.iterableKey = iterableKey;
+  }
+
+  @Override
+  public HttpMethod getMethod() {
+    return method;
+  }
+
+  @Override
+  public String getResponseKey() {
+    return responseKey;
+  }
+
+  @Override
+  public void setMethod(HttpMethod method) {
+    this.method = method;
+  }
+
+  @Override
+  public void setResponseKey(String responseKey) {
+    this.responseKey = responseKey;
+  }
+
+  @Override
+  public String getUrl() {
+    return url;
+  }
+
+  @Override
+  public void setUrl(String url) {
+    this.url = url;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/EmbeddedVariable.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/EmbeddedVariable.java
@@ -7,8 +7,6 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.PrePersist;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import lombok.Getter;
-import lombok.Setter;
 import org.folio.rest.workflow.enums.VariableType;
 import org.folio.rest.workflow.model.has.common.HasEmbeddedVariableCommon;
 import org.hibernate.annotations.ColumnDefault;
@@ -16,39 +14,27 @@ import org.hibernate.annotations.ColumnDefault;
 @Embeddable
 public class EmbeddedVariable implements HasEmbeddedVariableCommon {
 
-  @Getter
-  @Setter
   @NotNull
   @Size(min = 4, max = 64)
   @Column(name = "vkey", nullable = true)
   private String key;
 
-  @Getter
-  @Setter
   @Column(nullable = false)
   @Enumerated(EnumType.STRING)
   private VariableType type;
 
-  @Getter
-  @Setter
   @Column(nullable = false)
   @ColumnDefault("false")
   private Boolean spin;
 
-  @Getter
-  @Setter
   @Column(nullable = false)
   @ColumnDefault("false")
   private Boolean asArray;
 
-  @Getter
-  @Setter
   @Column(nullable = false)
   @ColumnDefault("false")
   private Boolean asJson;
 
-  @Getter
-  @Setter
   @Column(nullable = false)
   @ColumnDefault("false")
   private Boolean asTransient;
@@ -84,6 +70,66 @@ public class EmbeddedVariable implements HasEmbeddedVariableCommon {
     if (type == null) {
       type = VariableType.PROCESS;
     }
+  }
+
+  @Override
+  public Boolean getAsArray() {
+    return asArray;
+  }
+
+  @Override
+  public Boolean getAsJson() {
+    return asJson;
+  }
+
+  @Override
+  public Boolean getAsTransient() {
+    return asTransient;
+  }
+
+  @Override
+  public VariableType getType() {
+    return type;
+  }
+
+  @Override
+  public String getKey() {
+    return key;
+  }
+
+  @Override
+  public Boolean getSpin() {
+    return spin;
+  }
+
+  @Override
+  public void setAsArray(Boolean asArray) {
+    this.asArray = asArray;
+  }
+
+  @Override
+  public void setAsJson(Boolean asJson) {
+    this.asJson = asJson;
+  }
+
+  @Override
+  public void setAsTransient(Boolean asTransient) {
+    this.asTransient = asTransient;
+  }
+
+  @Override
+  public void setType(VariableType type) {
+    this.type = type;
+  }
+
+  @Override
+  public void setKey(String key) {
+    this.key = key;
+  }
+
+  @Override
+  public void setSpin(Boolean spin) {
+    this.spin = spin;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/FileTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/FileTask.java
@@ -5,33 +5,24 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.PrePersist;
-import lombok.Getter;
-import lombok.Setter;
 import org.folio.rest.workflow.enums.FileOp;
 import org.folio.rest.workflow.model.components.DelegateTask;
+import org.folio.rest.workflow.model.has.HasPath;
 import org.folio.rest.workflow.model.has.common.HasFileTaskCommon;
 
 @Entity
-public class FileTask extends AbstractTask implements DelegateTask, HasFileTaskCommon {
+public class FileTask extends AbstractTask implements DelegateTask, HasFileTaskCommon, HasPath {
 
-  @Getter
-  @Setter
   @Column(nullable = true)
   private String line;
 
-  @Getter
-  @Setter
   @Enumerated(EnumType.STRING)
   @Column(nullable = false)
   private FileOp op;
 
-  @Getter
-  @Setter
   @Column(nullable = false)
   private String path;
 
-  @Getter
-  @Setter
   @Column(nullable = true)
   private String target;
 
@@ -54,6 +45,46 @@ public class FileTask extends AbstractTask implements DelegateTask, HasFileTaskC
     if (path == null) {
       path = "";
     }
+  }
+
+  @Override
+  public String getLine() {
+    return line;
+  }
+
+  @Override
+  public FileOp getOp() {
+    return op;
+  }
+
+  @Override
+  public String getTarget() {
+    return target;
+  }
+
+  @Override
+  public void setLine(String line) {
+    this.line = line;
+  }
+
+  @Override
+  public void setOp(FileOp op) {
+    this.op = op;
+  }
+
+  @Override
+  public void setTarget(String target) {
+    this.target = target;
+  }
+
+  @Override
+  public String getPath() {
+    return path;
+  }
+
+  @Override
+  public void setPath(String path) {
+    this.path = path;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/FtpTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/FtpTask.java
@@ -5,8 +5,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.PrePersist;
-import lombok.Getter;
-import lombok.Setter;
 import org.folio.rest.workflow.enums.SftpOp;
 import org.folio.rest.workflow.model.components.DelegateTask;
 import org.folio.rest.workflow.model.has.HasPassword;
@@ -17,44 +15,28 @@ import org.folio.rest.workflow.model.has.common.HasFtpTaskCommon;
 @Entity
 public class FtpTask extends AbstractTask implements DelegateTask, HasFtpTaskCommon, HasPassword, HasService, HasUsername {
 
-  @Getter
-  @Setter
   @Column(nullable = false)
   private String destinationPath;
 
-  @Getter
-  @Setter
   @Column(nullable = false)
   private String host;
 
-  @Getter
-  @Setter
   @Enumerated(EnumType.STRING)
   @Column(nullable = false)
   private SftpOp op;
 
-  @Getter
-  @Setter
   @Column(nullable = false)
   private String originPath;
 
-  @Getter
-  @Setter
   @Column(nullable = true)
   private String password;
 
-  @Getter
-  @Setter
   @Column(nullable = false)
   private Integer port;
 
-  @Getter
-  @Setter
   @Column(nullable = false)
   private String scheme;
 
-  @Getter
-  @Setter
   @Column(nullable = true)
   private String username;
 
@@ -108,6 +90,86 @@ public class FtpTask extends AbstractTask implements DelegateTask, HasFtpTaskCom
   @Override
   public void setBasePath(String basePath) {
     // This is currently not used.
+  }
+
+  @Override
+  public String getUsername() {
+    return username;
+  }
+
+  @Override
+  public void setUsername(String username) {
+    this.username = username;
+  }
+
+  @Override
+  public String getHost() {
+    return host;
+  }
+
+  @Override
+  public Integer getPort() {
+    return port;
+  }
+
+  @Override
+  public String getScheme() {
+    return scheme;
+  }
+
+  @Override
+  public void setHost(String host) {
+    this.host = host;
+  }
+
+  @Override
+  public void setPort(Integer port) {
+    this.port = port;
+  }
+
+  @Override
+  public void setScheme(String scheme) {
+    this.scheme = scheme;
+  }
+
+  @Override
+  public String getPassword() {
+    return password;
+  }
+
+  @Override
+  public void setPassword(String password) {
+    this.password = password;
+  }
+
+  @Override
+  public String getDestinationPath() {
+    return destinationPath;
+  }
+
+  @Override
+  public SftpOp getOp() {
+    return op;
+  }
+
+  @Override
+  public String getOriginPath() {
+    return originPath;
+  }
+
+  @Override
+  public void setDestinationPath(String destinationPath) {
+    this.destinationPath = destinationPath;
+  }
+
+  @Override
+  public void setOp(SftpOp op) {
+    this.op = op;
+  }
+
+  @Override
+  public void setOriginPath(String originPath) {
+    this.originPath = originPath;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/InputTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/InputTask.java
@@ -5,14 +5,11 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.PrePersist;
 import java.util.HashSet;
 import java.util.Set;
-import lombok.Getter;
-import lombok.Setter;
+import org.folio.rest.workflow.model.has.HasInputs;
 
 @Entity
-public class InputTask extends AbstractTask {
+public class InputTask extends AbstractTask implements HasInputs {
 
-  @Getter
-  @Setter
   @ElementCollection
   private Set<EmbeddedInput> inputs;
 
@@ -30,6 +27,16 @@ public class InputTask extends AbstractTask {
     if (inputs == null) {
       inputs = new HashSet<>();
     }
+  }
+
+  @Override
+  public Set<EmbeddedInput> getInputs() {
+    return inputs;
+  }
+
+  @Override
+  public void setInputs(Set<EmbeddedInput> inputs) {
+    this.inputs = inputs;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/MoveToNode.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/MoveToNode.java
@@ -8,22 +8,16 @@ import jakarta.persistence.PrePersist;
 import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.Getter;
-import lombok.Setter;
 import org.folio.rest.workflow.model.components.Branch;
 import org.folio.rest.workflow.model.has.common.HasMoveToNodeCommon;
 
 @Entity
 public class MoveToNode extends Node implements Branch, HasMoveToNodeCommon {
 
-  @Getter
-  @Setter
   @NotNull
   @Column(nullable = false)
   private String gatewayId;
 
-  @Getter
-  @Setter
   @OneToMany
   @OrderColumn
   private List<Node> nodes;
@@ -47,6 +41,26 @@ public class MoveToNode extends Node implements Branch, HasMoveToNodeCommon {
     if (nodes == null) {
       nodes = new ArrayList<>();
     }
+  }
+
+  @Override
+  public List<Node> getNodes() {
+    return nodes;
+  }
+
+  @Override
+  public void setNodes(List<Node> nodes) {
+    this.nodes = nodes;
+  }
+
+  @Override
+  public String getGatewayId() {
+    return gatewayId;
+  }
+
+  @Override
+  public void setGatewayId(String gatewayId) {
+    this.gatewayId = gatewayId;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/Node.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/Node.java
@@ -9,8 +9,6 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.PrePersist;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import lombok.Getter;
-import lombok.Setter;
 import org.folio.rest.workflow.model.converter.JsonNodeConverter;
 import org.folio.rest.workflow.model.has.HasId;
 import org.folio.rest.workflow.model.has.HasInformational;
@@ -22,21 +20,15 @@ import org.folio.spring.domain.model.AbstractBaseEntity;
 @Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
 public abstract class Node extends AbstractBaseEntity implements HasId, HasInformational, HasName, HasNodeCommon, NodeInterface {
 
-  @Getter
-  @Setter
   @NotNull
   @Size(min = 3, max = 64)
   @Column(nullable = false)
   private String name;
 
-  @Getter
-  @Setter
   @Size(min = 0, max = 512)
   @Column(nullable = true)
   private String description;
 
-  @Getter
-  @Setter
   @JsonProperty(access = JsonProperty.Access.READ_ONLY)
   @Convert(converter = JsonNodeConverter.class, attributeName = "deserializeAs")
   private String deserializeAs = this.getClass().getSimpleName();
@@ -59,6 +51,36 @@ public abstract class Node extends AbstractBaseEntity implements HasId, HasInfor
     String replacement = "$1_$2";
     String name = getClass().getSimpleName();
     return String.format("%s_%s", name.replaceAll(regex, replacement).toLowerCase(), getId().replace("-", "_"));
+  }
+
+  @Override
+  public String getDeserializeAs() {
+    return deserializeAs;
+  }
+
+  @Override
+  public void setDeserializeAs(String deserializeAs) {
+    this.deserializeAs = deserializeAs;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public String getDescription() {
+    return description;
+  }
+
+  @Override
+  public void setDescription(String description) {
+    this.description = description;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/ProcessorTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/ProcessorTask.java
@@ -2,21 +2,27 @@ package org.folio.rest.workflow.model;
 
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
-import lombok.Getter;
-import lombok.Setter;
 import org.folio.rest.workflow.model.components.DelegateTask;
 import org.folio.rest.workflow.model.has.common.HasProcessorTaskCommon;
 
 @Entity
 public class ProcessorTask extends AbstractTask implements DelegateTask, HasProcessorTaskCommon {
 
-  @Getter
-  @Setter
   @Embedded
   private EmbeddedProcessor processor;
 
   public ProcessorTask() {
     super();
+  }
+
+  @Override
+  public EmbeddedProcessor getProcessor() {
+    return processor;
+  }
+
+  @Override
+  public void setProcessor(EmbeddedProcessor processor) {
+    this.processor = processor;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/ReceiveTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/ReceiveTask.java
@@ -5,15 +5,11 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.PrePersist;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import lombok.Getter;
-import lombok.Setter;
 import org.folio.rest.workflow.model.components.Wait;
 
 @Entity
 public class ReceiveTask extends AbstractTask implements Wait {
 
-  @Getter
-  @Setter
   @NotNull
   @Size(min = 4, max = 256)
   @Column(nullable = false)
@@ -33,6 +29,16 @@ public class ReceiveTask extends AbstractTask implements Wait {
     if (message == null) {
       message = "";
     }
+  }
+
+  @Override
+  public String getMessage() {
+    return message;
+  }
+
+  @Override
+  public void setMessage(String message) {
+    this.message = message;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/RequestTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/RequestTask.java
@@ -5,21 +5,15 @@ import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import java.util.HashSet;
 import java.util.Set;
-import lombok.Getter;
-import lombok.Setter;
 import org.folio.rest.workflow.model.components.DelegateTask;
 import org.folio.rest.workflow.model.has.common.HasRequestTaskCommon;
 
 @Entity
 public class RequestTask extends AbstractTask implements DelegateTask, HasRequestTaskCommon {
 
-  @Getter
-  @Setter
   @ElementCollection
   private Set<EmbeddedVariable> headerOutputVariables;
 
-  @Getter
-  @Setter
   @Embedded
   private EmbeddedRequest request;
 
@@ -27,6 +21,26 @@ public class RequestTask extends AbstractTask implements DelegateTask, HasReques
     super();
 
     headerOutputVariables = new HashSet<>();
+  }
+
+  @Override
+  public Set<EmbeddedVariable> getHeaderOutputVariables() {
+    return headerOutputVariables;
+  }
+
+  @Override
+  public EmbeddedRequest getRequest() {
+    return request;
+  }
+
+  @Override
+  public void setHeaderOutputVariables(Set<EmbeddedVariable> headerOutputVariables) {
+    this.headerOutputVariables = headerOutputVariables;
+  }
+
+  @Override
+  public void setRequest(EmbeddedRequest request) {
+    this.request = request;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/ScriptTask.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/ScriptTask.java
@@ -4,27 +4,19 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.PrePersist;
 import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
-import lombok.Setter;
 import org.folio.rest.workflow.model.has.HasCode;
 import org.folio.rest.workflow.model.has.common.HasScriptTaskCommon;
 
 @Entity
 public class ScriptTask extends AbstractTask implements HasCode, HasScriptTaskCommon {
 
-  @Getter
-  @Setter
   @NotNull
   @Column(columnDefinition = "TEXT", nullable = false)
   private String code;
 
-  @Getter
-  @Setter
   @Column(nullable = true)
   private String resultVariable;
 
-  @Getter
-  @Setter
   @Column(nullable = false)
   private String scriptFormat;
 
@@ -51,6 +43,36 @@ public class ScriptTask extends AbstractTask implements HasCode, HasScriptTaskCo
 
   public boolean hasResultVariable() {
     return resultVariable != null;
+  }
+
+  @Override
+  public String getResultVariable() {
+    return resultVariable;
+  }
+
+  @Override
+  public String getScriptFormat() {
+    return scriptFormat;
+  }
+
+  @Override
+  public void setResultVariable(String resultVariable) {
+    this.resultVariable = resultVariable;
+  }
+
+  @Override
+  public void setScriptFormat(String scriptFormat) {
+    this.scriptFormat = scriptFormat;
+  }
+
+  @Override
+  public String getCode() {
+    return code;
+  }
+
+  @Override
+  public void setCode(String code) {
+    this.code = code;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/Setup.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/Setup.java
@@ -3,22 +3,16 @@ package org.folio.rest.workflow.model;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.PrePersist;
-import lombok.Getter;
-import lombok.Setter;
 import org.folio.rest.workflow.model.has.HasAsync;
 import org.hibernate.annotations.ColumnDefault;
 
 @Embeddable
 public class Setup implements HasAsync {
 
-  @Getter
-  @Setter
   @Column(nullable = false)
   @ColumnDefault("false")
   private Boolean asyncAfter;
 
-  @Getter
-  @Setter
   @Column(nullable = false)
   @ColumnDefault("false")
   private Boolean asyncBefore;
@@ -39,6 +33,26 @@ public class Setup implements HasAsync {
     if (asyncBefore == null) {
       asyncBefore = false;
     }
+  }
+
+  @Override
+  public Boolean getAsyncAfter() {
+    return asyncAfter;
+  }
+
+  @Override
+  public Boolean getAsyncBefore() {
+    return asyncBefore;
+  }
+
+  @Override
+  public void setAsyncAfter(Boolean asyncAfter) {
+    this.asyncAfter = asyncAfter;
+  }
+
+  @Override
+  public void setAsyncBefore(Boolean asyncBefore) {
+    this.asyncBefore = asyncBefore;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/StartEvent.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/StartEvent.java
@@ -7,35 +7,29 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.PrePersist;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import lombok.Getter;
-import lombok.Setter;
 import org.folio.rest.workflow.enums.StartEventType;
 import org.folio.rest.workflow.model.components.Event;
+import org.folio.rest.workflow.model.has.HasAsyncBefore;
+import org.folio.rest.workflow.model.has.HasExpression;
+import org.folio.rest.workflow.model.has.HasInterrupting;
+import org.folio.rest.workflow.model.has.HasStartEventType;
 import org.hibernate.annotations.ColumnDefault;
 
 @Entity
-public class StartEvent extends Node implements Event {
+public class StartEvent extends Node implements Event, HasAsyncBefore, HasExpression, HasInterrupting, HasStartEventType {
 
-  @Getter
-  @Setter
   @Column(nullable = false)
   @ColumnDefault("false")
   private Boolean asyncBefore;
 
-  @Getter
-  @Setter
   @Size(min = 4, max = 256)
   @Column(nullable = true)
   private String expression;
 
-  @Getter
-  @Setter
   @Column(nullable = false)
   @ColumnDefault("false")
   private Boolean interrupting;
 
-  @Getter
-  @Setter
   @NotNull
   @Column(nullable = false)
   @Enumerated(EnumType.STRING)
@@ -65,6 +59,46 @@ public class StartEvent extends Node implements Event {
     if (type == null) {
       type = StartEventType.NONE;
     }
+  }
+
+  @Override
+  public String getExpression() {
+    return expression;
+  }
+
+  @Override
+  public void setExpression(String expression) {
+    this.expression = expression;
+  }
+
+  @Override
+  public Boolean getInterrupting() {
+    return interrupting;
+  }
+
+  @Override
+  public void setInterrupting(Boolean interrupting) {
+    this.interrupting = interrupting;
+  }
+
+  @Override
+  public StartEventType getType() {
+    return type;
+  }
+
+  @Override
+  public void setType(StartEventType type) {
+    this.type = type;
+  }
+
+  @Override
+  public Boolean getAsyncBefore() {
+    return asyncBefore;
+  }
+
+  @Override
+  public void setAsyncBefore(Boolean asyncBefore) {
+    this.asyncBefore = asyncBefore;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/Subprocess.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/Subprocess.java
@@ -7,22 +7,17 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.PrePersist;
 import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
-import lombok.Setter;
 import org.folio.rest.workflow.enums.SubprocessType;
 import org.folio.rest.workflow.model.components.Branch;
 import org.folio.rest.workflow.model.components.MultiInstance;
+import org.folio.rest.workflow.model.has.HasSubProcessType;
 
 @Entity
-public class Subprocess extends AbstractProcess implements Branch, MultiInstance {
+public class Subprocess extends AbstractProcess implements Branch, HasSubProcessType, MultiInstance {
 
-  @Getter
-  @Setter
   @Embedded
   private EmbeddedLoopReference loopRef;
 
-  @Getter
-  @Setter
   @NotNull
   @Column(nullable = false)
   @Enumerated(EnumType.STRING)
@@ -42,6 +37,26 @@ public class Subprocess extends AbstractProcess implements Branch, MultiInstance
     if (type == null) {
       type = SubprocessType.EMBEDDED;
     }
+  }
+
+  @Override
+  public EmbeddedLoopReference getLoopRef() {
+    return loopRef;
+  }
+
+  @Override
+  public void setLoopRef(EmbeddedLoopReference loopRef) {
+    this.loopRef = loopRef;
+  }
+
+  @Override
+  public SubprocessType getType() {
+    return type;
+  }
+
+  @Override
+  public void setType(SubprocessType type) {
+    this.type = type;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/Workflow.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/Workflow.java
@@ -19,8 +19,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import lombok.Getter;
-import lombok.Setter;
 import org.folio.rest.workflow.model.converter.JsonNodeConverter;
 import org.folio.rest.workflow.model.has.HasDeploymentId;
 import org.folio.rest.workflow.model.has.HasId;
@@ -38,31 +36,21 @@ import tools.jackson.databind.JsonNode;
 @JsonIgnoreProperties({ "hibernateLazyInitializer", "handler" })
 public class Workflow extends AbstractBaseEntity implements HasDeploymentId, HasId, HasInformational, HasName, HasNodes, HasVersionTag, HasWorkflowCommon {
 
-  @Getter
-  @Setter
   @Column(nullable = true)
   @ColumnDefault("false")
   private Boolean active;
 
-  @Getter
-  @Setter
   @Column(unique = true)
   private String deploymentId;
 
-  @Getter
-  @Setter
   @Size(min = 0, max = 512)
   @Column(nullable = true)
   private String description;
 
-  @Getter
-  @Setter
   @Min(0)
   @Column(nullable = false)
   private Integer historyTimeToLive;
 
-  @Getter
-  @Setter
   @ElementCollection
   @CollectionTable(name = "workflow_initial_context", joinColumns = @JoinColumn(name = "workflow_id"))
   @MapKeyColumn(name = "context_key")
@@ -70,27 +58,19 @@ public class Workflow extends AbstractBaseEntity implements HasDeploymentId, Has
   @Convert(converter = JsonNodeConverter.class, attributeName = "value")
   private Map<String, JsonNode> initialContext;
 
-  @Getter
-  @Setter
   @NotNull
   @Size(min = 4, max = 64)
   @Column(nullable = false, unique = true)
   private String name;
 
-  @Getter
-  @Setter
   @OneToMany
   @OrderColumn
   private List<Node> nodes;
 
-  @Getter
-  @Setter
   @Embedded
   private Setup setup;
 
   @Version
-  @Getter
-  @Setter
   @NotNull
   @Size(min = 1, max = 64)
   @Column(nullable = false)
@@ -132,6 +112,96 @@ public class Workflow extends AbstractBaseEntity implements HasDeploymentId, Has
     if (versionTag == null) {
       versionTag = "1.0";
     }
+  }
+
+  @Override
+  public Boolean getActive() {
+    return active;
+  }
+
+  @Override
+  public Integer getHistoryTimeToLive() {
+    return historyTimeToLive;
+  }
+
+  @Override
+  public Map<String, JsonNode> getInitialContext() {
+    return initialContext;
+  }
+
+  @Override
+  public Setup getSetup() {
+    return setup;
+  }
+
+  @Override
+  public String getVersionTag() {
+    return versionTag;
+  }
+
+  @Override
+  public List<Node> getNodes() {
+    return nodes;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String getDescription() {
+    return description;
+  }
+
+  @Override
+  public String getDeploymentId() {
+    return deploymentId;
+  }
+
+  @Override
+  public void setActive(Boolean active) {
+    this.active = active;
+  }
+
+  @Override
+  public void setHistoryTimeToLive(Integer historyTimeToLive) {
+    this.historyTimeToLive = historyTimeToLive;
+  }
+
+  @Override
+  public void setInitialContext(Map<String, JsonNode> initialContext) {
+    this.initialContext = initialContext;
+  }
+
+  @Override
+  public void setSetup(Setup setup) {
+    this.setup = setup;
+  }
+
+  @Override
+  public void setVersionTag(String versionTag) {
+    this.versionTag = versionTag;
+  }
+
+  @Override
+  public void setNodes(List<Node> nodes) {
+    this.nodes = nodes;
+  }
+
+  @Override
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  @Override
+  public void setDeploymentId(String deploymentId) {
+    this.deploymentId = deploymentId;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/has/HasAsync.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/HasAsync.java
@@ -5,12 +5,6 @@ package org.folio.rest.workflow.model.has;
  *
  * This should likely be changed in some way once the Camunda-specific functionality is refactored out.
  */
-public interface HasAsync {
-
-  public Boolean getAsyncAfter();
-  public Boolean getAsyncBefore();
-
-  public void setAsyncAfter(Boolean asyncAfter);
-  public void setAsyncBefore(Boolean asyncBefore);
+public interface HasAsync extends HasAsyncAfter, HasAsyncBefore {
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/has/HasAsyncAfter.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/HasAsyncAfter.java
@@ -1,0 +1,12 @@
+package org.folio.rest.workflow.model.has;
+
+/**
+ * The Camunda-specific asyncAfter field.
+ */
+public interface HasAsyncAfter {
+
+  public Boolean getAsyncAfter();
+
+  public void setAsyncAfter(Boolean asyncAfter);
+
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/HasAsyncBefore.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/HasAsyncBefore.java
@@ -1,0 +1,12 @@
+package org.folio.rest.workflow.model.has;
+
+/**
+ * The Camunda-specific asyncBefore field.
+ */
+public interface HasAsyncBefore {
+
+  public Boolean getAsyncBefore();
+
+  public void setAsyncBefore(Boolean asyncBefore);
+
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/HasInputs.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/HasInputs.java
@@ -1,0 +1,14 @@
+package org.folio.rest.workflow.model.has;
+
+import java.util.Set;
+import org.folio.rest.workflow.model.EmbeddedInput;
+
+/**
+ * This interface provides the Inputs methods.
+ */
+public interface HasInputs {
+
+  public Set<EmbeddedInput> getInputs();
+
+  public void setInputs(Set<EmbeddedInput> inputs);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/HasInterrupting.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/HasInterrupting.java
@@ -1,0 +1,11 @@
+package org.folio.rest.workflow.model.has;
+
+/**
+ * This interface provides the Interrupting methods.
+ */
+public interface HasInterrupting {
+
+  public Boolean getInterrupting();
+
+  public void setInterrupting(Boolean interrupting);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/HasMessage.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/HasMessage.java
@@ -7,5 +7,5 @@ public interface HasMessage {
 
   public String getMessage();
 
-  public void setMessage(String mesasge);
+  public void setMessage(String message);
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/has/HasStartEventType.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/HasStartEventType.java
@@ -1,0 +1,13 @@
+package org.folio.rest.workflow.model.has;
+
+import org.folio.rest.workflow.enums.StartEventType;
+
+/**
+ * This interface provides methods associated with {@link org.folio.rest.workflow.enums.StartEventType StartEventType}.
+ */
+public interface HasStartEventType {
+
+  public StartEventType getType();
+
+  public void setType(StartEventType type);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/HasSubProcessType.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/HasSubProcessType.java
@@ -1,0 +1,13 @@
+package org.folio.rest.workflow.model.has;
+
+import org.folio.rest.workflow.enums.SubprocessType;
+
+/**
+ * This interface provides methods associated with {@link org.folio.rest.workflow.enums.SubprocessType SubprocessType}.
+ */
+public interface HasSubProcessType {
+
+  public SubprocessType getType();
+
+  public void setType(SubprocessType type);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/common/HasEmbeddedInputCommon.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/common/HasEmbeddedInputCommon.java
@@ -17,7 +17,7 @@ public interface HasEmbeddedInputCommon {
   public List<String> getOptions();
   public Boolean getRequired();
 
-  public void setAttributes(List<InputAttribute> attribues);
+  public void setAttributes(List<InputAttribute> attributes);
   public void setDefaultValue(String defaultValue);
   public void setFieldId(String fieldId);
   public void setFieldLabel(String fieldLabel);

--- a/components/src/main/java/org/folio/rest/workflow/model/has/common/HasEmbeddedRequestCommon.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/common/HasEmbeddedRequestCommon.java
@@ -10,10 +10,10 @@ public interface HasEmbeddedRequestCommon {
   public String getAccept();
   public String getBodyTemplate();
   public String getContentType();
+  public boolean getIterable();
   public String getIterableKey();
   public HttpMethod getMethod();
   public String getResponseKey() ;
-  public boolean isIterable();
 
   public void setAccept(String accept);
   public void setBodyTemplate(String bodyTemplate);

--- a/components/src/test/java/org/folio/rest/workflow/model/EmbeddedRequestTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/EmbeddedRequestTest.java
@@ -14,7 +14,6 @@ import static org.springframework.test.util.ReflectionTestUtils.setField;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
-
 import org.folio.rest.workflow.enums.HttpMethod;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -110,7 +109,7 @@ class EmbeddedRequestTest {
   void getIterableWorksTest() {
     setField(embeddedRequest, "iterable", true);
 
-    assertEquals(true, embeddedRequest.isIterable());
+    assertEquals(true, embeddedRequest.getIterable());
   }
 
   @Test

--- a/components/src/test/java/org/folio/rest/workflow/model/components/MultiInstanceTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/components/MultiInstanceTest.java
@@ -6,8 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 import java.util.stream.Stream;
-import lombok.Getter;
-import lombok.Setter;
 import org.folio.rest.workflow.model.EmbeddedLoopReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -39,9 +37,17 @@ class MultiInstanceTest {
 
   private static class Impl implements MultiInstance {
 
-    @Getter
-    @Setter
     private EmbeddedLoopReference loopRef;
+
+    @Override
+    public EmbeddedLoopReference getLoopRef() {
+      return loopRef;
+    }
+
+    @Override
+    public void setLoopRef(EmbeddedLoopReference loopRef) {
+      this.loopRef = loopRef;
+    }
   };
 
   /**

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,13 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <spring-module-core.version>2.2.0-SNAPSHOT</spring-module-core.version>
     <maven.javadoc.skip>true</maven.javadoc.skip>
+
+    <!-- Remove SonarQube duplicate code coverage due to false positives. -->
+    <sonar.cpd.exclusions>
+      **/model/AbstractTask.java,
+      **/model/AbstractProcess.java,
+      **/model/Setup.java
+    </sonar.cpd.exclusions>
   </properties>
 
   <build>

--- a/service/descriptors/ModuleDescriptor-template.json
+++ b/service/descriptors/ModuleDescriptor-template.json
@@ -484,6 +484,7 @@
       { "name": "DB_USERNAME", "value": "folio_admin", "description": "Postgres user name." },
       { "name": "DB_PASSWORD", "value": "folio_admin", "description": "Postgres user name password." },
       { "name": "DB_DATABASE", "value": "okapi_modules", "description": "Postgres database name." },
+      { "name": "DB_SCHEMA", "value": "diku_mod_camunda", "description": "The database schema name." },
       { "name": "DB_QUERYTIMEOUT", "value": "60000", "description": "Database query timeout." },
       { "name": "DB_CHARSET", "value": "UTF-8", "description": "Database charset." },
       { "name": "DB_MAXPOOLSIZE", "value": "16", "description": "Database max pool size." },

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -92,12 +92,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.projectlombok</groupId>
-      <artifactId>lombok</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
        <groupId>org.apache.commons</groupId>
        <artifactId>commons-compress</artifactId>
        <version>1.28.0</version>

--- a/service/src/main/java/org/folio/rest/workflow/controller/WorkflowController.java
+++ b/service/src/main/java/org/folio/rest/workflow/controller/WorkflowController.java
@@ -178,10 +178,7 @@ public class WorkflowController {
   private String sanitize(JsonNode param) {
     if (param == null) return "";
 
-    return param
-      .toPrettyString()
-      .replaceAll("[^\\p{C}]", "")
-      .replaceAll("[\r\n]", " ");
+    return sanitize(param.toPrettyString());
   }
 
 }

--- a/service/src/main/java/org/folio/rest/workflow/controller/WorkflowController.java
+++ b/service/src/main/java/org/folio/rest/workflow/controller/WorkflowController.java
@@ -34,7 +34,7 @@ import tools.jackson.databind.JsonNode;
 @RequestMapping("/workflows")
 public class WorkflowController {
 
-  private final static Log LOG = LogFactory.getLog(WorkflowController.class);
+  private static final Log LOG = LogFactory.getLog(WorkflowController.class);
 
   private WorkflowEngineService workflowEngineService;
 
@@ -73,7 +73,7 @@ public class WorkflowController {
     @RequestParam(defaultValue="20") Integer limit,
     @TenantHeader String tenant
   ) {
-    LOG.debug(String.format("Performing CQL search: {}, offset, limit", query, offset, limit));
+    LOG.debug(String.format("Performing CQL search: %s, %s, %s", query, offset, limit));
     return workflowCqlService.findByCql(query, offset, limit);
   }
 
@@ -92,7 +92,7 @@ public class WorkflowController {
     @TenantHeader String tenant,
     @TokenHeader String token
   ) throws WorkflowEngineServiceException, WorkflowNotFoundException {
-    LOG.info(String.format("Activating: {}", id));
+    LOG.info(String.format("Activating: %s", id));
 
     workflowEngineService.exists(id);
 
@@ -105,7 +105,7 @@ public class WorkflowController {
     @TenantHeader String tenant,
     @TokenHeader String token
   ) throws WorkflowEngineServiceException, WorkflowNotFoundException {
-    LOG.info(String.format("Deactivating: {}", id));
+    LOG.info(String.format("Deactivating: %s", id));
 
     workflowEngineService.exists(id);
 
@@ -118,7 +118,7 @@ public class WorkflowController {
     @TenantHeader String tenant,
     @TokenHeader String token
   ) throws WorkflowEngineServiceException, WorkflowNotFoundException {
-    LOG.info(String.format("Deleting: {}", id));
+    LOG.info(String.format("Deleting: %s", id));
 
     workflowEngineService.exists(id);
 
@@ -134,7 +134,7 @@ public class WorkflowController {
     @TenantHeader String tenant,
     @TokenHeader String token
   ) throws WorkflowEngineServiceException {
-    LOG.debug(String.format("Retrieving History: {}", id));
+    LOG.debug(String.format("Retrieving History: %s", id));
     return workflowEngineService.history(id, tenant, token);
   }
 
@@ -145,7 +145,7 @@ public class WorkflowController {
     @TokenHeader String token,
     @RequestBody JsonNode context
   ) throws WorkflowEngineServiceException {
-    LOG.info(String.format("Starting: {} with context {}", id, context));
+    LOG.info(String.format("Starting: %s with context %s", id, context));
     return workflowEngineService.start(id, tenant, token, context);
   }
 

--- a/service/src/main/java/org/folio/rest/workflow/controller/WorkflowController.java
+++ b/service/src/main/java/org/folio/rest/workflow/controller/WorkflowController.java
@@ -36,6 +36,9 @@ public class WorkflowController {
 
   private static final Log LOG = LogFactory.getLog(WorkflowController.class);
 
+  private static final String REGX_NOT_GRAPH = "[^\\p{C}]";
+  private static final String REGX_EOL = "[\r\n]";
+
   private WorkflowEngineService workflowEngineService;
 
   private WorkflowCqlService workflowCqlService;
@@ -162,8 +165,8 @@ public class WorkflowController {
     if (param == null) return "";
 
     return param
-      .replaceAll("[^\\p{C}]", "")
-      .replaceAll("[\r\n]", " ");
+      .replaceAll(REGX_NOT_GRAPH, "")
+      .replaceAll(REGX_EOL, " ");
   }
 
   /**

--- a/service/src/main/java/org/folio/rest/workflow/controller/WorkflowController.java
+++ b/service/src/main/java/org/folio/rest/workflow/controller/WorkflowController.java
@@ -73,7 +73,7 @@ public class WorkflowController {
     @RequestParam(defaultValue="20") Integer limit,
     @TenantHeader String tenant
   ) {
-    LOG.debug(String.format("Performing CQL search: %s, %s, %s", query, offset, limit));
+    LOG.debug(String.format("Performing CQL search: %s, %s, %s", sanitize(query), offset, limit));
     return workflowCqlService.findByCql(query, offset, limit);
   }
 
@@ -92,7 +92,7 @@ public class WorkflowController {
     @TenantHeader String tenant,
     @TokenHeader String token
   ) throws WorkflowEngineServiceException, WorkflowNotFoundException {
-    LOG.info(String.format("Activating: %s", id));
+    LOG.info(String.format("Activating: %s", sanitize(id)));
 
     workflowEngineService.exists(id);
 
@@ -105,7 +105,7 @@ public class WorkflowController {
     @TenantHeader String tenant,
     @TokenHeader String token
   ) throws WorkflowEngineServiceException, WorkflowNotFoundException {
-    LOG.info(String.format("Deactivating: %s", id));
+    LOG.info(String.format("Deactivating: %s", sanitize(id)));
 
     workflowEngineService.exists(id);
 
@@ -118,7 +118,7 @@ public class WorkflowController {
     @TenantHeader String tenant,
     @TokenHeader String token
   ) throws WorkflowEngineServiceException, WorkflowNotFoundException {
-    LOG.info(String.format("Deleting: %s", id));
+    LOG.info(String.format("Deleting: %s", sanitize(id)));
 
     workflowEngineService.exists(id);
 
@@ -134,7 +134,7 @@ public class WorkflowController {
     @TenantHeader String tenant,
     @TokenHeader String token
   ) throws WorkflowEngineServiceException {
-    LOG.debug(String.format("Retrieving History: %s", id));
+    LOG.debug(String.format("Retrieving History: %s", sanitize(id)));
     return workflowEngineService.history(id, tenant, token);
   }
 
@@ -145,8 +145,43 @@ public class WorkflowController {
     @TokenHeader String token,
     @RequestBody JsonNode context
   ) throws WorkflowEngineServiceException {
-    LOG.info(String.format("Starting: %s with context %s", id, context));
+    LOG.info(String.format("Starting: %s with context %s", sanitize(id), sanitize(context)));
     return workflowEngineService.start(id, tenant, token, context);
+  }
+
+  /**
+   * Sanitize string parameter for logging purposes.
+   *
+   * Strip out all non-graph, non-whitespace, non-newline, non-carriage return characters.
+   *
+   * @param param The parameter to sanitize.
+   *
+   * @return A sanitized string.
+   */
+  private String sanitize(String param) {
+    if (param == null) return "";
+
+    return param
+      .replaceAll("[^\\p{C}]", "")
+      .replaceAll("[\r\n]", " ");
+  }
+
+  /**
+   * Sanitize JsonNode parameter for logging purposes.
+   *
+   * Strip out all non-graph, non-whitespace, non-newline, non-carriage return characters.
+   *
+   * @param param The parameter to sanitize.
+   *
+   * @return A sanitized string.
+   */
+  private String sanitize(JsonNode param) {
+    if (param == null) return "";
+
+    return param
+      .toPrettyString()
+      .replaceAll("[^\\p{C}]", "")
+      .replaceAll("[\r\n]", " ");
   }
 
 }

--- a/service/src/main/java/org/folio/rest/workflow/controller/WorkflowController.java
+++ b/service/src/main/java/org/folio/rest/workflow/controller/WorkflowController.java
@@ -3,6 +3,8 @@ package org.folio.rest.workflow.controller;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.folio.rest.workflow.exception.WorkflowEngineServiceException;
@@ -36,8 +38,8 @@ public class WorkflowController {
 
   private static final Log LOG = LogFactory.getLog(WorkflowController.class);
 
-  private static final String REGX_NOT_GRAPH = "[^\\p{C}]";
-  private static final String REGX_EOL = "[\r\n]";
+  private static final Pattern REGX_NOT_GRAPH = Pattern.compile("[^\\p{C}]");
+  private static final Pattern REGX_EOL = Pattern.compile("[\r\n]");
 
   private WorkflowEngineService workflowEngineService;
 
@@ -164,9 +166,10 @@ public class WorkflowController {
   private String sanitize(String param) {
     if (param == null) return "";
 
-    return param
-      .replaceAll(REGX_NOT_GRAPH, "")
-      .replaceAll(REGX_EOL, " ");
+    final Matcher matchNotGraph = REGX_NOT_GRAPH.matcher(param);
+    final Matcher matchEol = REGX_EOL.matcher(matchNotGraph.replaceAll(""));
+
+    return matchEol.replaceAll(" ");
   }
 
   /**

--- a/service/src/main/java/org/folio/rest/workflow/controller/WorkflowController.java
+++ b/service/src/main/java/org/folio/rest/workflow/controller/WorkflowController.java
@@ -3,7 +3,8 @@ package org.folio.rest.workflow.controller;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.folio.rest.workflow.exception.WorkflowEngineServiceException;
 import org.folio.rest.workflow.exception.WorkflowImportException;
 import org.folio.rest.workflow.exception.WorkflowNotFoundException;
@@ -29,10 +30,11 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import tools.jackson.databind.JsonNode;
 
-@Slf4j
 @RestController
 @RequestMapping("/workflows")
 public class WorkflowController {
+
+  private final static Log LOG = LogFactory.getLog(WorkflowController.class);
 
   private WorkflowEngineService workflowEngineService;
 
@@ -56,7 +58,7 @@ public class WorkflowController {
       @TokenHeader String token
     ) throws URISyntaxException, IOException, WorkflowImportException {
 
-    log.debug("Importing FWZ");
+    LOG.debug("Importing FWZ");
 
     Workflow workflow = workflowImportService.importFile(fwz.getResource());
     URI location = new URI(String.format("/workflows/%s", workflow.getId()));
@@ -71,7 +73,7 @@ public class WorkflowController {
     @RequestParam(defaultValue="20") Integer limit,
     @TenantHeader String tenant
   ) {
-    log.debug("Performing CQL search: {}, offset, limit", query, offset, limit);
+    LOG.debug(String.format("Performing CQL search: {}, offset, limit", query, offset, limit));
     return workflowCqlService.findByCql(query, offset, limit);
   }
 
@@ -90,7 +92,7 @@ public class WorkflowController {
     @TenantHeader String tenant,
     @TokenHeader String token
   ) throws WorkflowEngineServiceException, WorkflowNotFoundException {
-    log.info("Activating: {}", id);
+    LOG.info(String.format("Activating: {}", id));
 
     workflowEngineService.exists(id);
 
@@ -103,7 +105,7 @@ public class WorkflowController {
     @TenantHeader String tenant,
     @TokenHeader String token
   ) throws WorkflowEngineServiceException, WorkflowNotFoundException {
-    log.info("Deactivating: {}", id);
+    LOG.info(String.format("Deactivating: {}", id));
 
     workflowEngineService.exists(id);
 
@@ -116,7 +118,7 @@ public class WorkflowController {
     @TenantHeader String tenant,
     @TokenHeader String token
   ) throws WorkflowEngineServiceException, WorkflowNotFoundException {
-    log.info("Deleting: {}", id);
+    LOG.info(String.format("Deleting: {}", id));
 
     workflowEngineService.exists(id);
 
@@ -132,7 +134,7 @@ public class WorkflowController {
     @TenantHeader String tenant,
     @TokenHeader String token
   ) throws WorkflowEngineServiceException {
-    log.debug("Retrieving History: {}", id);
+    LOG.debug(String.format("Retrieving History: {}", id));
     return workflowEngineService.history(id, tenant, token);
   }
 
@@ -143,7 +145,7 @@ public class WorkflowController {
     @TokenHeader String token,
     @RequestBody JsonNode context
   ) throws WorkflowEngineServiceException {
-    log.info("Starting: {} with context {}", id, context);
+    LOG.info(String.format("Starting: {} with context {}", id, context));
     return workflowEngineService.start(id, tenant, token, context);
   }
 

--- a/service/src/main/java/org/folio/rest/workflow/exception/WorkflowAlreadyActiveException.java
+++ b/service/src/main/java/org/folio/rest/workflow/exception/WorkflowAlreadyActiveException.java
@@ -4,7 +4,7 @@ public class WorkflowAlreadyActiveException extends Exception {
 
   private static final long serialVersionUID = -7896387728725860219L;
 
-  private final static String WORKFLOW_ALREADY_ACTIVE_MESSAGE = "The workflow: %s, is already active.";
+  private static final String WORKFLOW_ALREADY_ACTIVE_MESSAGE = "The workflow: %s, is already active.";
 
   public WorkflowAlreadyActiveException(String id) {
     super(String.format(WORKFLOW_ALREADY_ACTIVE_MESSAGE, id));

--- a/service/src/main/java/org/folio/rest/workflow/exception/WorkflowNotFoundException.java
+++ b/service/src/main/java/org/folio/rest/workflow/exception/WorkflowNotFoundException.java
@@ -4,7 +4,7 @@ public class WorkflowNotFoundException extends Exception {
 
   private static final long serialVersionUID = -7896387728725860219L;
 
-  private final static String WORKFLOW_NOT_FOUND_MESSAGE = "The workflow: %s cannot be found.";
+  private static final String WORKFLOW_NOT_FOUND_MESSAGE = "The workflow: %s cannot be found.";
 
   public WorkflowNotFoundException(String id) {
     super(String.format(WORKFLOW_NOT_FOUND_MESSAGE, id));

--- a/service/src/main/java/org/folio/rest/workflow/model/Action.java
+++ b/service/src/main/java/org/folio/rest/workflow/model/Action.java
@@ -5,30 +5,22 @@ import jakarta.persistence.Embeddable;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
-import lombok.Setter;
-import org.folio.rest.workflow.has.common.HasActionCommon;
 import org.folio.rest.workflow.enums.HttpMethod;
+import org.folio.rest.workflow.has.common.HasActionCommon;
 import org.folio.rest.workflow.model.has.HasMethod;
 import org.folio.rest.workflow.model.has.HasPathPattern;
 
 @Embeddable
 public class Action implements HasActionCommon, HasMethod, HasPathPattern {
 
-  @Getter
-  @Setter
   @NotNull
   @Column(nullable = false)
   private String interfaceName;
 
-  @Getter
-  @Setter
   @NotNull
   @Column(nullable = false)
   private String pathPattern;
 
-  @Getter
-  @Setter
   @NotNull
   @Column(nullable = false)
   @Enumerated(EnumType.STRING)
@@ -44,6 +36,36 @@ public class Action implements HasActionCommon, HasMethod, HasPathPattern {
     this.interfaceName = interfaceName;
     this.pathPattern = pathPattern;
     this.method = method;
+  }
+
+  @Override
+  public String getPathPattern() {
+    return pathPattern;
+  }
+
+  @Override
+  public void setPathPattern(String pathPattern) {
+    this.pathPattern = pathPattern;
+  }
+
+  @Override
+  public HttpMethod getMethod() {
+    return method;
+  }
+
+  @Override
+  public void setMethod(HttpMethod method) {
+    this.method = method;
+  }
+
+  @Override
+  public String getInterfaceName() {
+    return interfaceName;
+  }
+
+  @Override
+  public void setInterfaceName(String interfaceName) {
+    this.interfaceName = interfaceName;
   }
 
 }

--- a/service/src/main/java/org/folio/rest/workflow/model/ExtractedWorkflow.java
+++ b/service/src/main/java/org/folio/rest/workflow/model/ExtractedWorkflow.java
@@ -5,13 +5,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
-import lombok.Getter;
 import tools.jackson.databind.JsonNode;
 
 /**
  * A collection of Workflow Nodes for use during import.
  */
-@Getter
 public class ExtractedWorkflow {
 
   /**
@@ -125,6 +123,76 @@ public class ExtractedWorkflow {
     nodes = new HashMap<>();
     triggers = new HashMap<>();
     scripts = new HashMap<>();
+  }
+
+  /**
+   * @return the expanded
+   */
+  public List<String> getExpanded() {
+    return expanded;
+  }
+
+  /**
+   * @return the required
+   */
+  public Map<String, JsonNode> getRequired() {
+    return required;
+  }
+
+  /**
+   * @return the nodes
+   */
+  public Map<String, JsonNode> getNodes() {
+    return nodes;
+  }
+
+  /**
+   * @return the triggers
+   */
+  public Map<String, JsonNode> getTriggers() {
+    return triggers;
+  }
+
+  /**
+   * @return the scripts
+   */
+  public Map<String, String> getScripts() {
+    return scripts;
+  }
+
+  /**
+   * @param expanded the expanded to set
+   */
+  public void setExpanded(List<String> expanded) {
+    this.expanded = expanded;
+  }
+
+  /**
+   * @param required the required to set
+   */
+  public void setRequired(Map<String, JsonNode> required) {
+    this.required = required;
+  }
+
+  /**
+   * @param nodes the nodes to set
+   */
+  public void setNodes(Map<String, JsonNode> nodes) {
+    this.nodes = nodes;
+  }
+
+  /**
+   * @param triggers the triggers to set
+   */
+  public void setTriggers(Map<String, JsonNode> triggers) {
+    this.triggers = triggers;
+  }
+
+  /**
+   * @param scripts the scripts to set
+   */
+  public void setScripts(Map<String, String> scripts) {
+    this.scripts = scripts;
   }
 
 }

--- a/service/src/main/java/org/folio/rest/workflow/model/Handler.java
+++ b/service/src/main/java/org/folio/rest/workflow/model/Handler.java
@@ -2,26 +2,16 @@ package org.folio.rest.workflow.model;
 
 import java.util.ArrayList;
 import java.util.List;
-import lombok.Getter;
-import lombok.Setter;
 import org.folio.rest.workflow.enums.HttpMethod;
 
 public class Handler {
 
-  @Getter
-  @Setter
   private List<String> methods;
 
-  @Getter
-  @Setter
   private String pathPattern;
 
-  @Getter
-  @Setter
   private List<String> permissionsRequired;
 
-  @Getter
-  @Setter
   private List<String> permissionsDesired;
 
   public Handler() {
@@ -32,6 +22,62 @@ public class Handler {
     List<Action> actions = new ArrayList<>();
     methods.forEach(method -> actions.add(new Action(interfaceName, pathPattern, HttpMethod.valueOf(method))));
     return actions;
+  }
+
+  /**
+   * @return the methods
+   */
+  public List<String> getMethods() {
+    return methods;
+  }
+
+  /**
+   * @return the pathPattern
+   */
+  public String getPathPattern() {
+    return pathPattern;
+  }
+
+  /**
+   * @return the permissionsRequired
+   */
+  public List<String> getPermissionsRequired() {
+    return permissionsRequired;
+  }
+
+  /**
+   * @return the permissionsDesired
+   */
+  public List<String> getPermissionsDesired() {
+    return permissionsDesired;
+  }
+
+  /**
+   * @param methods the methods to set
+   */
+  public void setMethods(List<String> methods) {
+    this.methods = methods;
+  }
+
+  /**
+   * @param pathPattern the pathPattern to set
+   */
+  public void setPathPattern(String pathPattern) {
+    this.pathPattern = pathPattern;
+  }
+
+  /**
+   * @param permissionsRequired the permissionsRequired to set
+   */
+  public void setPermissionsRequired(List<String> permissionsRequired) {
+    this.permissionsRequired = permissionsRequired;
+  }
+
+  /**
+   * @param permissionsDesired the permissionsDesired to set
+   */
+  public void setPermissionsDesired(List<String> permissionsDesired) {
+    this.permissionsDesired = permissionsDesired;
   }
 
 }

--- a/service/src/main/java/org/folio/rest/workflow/model/Trigger.java
+++ b/service/src/main/java/org/folio/rest/workflow/model/Trigger.java
@@ -6,8 +6,6 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import lombok.Getter;
-import lombok.Setter;
 import org.folio.rest.workflow.enums.HttpMethod;
 import org.folio.rest.workflow.model.has.HasId;
 import org.folio.rest.workflow.model.has.HasInformational;
@@ -19,28 +17,20 @@ import org.folio.spring.domain.model.AbstractBaseEntity;
 @Entity
 public class Trigger extends AbstractBaseEntity implements HasId, HasInformational, HasMethod, HasName, HasPathPattern {
 
-  @Getter
-  @Setter
   @NotNull
   @Size(min = 4, max = 64)
   @Column(unique = true)
   private String name;
 
-  @Getter
-  @Setter
   @Size(min = 0, max = 256)
   @Column(nullable = true)
   private String description;
 
-  @Getter
-  @Setter
   @NotNull
   @Size(min = 2, max = 256)
   @Column(nullable = false)
   private String pathPattern;
 
-  @Getter
-  @Setter
   @NotNull
   @Column(nullable = false)
   @Enumerated(EnumType.STRING)
@@ -48,6 +38,62 @@ public class Trigger extends AbstractBaseEntity implements HasId, HasInformation
 
   public Trigger() {
     super();
+  }
+
+  /**
+   * @return the name
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * @return the description
+   */
+  public String getDescription() {
+    return description;
+  }
+
+  /**
+   * @return the pathPattern
+   */
+  public String getPathPattern() {
+    return pathPattern;
+  }
+
+  /**
+   * @return the method
+   */
+  public HttpMethod getMethod() {
+    return method;
+  }
+
+  /**
+   * @param name the name to set
+   */
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  /**
+   * @param description the description to set
+   */
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  /**
+   * @param pathPattern the pathPattern to set
+   */
+  public void setPathPattern(String pathPattern) {
+    this.pathPattern = pathPattern;
+  }
+
+  /**
+   * @param method the method to set
+   */
+  public void setMethod(HttpMethod method) {
+    this.method = method;
   }
 
 }

--- a/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
@@ -1,7 +1,8 @@
 package org.folio.rest.workflow.service;
 
 import java.util.Iterator;
-import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.folio.rest.workflow.dto.WorkflowDto;
 import org.folio.rest.workflow.dto.WorkflowOperationalDto;
 import org.folio.rest.workflow.exception.WorkflowEngineServiceException;
@@ -23,9 +24,10 @@ import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.node.ArrayNode;
 import tools.jackson.databind.node.ObjectNode;
 
-@Slf4j
 @Service
 public class WorkflowEngineService {
+
+  private final static Log LOG = LogFactory.getLog(WorkflowEngineService.class);
 
   private static final String WORKFLOW_ENGINE_ACTIVATE_URL_TEMPLATE = "%s%s/workflow-engine/workflows/activate";
   private static final String WORKFLOW_ENGINE_DEACTIVATE_URL_TEMPLATE = "%s%s/workflow-engine/workflows/deactivate";
@@ -214,7 +216,7 @@ public class WorkflowEngineService {
 
       ArrayNode incidents = response.getBody();
       if (response.getStatusCode() != HttpStatus.OK || incidents == null) {
-        log.debug("Unable to get workflow incidents history from workflow engine!");
+        LOG.debug(String.format("Unable to get workflow incidents history from workflow engine!"));
 
         incidents = mapper.createArrayNode();
       }
@@ -242,7 +244,7 @@ public class WorkflowEngineService {
 
     HttpEntity<WorkflowDto> entity = new HttpEntity<>(workflow, headers(tenant, token));
     String url = String.format(requestPath, okapiUrl, basePath);
-    log.debug("Send Okapi workflow engine request {} {}", HttpMethod.POST, url);
+    LOG.debug(String.format("Send Okapi workflow engine request {} {}", HttpMethod.POST, url));
 
     try {
       ResponseEntity<Workflow> response = exchange(url, HttpMethod.POST, entity, Workflow.class);
@@ -252,7 +254,7 @@ public class WorkflowEngineService {
 
         if (responseWorkflow != null) {
           String deploymentId = responseWorkflow.getDeploymentId();
-          log.info("Workflow is active = {}, deploymentID = {}", Boolean.TRUE.equals(responseWorkflow.getActive()), deploymentId);
+          LOG.info(String.format("Workflow is active = {}, deploymentID = {}", Boolean.TRUE.equals(responseWorkflow.getActive()), deploymentId));
           return workflowRepo.save(responseWorkflow);
         }
       }
@@ -265,7 +267,7 @@ public class WorkflowEngineService {
 
   private HttpHeaders headers(String tenant, String token) {
     HttpHeaders requestHeaders = new HttpHeaders();
-    log.debug("Request Headers: tenant '{}' and token '{}'.", tenant, token);
+    LOG.debug(String.format("Request Headers: tenant '{}' and token '{}'.", tenant, token));
 
     if (tenant != null) {
       requestHeaders.add(tenantHeaderName, tenant);
@@ -280,7 +282,7 @@ public class WorkflowEngineService {
   }
 
   private <T> ResponseEntity<T> exchange(String url, HttpMethod method, HttpEntity<?> request, Class<T> responseType) {
-    log.debug("Exchange for {} {} {}", responseType.getSimpleName(), method, url);
+    LOG.debug(String.format("Exchange for {} {} {}", responseType.getSimpleName(), method, url));
     return this.restTemplate.exchange(url, method, request, responseType, (Object[]) new String[0]);
   }
 

--- a/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
@@ -244,7 +244,7 @@ public class WorkflowEngineService {
 
     HttpEntity<WorkflowDto> entity = new HttpEntity<>(workflow, headers(tenant, token));
     String url = String.format(requestPath, okapiUrl, basePath);
-    LOG.debug(String.format("Send Okapi workflow engine request {} {}", HttpMethod.POST, url));
+    LOG.debug(String.format("Send Okapi workflow engine request %s %s", HttpMethod.POST, url));
 
     try {
       ResponseEntity<Workflow> response = exchange(url, HttpMethod.POST, entity, Workflow.class);
@@ -254,7 +254,7 @@ public class WorkflowEngineService {
 
         if (responseWorkflow != null) {
           String deploymentId = responseWorkflow.getDeploymentId();
-          LOG.info(String.format("Workflow is active = {}, deploymentID = {}", Boolean.TRUE.equals(responseWorkflow.getActive()), deploymentId));
+          LOG.info(String.format("Workflow is active = %s, deploymentID = %s", Boolean.TRUE.equals(responseWorkflow.getActive()), deploymentId));
           return workflowRepo.save(responseWorkflow);
         }
       }
@@ -267,7 +267,7 @@ public class WorkflowEngineService {
 
   private HttpHeaders headers(String tenant, String token) {
     HttpHeaders requestHeaders = new HttpHeaders();
-    LOG.debug(String.format("Request Headers: tenant '{}' and token '{}'.", tenant, token));
+    LOG.debug(String.format("Request Headers: tenant '%s' and token '%s'.", tenant, token));
 
     if (tenant != null) {
       requestHeaders.add(tenantHeaderName, tenant);
@@ -282,7 +282,7 @@ public class WorkflowEngineService {
   }
 
   private <T> ResponseEntity<T> exchange(String url, HttpMethod method, HttpEntity<?> request, Class<T> responseType) {
-    LOG.debug(String.format("Exchange for {} {} {}", responseType.getSimpleName(), method, url));
+    LOG.debug(String.format("Exchange for %s %s %s", responseType.getSimpleName(), method, url));
     return this.restTemplate.exchange(url, method, request, responseType, (Object[]) new String[0]);
   }
 

--- a/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
@@ -216,7 +216,7 @@ public class WorkflowEngineService {
 
       ArrayNode incidents = response.getBody();
       if (response.getStatusCode() != HttpStatus.OK || incidents == null) {
-        LOG.debug(String.format("Unable to get workflow incidents history from workflow engine!"));
+        LOG.debug("Unable to get workflow incidents history from workflow engine!");
 
         incidents = mapper.createArrayNode();
       }

--- a/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
@@ -27,7 +27,7 @@ import tools.jackson.databind.node.ObjectNode;
 @Service
 public class WorkflowEngineService {
 
-  private final static Log LOG = LogFactory.getLog(WorkflowEngineService.class);
+  private static final Log LOG = LogFactory.getLog(WorkflowEngineService.class);
 
   private static final String WORKFLOW_ENGINE_ACTIVATE_URL_TEMPLATE = "%s%s/workflow-engine/workflows/activate";
   private static final String WORKFLOW_ENGINE_DEACTIVATE_URL_TEMPLATE = "%s%s/workflow-engine/workflows/deactivate";

--- a/service/src/main/java/org/folio/rest/workflow/service/WorkflowImportService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/WorkflowImportService.java
@@ -64,7 +64,7 @@ import tools.jackson.databind.node.ObjectNode;
 @Service
 public class WorkflowImportService {
 
-  private final static Log LOG = LogFactory.getLog(WorkflowImportService.class);
+  private static final Log LOG = LogFactory.getLog(WorkflowImportService.class);
 
   private ObjectMapper objectMapper;
 

--- a/service/src/main/java/org/folio/rest/workflow/service/WorkflowImportService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/WorkflowImportService.java
@@ -289,10 +289,8 @@ public class WorkflowImportService {
    * @param pathParts The array of path parts.
    * @param inputStream The input stream to use.
    * @param extracted The extracted data.
-   *
-   * @throws IOException On error reading the file stream, extracting the JSON, or other such errors.
    */
-  private void extractTopLevel(String name, InputStream inputStream, ExtractedWorkflow extracted) throws IOException {
+  private void extractTopLevel(String name, InputStream inputStream, ExtractedWorkflow extracted) {
     if (FWZ_JSON.equalsIgnoreCase(name)) {
       extracted.getRequired().put(FWZ_JSON, objectMapper.readTree(inputStream));
 
@@ -315,10 +313,9 @@ public class WorkflowImportService {
    * @param extracted The extracted data.
    * @param pathParts The broken up path parts.
    *
-   * @throws IOException On error reading the file stream, extracting the JSON, or other such errors.
    * @throws WorkflowImportInvalidOrMissingProperty  On import failure due to invalid or missing property.
    */
-  private void extractSubLevel(String name, InputStream inputStream, ExtractedWorkflow extracted, String[] pathParts) throws IOException, WorkflowImportInvalidOrMissingProperty {
+  private void extractSubLevel(String name, InputStream inputStream, ExtractedWorkflow extracted, String[] pathParts) throws WorkflowImportInvalidOrMissingProperty {
 
     JsonNode json = objectMapper.readTree(inputStream);
     if (!json.has(ID) || json.get(ID).getNodeType() != JsonNodeType.STRING) {

--- a/service/src/main/java/org/folio/rest/workflow/service/WorkflowImportService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/WorkflowImportService.java
@@ -534,7 +534,7 @@ public class WorkflowImportService {
       String version = json.get(VERSION).asString();
 
       if (!VERSION_PATTERN_1_0.matcher(version).find()) {
-        LOG.warn(String.format("Unknown version '{}', attempting import anyway.", version));
+        LOG.warn(String.format("Unknown version '%s', attempting import anyway.", version));
       }
     } else {
       LOG.warn("No version is specified, attempting import anyway.");
@@ -547,7 +547,7 @@ public class WorkflowImportService {
    * @param name The name of the unknown file or directory.
    */
   private void warnOnUnknownFileOrDir(String name) {
-    LOG.warn(String.format("Ignoring unknown file or directory: '{}'.", name));
+    LOG.warn(String.format("Ignoring unknown file or directory: '%s'.", name));
   }
 
 }

--- a/service/src/main/java/org/folio/rest/workflow/service/WorkflowImportService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/WorkflowImportService.java
@@ -30,7 +30,6 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarFile;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
@@ -38,6 +37,8 @@ import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.commons.compress.utils.SeekableInMemoryByteChannel;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.folio.rest.workflow.enums.CompressFileFormat;
 import org.folio.rest.workflow.exception.WorkflowImportAlreadyImported;
 import org.folio.rest.workflow.exception.WorkflowImportException;
@@ -60,9 +61,10 @@ import tools.jackson.databind.node.ArrayNode;
 import tools.jackson.databind.node.JsonNodeType;
 import tools.jackson.databind.node.ObjectNode;
 
-@Slf4j
 @Service
 public class WorkflowImportService {
+
+  private final static Log LOG = LogFactory.getLog(WorkflowImportService.class);
 
   private ObjectMapper objectMapper;
 
@@ -532,10 +534,10 @@ public class WorkflowImportService {
       String version = json.get(VERSION).asString();
 
       if (!VERSION_PATTERN_1_0.matcher(version).find()) {
-        log.warn("Unknown version '{}', attempting import anyway.", version);
+        LOG.warn(String.format("Unknown version '{}', attempting import anyway.", version));
       }
     } else {
-      log.warn("No version is specified, attempting import anyway.");
+      LOG.warn("No version is specified, attempting import anyway.");
     }
   }
 
@@ -545,7 +547,7 @@ public class WorkflowImportService {
    * @param name The name of the unknown file or directory.
    */
   private void warnOnUnknownFileOrDir(String name) {
-    log.warn("Ignoring unknown file or directory: '{}'.", name);
+    LOG.warn(String.format("Ignoring unknown file or directory: '{}'.", name));
   }
 
 }

--- a/service/src/main/java/org/folio/rest/workflow/service/WorkflowImportService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/WorkflowImportService.java
@@ -20,7 +20,6 @@ import static org.folio.rest.workflow.model.ExtractedWorkflow.VERSION;
 import static org.folio.rest.workflow.model.ExtractedWorkflow.VERSION_PATTERN_1_0;
 import static org.folio.rest.workflow.model.ExtractedWorkflow.WORKFLOW_JSON;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.github.jknack.handlebars.internal.Files;
 import java.io.BufferedInputStream;
 import java.io.IOException;
@@ -140,9 +139,8 @@ public class WorkflowImportService {
    *
    * @throws WorkflowImportInvalidOrMissingProperty If a property is missing.
    * @throws WorkflowImportRequiredFileMissing If the script file is not found.
-   * @throws JsonProcessingException On error processing the JSON.
    */
-  private void collapseNodeScripts(ExtractedWorkflow extracted) throws WorkflowImportInvalidOrMissingProperty, WorkflowImportRequiredFileMissing, JsonProcessingException {
+  private void collapseNodeScripts(ExtractedWorkflow extracted) throws WorkflowImportInvalidOrMissingProperty, WorkflowImportRequiredFileMissing {
     for (Entry<String, JsonNode> entry : extracted.getNodes().entrySet()) {
       if (collapseNodeScriptsContinue(entry)) {
         continue;
@@ -345,10 +343,9 @@ public class WorkflowImportService {
    *
    * @param extracted The extracted data.
    *
-   * @throws JsonProcessingException On JSON parse failure.
    * @throws WorkflowImportInvalidOrMissingProperty On invalid property.
    */
-  private void expandWorkflow(ExtractedWorkflow extracted) throws  JsonProcessingException, WorkflowImportInvalidOrMissingProperty {
+  private void expandWorkflow(ExtractedWorkflow extracted) throws WorkflowImportInvalidOrMissingProperty {
     for (JsonNode node : extracted.getNodes().values()) {
       expandNode(extracted.getNodes(), node, extracted.getExpanded());
     }
@@ -374,10 +371,9 @@ public class WorkflowImportService {
    * @param node The node to process.
    * @param expanded An array of IDs of nodes that have already been expanded.
    *
-   * @throws JsonProcessingException On JSON parse failure.
    * @throws WorkflowImportInvalidOrMissingProperty On invalid property.
    */
-  private void expandNode(Map<String, JsonNode> nodes, JsonNode node, List<String> expanded) throws JsonProcessingException, WorkflowImportInvalidOrMissingProperty {
+  private void expandNode(Map<String, JsonNode> nodes, JsonNode node, List<String> expanded) throws WorkflowImportInvalidOrMissingProperty {
     String nodeId = node.get(ID).asString();
     if (expanded.contains(nodeId)) {
       return;

--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -58,7 +58,7 @@ spring:
     #url: jdbc:h2:./target/mod-workflow;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=PostgreSQL;DATABASE_TO_LOWER=true;DEFAULT_NULL_ORDERING=HIGH
     #url: jdbc:h2:mem:AZ;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=PostgreSQL;DATABASE_TO_LOWER=true;DEFAULT_NULL_ORDERING=HIGH
     driverClassName: org.postgresql.Driver
-    url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_DATABASE:mod_workflow}
+    url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_DATABASE:mod_workflow}?currentSchema=${DB_SCHEMA:diku_mod_workflow},public
 
     username: ${DB_USERNAME:folio_admin}
     password: ${DB_PASSWORD:folio_admin}
@@ -78,7 +78,10 @@ spring:
     #database-platform: org.hibernate.dialect.H2Dialect
     database-platform: org.hibernate.dialect.PostgreSQLDialect
 
-    properties.hibernate.jdbc.lob.non_contextual_creation: true
+    properties.hibernate:
+      jdbc.lob.non_contextual_creation: true
+      default_schema: ${DB_SCHEMA:diku_mod_workflow}
+
     generate-ddl: false
     hibernate.ddl-auto: update
     #hibernate.hbm2ddl.auto: none


### PR DESCRIPTION
Resolves [MODWRKFLOW-60](https://folio-org.atlassian.net/browse/MODWRKFLOW-60) .

~Update minimum Java version to 25.~
Tested under **Java 25**, but minimum Java remains at **Java 21**.
  - This is done because some of the **FOLIO** services are not all **Java 25** ready yet.

**Lombok** no longer works and it is easier to just completely remove **Lombok** rather than to deal with its problems.
  - Add all of the getters and setters.
  - Use the **Apache** logger instead of **Slf4j** because **Spring-Boot** already brings in the **Apache** logger.

Rename the `isIterable()` to `getIterable()` for consistency.

Add missing `Has*` and other such classes such that the components models all have an annotation enforced getter and setter via interface inheritance.

Fix problems with newer Postgresql (17+) where the schema must be specified.
  - Expose the schema name via `DB_SCHEMA`.
  - The name includes the tenant name followed by the module name.
  - The old behavior used a schema name more like `diku_workflow_service` (tenant name plus `workflow_service`).
  - Ensure that the `public` is still in the schema search path.