### PR TITLE
MODWRKFLOW-54: OkHttpConfig is no longer needed.

### DIFF
--- a/service/src/main/java/org/folio/rest/workflow/config/OkHttpConfig.java
+++ b/service/src/main/java/org/folio/rest/workflow/config/OkHttpConfig.java
@@ -1,8 +1,0 @@
-package org.folio.rest.workflow.config;
-
-import org.springframework.context.annotation.Configuration;
-
-@Configuration
-public class OkHttpConfig {
-
-}


### PR DESCRIPTION
[MODWRKFLOW-54](https://folio-org.atlassian.net/browse/MODWRKFLOW-54)

The `folio-spring-support` switched to Spring-Boot 4+ and as a result removed `OkHttpConfig`. This bean configuration is only added because of a requirement by `folio-spring-support` and serves no purpose anymore.

see: https://github.com/folio-org/folio-spring-support/pull/287
see: https://folio-org.atlassian.net/browse/FOLSPRINGS-204
see: https://folio-org.atlassian.net/browse/MODWRKFLOW-34