### PR TITLE
MODWRKFLOW-69: Support checksums, created on date, and updated on date.

### DIFF
--- a/components/src/main/java/org/folio/rest/workflow/dto/WorkflowDto.java
+++ b/components/src/main/java/org/folio/rest/workflow/dto/WorkflowDto.java
@@ -1,16 +1,19 @@
 package org.folio.rest.workflow.dto;
 
+import org.folio.rest.workflow.model.has.HasChecksum;
+import org.folio.rest.workflow.model.has.HasCreatedOn;
 import org.folio.rest.workflow.model.has.HasDeploymentId;
 import org.folio.rest.workflow.model.has.HasId;
 import org.folio.rest.workflow.model.has.HasInformational;
 import org.folio.rest.workflow.model.has.HasName;
 import org.folio.rest.workflow.model.has.HasNodes;
+import org.folio.rest.workflow.model.has.HasUpdatedOn;
 import org.folio.rest.workflow.model.has.HasVersionTag;
 import org.folio.rest.workflow.model.has.common.HasWorkflowCommon;
 
 /**
  * This is a DTO design for providing the entire {@link org.folio.rest.workflow.model.Workflow Workflow} model.
  */
-public interface WorkflowDto extends HasDeploymentId, HasId, HasInformational, HasName, HasNodes, HasVersionTag, HasWorkflowCommon {
+public interface WorkflowDto extends HasChecksum, HasCreatedOn, HasDeploymentId, HasId, HasInformational, HasName, HasNodes, HasUpdatedOn, HasVersionTag, HasWorkflowCommon {
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/Workflow.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/Workflow.java
@@ -98,12 +98,12 @@ public class Workflow extends AbstractBaseEntity implements HasChecksum, HasCrea
 
     active = false;
     checksum = null;
-    createdOn = Instant.now();
+    createdOn = now();
     name = "";
     historyTimeToLive = 0;
     initialContext = new HashMap<>();
     nodes = new ArrayList<>();
-    updatedOn = Instant.now();
+    updatedOn = now();
     versionTag = "1.0";
   }
 
@@ -114,7 +114,7 @@ public class Workflow extends AbstractBaseEntity implements HasChecksum, HasCrea
     }
 
     if (createdOn == null) {
-      createdOn = Instant.now();
+      createdOn = now();
     }
 
     if (historyTimeToLive == null) {
@@ -134,7 +134,7 @@ public class Workflow extends AbstractBaseEntity implements HasChecksum, HasCrea
     }
 
     if (updatedOn == null) {
-      updatedOn = Instant.now();
+      updatedOn = now();
     }
 
     if (versionTag == null) {
@@ -265,6 +265,18 @@ public class Workflow extends AbstractBaseEntity implements HasChecksum, HasCrea
   @Override
   public void setDeploymentId(String deploymentId) {
     this.deploymentId = deploymentId;
+  }
+
+  /**
+   * Get the current time.
+   *
+   * This is used to allow for easier unit testing where the unit tests need only override this method through mocks or similar.
+   *
+   * @return The current instant.
+   */
+  Instant now() {
+
+    return Instant.now();
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/Workflow.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/Workflow.java
@@ -1,6 +1,7 @@
 package org.folio.rest.workflow.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.annotation.Nullable;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
@@ -15,16 +16,20 @@ import jakarta.persistence.PrePersist;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.folio.rest.workflow.model.converter.JsonNodeConverter;
+import org.folio.rest.workflow.model.has.HasChecksum;
+import org.folio.rest.workflow.model.has.HasCreatedOn;
 import org.folio.rest.workflow.model.has.HasDeploymentId;
 import org.folio.rest.workflow.model.has.HasId;
 import org.folio.rest.workflow.model.has.HasInformational;
 import org.folio.rest.workflow.model.has.HasName;
 import org.folio.rest.workflow.model.has.HasNodes;
+import org.folio.rest.workflow.model.has.HasUpdatedOn;
 import org.folio.rest.workflow.model.has.HasVersionTag;
 import org.folio.rest.workflow.model.has.common.HasWorkflowCommon;
 import org.folio.spring.domain.model.AbstractBaseEntity;
@@ -34,11 +39,19 @@ import tools.jackson.databind.JsonNode;
 
 @Entity
 @JsonIgnoreProperties({ "hibernateLazyInitializer", "handler" })
-public class Workflow extends AbstractBaseEntity implements HasDeploymentId, HasId, HasInformational, HasName, HasNodes, HasVersionTag, HasWorkflowCommon {
+public class Workflow extends AbstractBaseEntity implements HasChecksum, HasCreatedOn, HasDeploymentId, HasId, HasInformational, HasName, HasNodes, HasUpdatedOn, HasVersionTag, HasWorkflowCommon {
 
   @Column(nullable = true)
   @ColumnDefault("false")
   private Boolean active;
+
+  @Nullable
+  @Column
+  private String checksum;
+
+  @NotNull
+  @Column(columnDefinition="TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()")
+  private Instant createdOn;
 
   @Column(unique = true)
   private String deploymentId;
@@ -70,6 +83,10 @@ public class Workflow extends AbstractBaseEntity implements HasDeploymentId, Has
   @Embedded
   private Setup setup;
 
+  @NotNull
+  @Column(columnDefinition="TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()")
+  private Instant updatedOn;
+
   @Version
   @NotNull
   @Size(min = 1, max = 64)
@@ -80,10 +97,13 @@ public class Workflow extends AbstractBaseEntity implements HasDeploymentId, Has
     super();
 
     active = false;
+    checksum = null;
+    createdOn = Instant.now();
     name = "";
     historyTimeToLive = 0;
     initialContext = new HashMap<>();
     nodes = new ArrayList<>();
+    updatedOn = Instant.now();
     versionTag = "1.0";
   }
 
@@ -91,6 +111,10 @@ public class Workflow extends AbstractBaseEntity implements HasDeploymentId, Has
   public void prePersist() {
     if (active == null) {
       active = false;
+    }
+
+    if (createdOn == null) {
+      createdOn = Instant.now();
     }
 
     if (historyTimeToLive == null) {
@@ -109,6 +133,10 @@ public class Workflow extends AbstractBaseEntity implements HasDeploymentId, Has
       nodes = new ArrayList<>();
     }
 
+    if (updatedOn == null) {
+      updatedOn = Instant.now();
+    }
+
     if (versionTag == null) {
       versionTag = "1.0";
     }
@@ -125,6 +153,16 @@ public class Workflow extends AbstractBaseEntity implements HasDeploymentId, Has
   }
 
   @Override
+  public String getChecksum() {
+    return checksum;
+  }
+
+  @Override
+  public Instant getCreatedOn() {
+    return createdOn;
+  }
+
+  @Override
   public Integer getHistoryTimeToLive() {
     return historyTimeToLive;
   }
@@ -137,6 +175,11 @@ public class Workflow extends AbstractBaseEntity implements HasDeploymentId, Has
   @Override
   public Setup getSetup() {
     return setup;
+  }
+
+  @Override
+  public Instant getUpdatedOn() {
+    return updatedOn;
   }
 
   @Override
@@ -170,6 +213,16 @@ public class Workflow extends AbstractBaseEntity implements HasDeploymentId, Has
   }
 
   @Override
+  public void setChecksum(String checksum) {
+    this.checksum = checksum;
+  }
+
+  @Override
+  public void setCreatedOn(Instant createdOn) {
+    this.createdOn = createdOn;
+  }
+
+  @Override
   public void setHistoryTimeToLive(Integer historyTimeToLive) {
     this.historyTimeToLive = historyTimeToLive;
   }
@@ -182,6 +235,11 @@ public class Workflow extends AbstractBaseEntity implements HasDeploymentId, Has
   @Override
   public void setSetup(Setup setup) {
     this.setup = setup;
+  }
+
+  @Override
+  public void setUpdatedOn(Instant updatedOn) {
+    this.updatedOn = updatedOn;
   }
 
   @Override

--- a/components/src/main/java/org/folio/rest/workflow/model/has/HasChecksum.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/HasChecksum.java
@@ -1,0 +1,11 @@
+package org.folio.rest.workflow.model.has;
+
+/**
+ * This interface provides the Checksum methods.
+ */
+public interface HasChecksum {
+
+  public String getChecksum();
+
+  public void setChecksum(String checksum);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/HasCreatedOn.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/HasCreatedOn.java
@@ -1,0 +1,13 @@
+package org.folio.rest.workflow.model.has;
+
+import java.time.Instant;
+
+/**
+ * This interface provides the CreatedOn methods.
+ */
+public interface HasCreatedOn {
+
+  public Instant getCreatedOn();
+
+  public void setCreatedOn(Instant createdOn);
+}

--- a/components/src/main/java/org/folio/rest/workflow/model/has/HasUpdatedOn.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/HasUpdatedOn.java
@@ -1,0 +1,13 @@
+package org.folio.rest.workflow.model.has;
+
+import java.time.Instant;
+
+/**
+ * This interface provides the UpdatedOn methods.
+ */
+public interface HasUpdatedOn {
+
+  public Instant getUpdatedOn();
+
+  public void setUpdatedOn(Instant updatedOn);
+}

--- a/components/src/test/java/org/folio/rest/workflow/model/WorkflowTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/WorkflowTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.springframework.test.util.ReflectionTestUtils.getField;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -32,6 +33,21 @@ class WorkflowTest {
    */
   public static final String VERSION = "1.0";
 
+  /**
+   * An arbitrary hash.
+   */
+  public static final String HASH = "aee6d39cd3f123452aed7ada75440d7a";
+
+  /**
+   * An arbitrary date.
+   */
+  public static final Instant NOW = Instant.now();
+
+  /**
+   * An arbitrary date that occurs some time after the arbitrary now date.
+   */
+  public static final Instant LATER = Instant.from(NOW).plusSeconds(1000);
+
   @Mock
   private Setup setup;
 
@@ -46,10 +62,12 @@ class WorkflowTest {
 
   @BeforeEach
   void beforeEach() {
-    workflow = new Workflow();
+    workflow = Mockito.spy(Workflow.class);
     nodes = new ArrayList<>();
     nodes.add(node);
     initialContext = new HashMap<>();
+
+    Mockito.lenient().doReturn(NOW).when(workflow).now();
   }
 
   @Test
@@ -158,6 +176,36 @@ class WorkflowTest {
   }
 
   @Test
+  void getChecksumWorksTest() {
+    setField(workflow, "checksum", HASH);
+
+    assertEquals(HASH, workflow.getChecksum());
+  }
+
+  @Test
+  void setChecksumWorksTest() {
+    setField(workflow, "checksum", null);
+
+    workflow.setChecksum(HASH);
+    assertEquals(HASH, getField(workflow, "checksum"));
+  }
+
+  @Test
+  void getCreatedOnWorksTest() {
+    setField(workflow, "createdOn", NOW);
+
+    assertEquals(NOW, workflow.getCreatedOn());
+  }
+
+  @Test
+  void setCreatedOnWorksTest() {
+    setField(workflow, "createdOn", null);
+
+    workflow.setCreatedOn(NOW);
+    assertEquals(NOW, getField(workflow, "createdOn"));
+  }
+
+  @Test
   void getDeploymentIdWorksTest() {
     setField(workflow, "deploymentId", VALUE);
 
@@ -202,6 +250,21 @@ class WorkflowTest {
     assertEquals(initialContext, getField(workflow, "initialContext"));
   }
 
+  @Test
+  void getUpdatedOnWorksTest() {
+    setField(workflow, "updatedOn", NOW);
+
+    assertEquals(NOW, workflow.getUpdatedOn());
+  }
+
+  @Test
+  void setUpdatedOnWorksTest() {
+    setField(workflow, "updatedOn", null);
+
+    workflow.setUpdatedOn(NOW);
+    assertEquals(NOW, getField(workflow, "updatedOn"));
+  }
+
   @ParameterizedTest
   @MethodSource("providePrePersistFor")
   void prePersistWorksTest(Map<String, Object> initial, Map<String, Object> expected, Map<String, Boolean> persist) {
@@ -232,8 +295,9 @@ class WorkflowTest {
    *
    * @return
    *   The arguments array stream with the stream columns as:
-   *     - Arguments initial The initial values.
-   *     - Arguments expect The expected values.
+   *     - Arguments initial The initial values to be stored on the object.
+   *     - Arguments expect The expected values to be after the pre-presistence call.
+   *     - The parent field setup structure for nested pre-persistence.
    */
   private static Stream<Arguments> providePrePersistFor() {
     final Map<String, JsonNode> ic = new HashMap<>();
@@ -251,44 +315,59 @@ class WorkflowTest {
 
     return List.of(
       Arguments.of(
-        helperFieldMap(null,  null,      null,  null,    null,      null,    setupNull),
-        helperFieldMap(false, 0,         "",    icEmpty, emptyList, VERSION, setupNull),
-        helperPersistMap(                                                    null)
+        helperFieldMap(null,  null, null,  null,      null,  null,    null,      null,  null,    setupNull),
+        helperFieldMap(false, null, NOW,   0,         "",    icEmpty, emptyList, NOW,   VERSION, setupNull),
+        helperPersistMap(                                                                        null)
       ),
       Arguments.of(
-        helperFieldMap(true,  null,      null,  null,    null,      null,    setupNull),
-        helperFieldMap(true,  0,         "",    icEmpty, emptyList, VERSION, setupNull),
-        helperPersistMap(                                                    null)
+        helperFieldMap(null,  HASH, null,  null,      null,  null,    null,      null,  null,    setupNull),
+        helperFieldMap(false, HASH, NOW,   0,         "",    icEmpty, emptyList, NOW,   VERSION, setupNull),
+        helperPersistMap(                                                                        null)
       ),
       Arguments.of(
-        helperFieldMap(null,  INT_VALUE, null,  null,    null,      null,    setupNull),
-        helperFieldMap(false, INT_VALUE, "",    icEmpty, emptyList, VERSION, setupNull),
-        helperPersistMap(                                                    null)
+        helperFieldMap(null,  null, LATER, null,      null,  null,    null,      null,  null,    setupNull),
+        helperFieldMap(false, null, LATER, 0,         "",    icEmpty, emptyList, NOW,   VERSION, setupNull),
+        helperPersistMap(                                                                        null)
       ),
       Arguments.of(
-        helperFieldMap(null,  null,      VALUE, null,    null,      null,    setupNull),
-        helperFieldMap(false, 0,         VALUE, icEmpty, emptyList, VERSION, setupNull),
-        helperPersistMap(                                                    null)
+        helperFieldMap(true,  null, null,  null,      null,  null,    null,      null,  null,    setupNull),
+        helperFieldMap(true,  null, NOW,   0,         "",    icEmpty, emptyList, NOW,   VERSION, setupNull),
+        helperPersistMap(                                                                        null)
       ),
       Arguments.of(
-        helperFieldMap(true,  null,      null,  ic,      null,      null,    setupNull),
-        helperFieldMap(true,  0,         "",    ic,      emptyList, VERSION, setupNull),
-        helperPersistMap(                                                    null)
+        helperFieldMap(null,  null, null,  INT_VALUE, null,  null,    null,      null,  null,    setupNull),
+        helperFieldMap(false, null, NOW,   INT_VALUE, "",    icEmpty, emptyList, NOW,   VERSION, setupNull),
+        helperPersistMap(                                                                        null)
       ),
       Arguments.of(
-        helperFieldMap(null,  null,      null,  null,    nodeList,  null,    setupNull),
-        helperFieldMap(false, 0,         "",    icEmpty, nodeList,  VERSION, setupNull),
-        helperPersistMap(                                                    null)
+        helperFieldMap(null,  null, null, null,       VALUE, null,    null,      null,  null,    setupNull),
+        helperFieldMap(false, null, NOW,  0,          VALUE, icEmpty, emptyList, NOW,   VERSION, setupNull),
+        helperPersistMap(                                                                           null)
       ),
       Arguments.of(
-        helperFieldMap(null,  null,      null,  null,    null,      VALUE,   setupNull),
-        helperFieldMap(false, 0,         "",    icEmpty, emptyList, VALUE,   setupNull),
-        helperPersistMap(                                                    null)
+        helperFieldMap(null,  null, null,  null,      null,  ic,      null,      null,  null,    setupNull),
+        helperFieldMap(false, null, NOW,   0,         "",    ic,      emptyList, NOW,   VERSION, setupNull),
+        helperPersistMap(                                                                        null)
       ),
       Arguments.of(
-        helperFieldMap(null,  null,      null,  null,    null,      VALUE,   setup),
-        helperFieldMap(false, 0,         "",    icEmpty, emptyList, VALUE,   setup),
-        helperPersistMap(                                                    true)
+        helperFieldMap(null,  null, null,  null,      null,  null,    nodeList,  null,  null,    setupNull),
+        helperFieldMap(false, null, NOW,   0,         "",    icEmpty, nodeList,  NOW,   VERSION, setupNull),
+        helperPersistMap(                                                                        null)
+      ),
+      Arguments.of(
+        helperFieldMap(null,  null, null,  null,      null,  null,    null,      LATER, null,    setupNull),
+        helperFieldMap(false, null, NOW,   0,         "",    icEmpty, emptyList, LATER, VERSION, setupNull),
+        helperPersistMap(                                                                        null)
+      ),
+      Arguments.of(
+        helperFieldMap(null,  null, null,  null,      null,  null,    null,      null,  VALUE,   setupNull),
+        helperFieldMap(false, null, NOW,   0,         "",    icEmpty, emptyList, NOW,   VALUE,   setupNull),
+        helperPersistMap(                                                                        null)
+      ),
+      Arguments.of(
+        helperFieldMap(null,  null, null,  null,      null,  null,    null,      null,  null,    setup),
+        helperFieldMap(false, null, NOW,   0,         "",    icEmpty, emptyList, NOW,   VERSION, setup),
+        helperPersistMap(                                                                        true)
       )
     ).stream();
   }
@@ -297,24 +376,30 @@ class WorkflowTest {
    * Helper for reducing in line code repetition for assignments.
    *
    * @param active            The active value.
+   * @param checksum          The checksum value.
+   * @param createdOn         The createdOn value.
    * @param historyTimeToLive The historyTimeToLive value.
    * @param name              The name value.
    * @param initialContext    The initialContext value.
    * @param nodes             The nodes value.
+   * @param updatedOn         The updatedOn value.
    * @param versionTag        The versionTag value.
    * @param setup             The setup value.
    *
    * @return The built arguments map.
    */
-  private static Map<String, Object> helperFieldMap(Boolean active, Integer historyTimeToLive, String name, Map<String, JsonNode> initialContext, List<Node> nodes, String versionTag, Setup setup) {
+  private static Map<String, Object> helperFieldMap(Boolean active, String checksum, Instant createdOn, Integer historyTimeToLive, String name, Map<String, JsonNode> initialContext, List<Node> nodes, Instant updatedOn, String versionTag, Setup setup) {
 
     final Map<String, Object> map = new HashMap<>();
 
     map.put("active", active);
+    map.put("checksum", checksum);
+    map.put("createdOn", createdOn);
     map.put("historyTimeToLive", historyTimeToLive);
     map.put("name", name);
     map.put("initialContext", initialContext);
     map.put("nodes", nodes);
+    map.put("updatedOn", updatedOn);
     map.put("versionTag", versionTag);
     map.put("setup", setup);
 

--- a/components/src/test/java/org/folio/rest/workflow/model/WorkflowTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/WorkflowTest.java
@@ -3,7 +3,9 @@ package org.folio.rest.workflow.model;
 import static org.folio.spring.test.mock.MockMvcConstant.INT_VALUE;
 import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.util.ReflectionTestUtils.getField;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
@@ -62,12 +64,12 @@ class WorkflowTest {
 
   @BeforeEach
   void beforeEach() {
-    workflow = Mockito.spy(Workflow.class);
+    workflow = spy(Workflow.class);
     nodes = new ArrayList<>();
     nodes.add(node);
     initialContext = new HashMap<>();
 
-    Mockito.lenient().doReturn(NOW).when(workflow).now();
+    lenient().doReturn(NOW).when(workflow).now();
   }
 
   @Test

--- a/components/src/test/java/org/folio/rest/workflow/model/WorkflowTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/WorkflowTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import tools.jackson.databind.JsonNode;
 
@@ -312,7 +311,7 @@ class WorkflowTest {
 
     final List<Node> emptyList = new ArrayList<>();
 
-    final Setup setup = Mockito.spy(new Setup());
+    final Setup setup = spy(new Setup());
     final Setup setupNull = null;
 
     return List.of(

--- a/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
@@ -254,9 +254,13 @@ public class WorkflowEngineService {
 
         if (responseWorkflow != null) {
           String deploymentId = responseWorkflow.getDeploymentId();
+          Boolean active = responseWorkflow.getActive();
 
+          responseWorkflow.setChecksum(workflow.getChecksum());
+          responseWorkflow.setCreatedOn(workflow.getCreatedOn());
           responseWorkflow.setUpdatedOn(Instant.now());
-          LOG.info(String.format("Workflow is active = %s, deploymentID = %s", Boolean.TRUE.equals(responseWorkflow.getActive()), deploymentId));
+
+          LOG.info(String.format("Workflow is active = %s, deploymentID = %s", Boolean.TRUE.equals(active), deploymentId));
           return workflowRepo.save(responseWorkflow);
         }
       }

--- a/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
@@ -1,5 +1,6 @@
 package org.folio.rest.workflow.service;
 
+import java.time.Instant;
 import java.util.Iterator;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -253,6 +254,8 @@ public class WorkflowEngineService {
 
         if (responseWorkflow != null) {
           String deploymentId = responseWorkflow.getDeploymentId();
+
+          responseWorkflow.setUpdatedOn(Instant.now());
           LOG.info(String.format("Workflow is active = %s, deploymentID = %s", Boolean.TRUE.equals(responseWorkflow.getActive()), deploymentId));
           return workflowRepo.save(responseWorkflow);
         }

--- a/service/src/test/java/org/folio/rest/workflow/controller/WorkflowControllerTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/controller/WorkflowControllerTest.java
@@ -203,7 +203,10 @@ class WorkflowControllerTest {
       String workflowJson = mapper.writeValueAsString(workflow);
 
       assertTrue(mediaType.isCompatibleWith(responseType));
-      assertEquals(workflowJson, result.getResponse().getContentAsString());
+
+      Workflow responseWorkflow = mapper.readValue(result.getResponse().getContentAsString(), Workflow.class);
+
+      assertEquals(workflowJson, mapper.writeValueAsString(responseWorkflow));
     }
   }
 
@@ -232,7 +235,10 @@ class WorkflowControllerTest {
       String workflowJson = mapper.writeValueAsString(workflow);
 
       assertTrue(mediaType.isCompatibleWith(responseType));
-      assertEquals(workflowJson, result.getResponse().getContentAsString());
+
+      Workflow responseWorkflow = mapper.readValue(result.getResponse().getContentAsString(), Workflow.class);
+
+      assertEquals(workflowJson, mapper.writeValueAsString(responseWorkflow));
     }
   }
 
@@ -406,7 +412,10 @@ class WorkflowControllerTest {
       String workflowJson = mapper.writeValueAsString(workflow);
 
       assertTrue(mediaType.isCompatibleWith(responseType));
-      assertEquals(workflowJson, result.getResponse().getContentAsString());
+
+      Workflow responseWorkflow = mapper.readValue(result.getResponse().getContentAsString(), Workflow.class);
+
+      assertEquals(workflowJson, mapper.writeValueAsString(responseWorkflow));
     }
   }
 


### PR DESCRIPTION
Resolves [MODWRKFLOW-69](https://folio-org.atlassian.net/browse/MODWRKFLOW-69) .

Add checksum, created on, and updated on fields.

Provide default time stamps.
Provide interfaces for handling added fields.

Update unit tests.