### PR TITLE
MODWRKFLOW-62: Utilize `folio.sql.schema` from spring-module-core tenant module.

### DIFF
--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -117,6 +117,7 @@ event:
     path: events
 
 folio:
+  sql.schema: ${DB_SCHEMA:diku_mod_workflow}
   tenant.validation: false
 
 tenant:


### PR DESCRIPTION
Resolves [MODWRKFLOW-62](https://folio-org.atlassian.net/browse/MODWRKFLOW-62) .

Provide explicit default schema name.