### PR TITLE
MODWRKFLOW-72: Properly handle when workflow engine does not have a workflow to deactivate on workflow delete.

### DIFF
--- a/service/src/main/java/org/folio/rest/workflow/controller/WorkflowController.java
+++ b/service/src/main/java/org/folio/rest/workflow/controller/WorkflowController.java
@@ -7,6 +7,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.folio.rest.workflow.exception.WorkflowDeploymentNotFound;
 import org.folio.rest.workflow.exception.WorkflowEngineServiceException;
 import org.folio.rest.workflow.exception.WorkflowImportException;
 import org.folio.rest.workflow.exception.WorkflowNotFoundException;
@@ -138,7 +139,7 @@ public class WorkflowController {
     @PathVariable String id,
     @TenantHeader String tenant,
     @TokenHeader String token
-  ) throws WorkflowEngineServiceException {
+  ) throws WorkflowDeploymentNotFound, WorkflowEngineServiceException {
     LOG.debug(String.format("Retrieving History: %s", sanitize(id)));
     return workflowEngineService.history(id, tenant, token);
   }
@@ -149,7 +150,7 @@ public class WorkflowController {
     @TenantHeader String tenant,
     @TokenHeader String token,
     @RequestBody JsonNode context
-  ) throws WorkflowEngineServiceException {
+  ) throws WorkflowDeploymentNotFound, WorkflowEngineServiceException, WorkflowNotFoundException {
     LOG.info(String.format("Starting: %s with context %s", sanitize(id), sanitize(context)));
     return workflowEngineService.start(id, tenant, token, context);
   }

--- a/service/src/main/java/org/folio/rest/workflow/controller/advice/WorkflowControllerAdvice.java
+++ b/service/src/main/java/org/folio/rest/workflow/controller/advice/WorkflowControllerAdvice.java
@@ -5,6 +5,7 @@ import jakarta.persistence.EntityNotFoundException;
 import org.folio.rest.workflow.exception.WorkflowAlreadyActiveException;
 import org.folio.rest.workflow.exception.WorkflowCreateAlreadyExistsException;
 import org.folio.rest.workflow.exception.WorkflowDeploymentException;
+import org.folio.rest.workflow.exception.WorkflowDeploymentNotFound;
 import org.folio.rest.workflow.exception.WorkflowEngineServiceException;
 import org.folio.rest.workflow.exception.WorkflowImportException;
 import org.folio.rest.workflow.exception.WorkflowNotFoundException;
@@ -73,6 +74,12 @@ public class WorkflowControllerAdvice extends AbstractAdvice {
   @ExceptionHandler(WorkflowDeploymentException.class)
   public ResponseEntity<String> handleWorkflowDeploymentException(WorkflowDeploymentException exception) {
     return buildError(exception, HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  @ResponseStatus(HttpStatus.NOT_FOUND)
+  @ExceptionHandler(WorkflowDeploymentNotFound.class)
+  public ResponseEntity<String> handleWorkflowDeploymentNotFound(WorkflowDeploymentNotFound exception) {
+    return buildError(exception, HttpStatus.NOT_FOUND);
   }
 
   @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/service/src/main/java/org/folio/rest/workflow/exception/WorkflowAlreadyActiveException.java
+++ b/service/src/main/java/org/folio/rest/workflow/exception/WorkflowAlreadyActiveException.java
@@ -10,4 +10,8 @@ public class WorkflowAlreadyActiveException extends Exception {
     super(String.format(WORKFLOW_ALREADY_ACTIVE_MESSAGE, id));
   }
 
+  public WorkflowAlreadyActiveException(String id, Exception e) {
+    super(String.format(WORKFLOW_ALREADY_ACTIVE_MESSAGE, id), e);
+  }
+
 }

--- a/service/src/main/java/org/folio/rest/workflow/exception/WorkflowDeploymentNotFound.java
+++ b/service/src/main/java/org/folio/rest/workflow/exception/WorkflowDeploymentNotFound.java
@@ -1,0 +1,26 @@
+package org.folio.rest.workflow.exception;
+
+/**
+ * For providing a 404 when any Workflow deployment is not found in the Workflow Engine.
+ */
+public class WorkflowDeploymentNotFound extends Exception {
+
+  private static final long serialVersionUID = 424162623670077L;
+
+  public WorkflowDeploymentNotFound(String message) {
+    super(message);
+  }
+
+  public WorkflowDeploymentNotFound(String message, Exception e) {
+    super(message, e);
+  }
+
+  public WorkflowDeploymentNotFound(int code) {
+    super(Integer.toString(code));
+  }
+
+  public WorkflowDeploymentNotFound(int code, Exception e) {
+    super(Integer.toString(code), e);
+  }
+
+}

--- a/service/src/main/java/org/folio/rest/workflow/exception/WorkflowNotFoundException.java
+++ b/service/src/main/java/org/folio/rest/workflow/exception/WorkflowNotFoundException.java
@@ -10,4 +10,8 @@ public class WorkflowNotFoundException extends Exception {
     super(String.format(WORKFLOW_NOT_FOUND_MESSAGE, id));
   }
 
+  public WorkflowNotFoundException(String id, Exception e) {
+    super(String.format(WORKFLOW_NOT_FOUND_MESSAGE, id), e);
+  }
+
 }

--- a/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
@@ -7,11 +7,11 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.folio.rest.workflow.dto.WorkflowDto;
 import org.folio.rest.workflow.dto.WorkflowOperationalDto;
+import org.folio.rest.workflow.exception.WorkflowDeploymentNotFound;
 import org.folio.rest.workflow.exception.WorkflowEngineServiceException;
 import org.folio.rest.workflow.exception.WorkflowNotFoundException;
 import org.folio.rest.workflow.model.Workflow;
 import org.folio.rest.workflow.model.repo.WorkflowRepo;
-import org.mockito.ArgumentMatchers;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.restclient.RestTemplateBuilder;
 import org.springframework.http.HttpEntity;
@@ -20,6 +20,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.json.JsonMapper;
@@ -95,13 +96,34 @@ public class WorkflowEngineService {
   public void delete(String workflowId, String tenant, String token)
       throws WorkflowEngineServiceException {
 
-    final ArrayNode node = fetchProcessInstanceHistory(workflowId, tenant, token);
+    final WorkflowOperationalDto workflow = workflowRepo.getViewById(workflowId, WorkflowOperationalDto.class);
+    final String id = workflow.getDeploymentId();
+    final String version = workflow.getVersionTag();
 
-    if (!node.isEmpty()) {
-      try {
-        deactivate(workflowId, tenant, token);
-      } catch (WorkflowEngineServiceException e) {
-        throw new WorkflowEngineServiceException(String.format("Failed to delete Workflow '%s' due to deactivation failure: %s!", workflowId, e.getMessage()), e);
+    // Deployment ID will not exist if it has never been activated.
+    if (id != null) {
+      final ResponseEntity<ArrayNode> response = fetchDeploymentDefinitions(id, version, tenant, token);
+
+      if (response.getStatusCode() == HttpStatus.OK || response.getStatusCode() == HttpStatus.NOT_FOUND) {
+        final ArrayNode definitions = !response.hasBody()
+          ? null
+          : response.getBody();
+
+        if (definitions != null && response.getStatusCode() != HttpStatus.NOT_FOUND && !definitions.isEmpty()) {
+          try {
+            deactivate(workflowId, tenant, token);
+          } catch (WorkflowEngineServiceException e) {
+            final String message = String.format(
+              "Failed to delete Workflow ID '%s' for Deployment ID '%s' and Version Tag '%s' due to deactivation failure: %s!",
+              workflowId,
+              id,
+              version,
+              e.getMessage()
+            );
+
+            throw new WorkflowEngineServiceException(message, e);
+          }
+        }
       }
     }
 
@@ -122,13 +144,23 @@ public class WorkflowEngineService {
   }
 
   public JsonNode start(String workflowId, String tenant, String token, JsonNode context)
-      throws WorkflowEngineServiceException {
+      throws WorkflowDeploymentNotFound, WorkflowEngineServiceException, WorkflowNotFoundException {
 
     WorkflowOperationalDto workflow = workflowRepo.getViewById(workflowId, WorkflowOperationalDto.class);
+
+    if (workflow == null) {
+      throw new WorkflowNotFoundException(String.format("Workflow ID '%s'", workflowId));
+    }
+
     String id = workflow.getDeploymentId();
     String version = workflow.getVersionTag();
 
-    JsonNode definition = fetchDeploymentDefinition(id, version, tenant, token);
+    JsonNode definition = fetchFirstDeploymentDefinition(workflowId, id, version, tenant, token);
+
+    if (!definition.has("id") ) {
+      throw new WorkflowEngineServiceException(String.format("Workflow ID '%s' with Deployment ID '%s' has no definition ID!", workflowId, id));
+    }
+
     String definitionId = definition.get("id").asString();
 
     HttpEntity<JsonNode> contextHttpEntity = new HttpEntity<>(context, headers(tenant, token));
@@ -137,20 +169,26 @@ public class WorkflowEngineService {
     Map<String, Object> params = Map.of("arg1", definitionId);
 
     try {
-      ResponseEntity<JsonNode> response = exchange(url, HttpMethod.POST, contextHttpEntity, JsonNode.class, params);
+      final ResponseEntity<JsonNode> response = exchange(url, HttpMethod.POST, contextHttpEntity, JsonNode.class, params);
+
+      if (response.getStatusCode() == HttpStatus.NOT_FOUND) {
+        throw new WorkflowNotFoundException(String.format("Workflow ID '%s'", workflowId));
+      }
 
       return response.getBody();
-    } catch (Exception e) {
+    } catch (RestClientException e) {
       throw new WorkflowEngineServiceException(String.format("Failed to start workflow: %s!", e.getMessage()), e);
     }
   }
 
-  public JsonNode history(String workflowId, String tenant, String token) throws WorkflowEngineServiceException {
+  public JsonNode history(String workflowId, String tenant, String token)
+      throws WorkflowDeploymentNotFound, WorkflowEngineServiceException {
+
     WorkflowOperationalDto workflow = workflowRepo.getViewById(workflowId, WorkflowOperationalDto.class);
-    String deploymentId = workflow.getDeploymentId();
+    String id = workflow.getDeploymentId();
     String version = workflow.getVersionTag();
 
-    JsonNode processDefinition = fetchDeploymentDefinition(deploymentId, version, tenant, token);
+    JsonNode processDefinition = fetchFirstDeploymentDefinition(workflowId, id, version, tenant, token);
     String processDefinitionId = processDefinition.get("id").asString();
 
     ArrayNode instances = fetchProcessInstanceHistory(processDefinitionId, tenant, token);
@@ -168,24 +206,66 @@ public class WorkflowEngineService {
     return instances;
   }
 
-  private JsonNode fetchDeploymentDefinition(String deploymentId, String version, String tenant, String token)
-      throws WorkflowEngineServiceException {
+  /**
+   * Fetch the first matching deployment for the given workflow.
+   *
+   * @param workflowId   The Workflow ID, for use in exception logs.
+   * @param deploymentId The Deployment ID to find.
+   * @param version      The version tag to use.
+   * @param tenant       The FOLIO tenant.
+   * @param token        The session token.
+   *
+   * @return The first matching response.
+   *
+   * @throws WorkflowDeploymentNotFound     On not found.
+   * @throws WorkflowEngineServiceException On error.
+   */
+  private JsonNode fetchFirstDeploymentDefinition(String workflowId, String deploymentId, String version, String tenant, String token)
+      throws WorkflowDeploymentNotFound, WorkflowEngineServiceException {
 
-    HttpEntity<Void> httpEntity = new HttpEntity<>(headers(tenant, token));
+    final ResponseEntity<ArrayNode> response = fetchDeploymentDefinitions(deploymentId, version, tenant, token);
 
-    String url = String.format(PROCESS_DEFINITION_GET_URL_TEMPLATE, okapiUrl, restPath);
-    Map<String, Object> params = Map.of("arg1", deploymentId, "arg2", version);
+    if (response.getStatusCode() == HttpStatus.OK || response.getStatusCode() == HttpStatus.NOT_FOUND) {
+      final ArrayNode definitions = !response.hasBody()
+        ? null
+        : response.getBody();
 
-    try {
-      ResponseEntity<ArrayNode> response = exchange(url, HttpMethod.GET, httpEntity, ArrayNode.class, params);
-
-      ArrayNode definitions = response.getBody();
-      if (response.getStatusCode() == HttpStatus.OK && definitions != null && !definitions.isEmpty()) {
-        return definitions.get(0);
+      if (definitions == null || response.getStatusCode() == HttpStatus.NOT_FOUND || definitions.isEmpty() || definitions.get(0) == null) {
+        throw new WorkflowDeploymentNotFound(String.format("Workflow with Deployment ID '%s' for Workflow ID '%s' is not found.", deploymentId, workflowId));
       }
 
-      throw new WorkflowEngineServiceException("Unable to get workflow process definition from workflow engine!");
-    } catch (Exception e) {
+      return definitions.get(0);
+    }
+
+    throw new WorkflowEngineServiceException("Unable to get workflow process definition from workflow engine!");
+  }
+
+  /**
+   * Fetch all deployments, but return the response entity to allow caller to handle.
+   *
+   * @param deploymentId The activated Workflow deployment ID.
+   * @param version      The Workflow version number.
+   * @param tenant       The tenant.
+   * @param token        The token.
+   *
+   * @return The response entity.
+   *
+   * @throws WorkflowEngineServiceException On error.
+   */
+  private ResponseEntity<ArrayNode> fetchDeploymentDefinitions(String deploymentId, String version, String tenant, String token)
+      throws WorkflowEngineServiceException {
+
+    if (deploymentId == null) {
+      throw new WorkflowEngineServiceException("Failed to deployment definition: Deployment ID is missing!");
+    }
+
+    final HttpEntity<Void> httpEntity = new HttpEntity<>(headers(tenant, token));
+    final String url = String.format(PROCESS_DEFINITION_GET_URL_TEMPLATE, okapiUrl, restPath);
+    final Map<String, Object> params = Map.of("arg1", deploymentId, "arg2", version);
+
+    try {
+      return exchange(url, HttpMethod.GET, httpEntity, ArrayNode.class, params);
+    } catch (RestClientException e) {
       throw new WorkflowEngineServiceException(String.format("Failed to deployment definition: %s!", e.getMessage()), e);
     }
   }
@@ -207,7 +287,7 @@ public class WorkflowEngineService {
       }
 
       throw new WorkflowEngineServiceException("Unable to get workflow process instance history from workflow engine!");
-    } catch (Exception e) {
+    } catch (RestClientException e) {
       throw new WorkflowEngineServiceException(String.format("Failed to fetch process instance history: %s!", e.getMessage()), e);
     }
   }
@@ -230,7 +310,7 @@ public class WorkflowEngineService {
       }
 
       return incidents;
-    } catch (Exception e) {
+    } catch (RestClientException e) {
       throw new WorkflowEngineServiceException(String.format("Failed to fetch incident history: %s!", e.getMessage()), e);
     }
   }
@@ -273,7 +353,7 @@ public class WorkflowEngineService {
           return workflowRepo.save(responseWorkflow);
         }
       }
-    } catch (Exception e) {
+    } catch (RestClientException e) {
       throw new WorkflowEngineServiceException(String.format("Failed to send workflow request: %s!", e.getMessage()), e);
     }
 
@@ -296,9 +376,9 @@ public class WorkflowEngineService {
     return requestHeaders;
   }
 
-  private <T> ResponseEntity<T> exchange(String url, HttpMethod method, HttpEntity<?> request, Class<T> responseType, Map<String, ?> params) {
-    LOG.debug(String.format("Exchange for %s %s %s", responseType.getSimpleName(), method, url));
-    return this.restTemplate.exchange(url, method, request, responseType, (Object[]) new String[0], params);
+  private <T> ResponseEntity<T> exchange(String url, HttpMethod method, HttpEntity<?> request, Class<T> responseType, Map<String, ? extends Object> params) {
+    LOG.debug(String.format("Exchange for %s %s %s %s", responseType.getSimpleName(), method, url, params));
+    return this.restTemplate.exchange(url, method, request, responseType, params);
   }
 
 }

--- a/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
@@ -105,9 +105,9 @@ public class WorkflowEngineService {
       final ResponseEntity<ArrayNode> response = fetchDeploymentDefinitions(id, version, tenant, token);
 
       if (response.getStatusCode() == HttpStatus.OK || response.getStatusCode() == HttpStatus.NOT_FOUND) {
-        final ArrayNode definitions = !response.hasBody()
-          ? null
-          : response.getBody();
+        final ArrayNode definitions = response.hasBody()
+          ? response.getBody()
+          : null;
 
         if (definitions != null && response.getStatusCode() != HttpStatus.NOT_FOUND && !definitions.isEmpty()) {
           try {
@@ -197,10 +197,13 @@ public class WorkflowEngineService {
 
     while (iter.hasNext()) {
       JsonNode instance = iter.next();
-      String processInstanceId = instance.get("id").asString();
 
-      ((ObjectNode) instance).withArray("incidents")
-        .addAll(fetchIncidentsHistory(processInstanceId, tenant, token));
+      if (instance.has("id")) {
+        String processInstanceId = instance.get("id").asString();
+
+        ((ObjectNode) instance).withArray("incidents")
+          .addAll(fetchIncidentsHistory(processInstanceId, tenant, token));
+      }
     }
 
     return instances;
@@ -226,9 +229,9 @@ public class WorkflowEngineService {
     final ResponseEntity<ArrayNode> response = fetchDeploymentDefinitions(deploymentId, version, tenant, token);
 
     if (response.getStatusCode() == HttpStatus.OK || response.getStatusCode() == HttpStatus.NOT_FOUND) {
-      final ArrayNode definitions = !response.hasBody()
-        ? null
-        : response.getBody();
+      final ArrayNode definitions = response.hasBody()
+        ? response.getBody()
+        : null;
 
       if (definitions == null || response.getStatusCode() == HttpStatus.NOT_FOUND || definitions.isEmpty() || definitions.get(0) == null) {
         throw new WorkflowDeploymentNotFound(String.format("Workflow with Deployment ID '%s' for Workflow ID '%s' is not found.", deploymentId, workflowId));
@@ -281,8 +284,11 @@ public class WorkflowEngineService {
     try {
       ResponseEntity<ArrayNode> response = exchange(url, HttpMethod.GET, httpEntity, ArrayNode.class, params);
 
-      ArrayNode definitions = response.getBody();
-      if (response.getStatusCode() == HttpStatus.OK && definitions != null) {
+      final ArrayNode definitions = response.hasBody()
+        ? response.getBody()
+        : null;
+
+      if (definitions != null && response.getStatusCode() == HttpStatus.OK) {
         return definitions;
       }
 
@@ -302,8 +308,11 @@ public class WorkflowEngineService {
     try {
       ResponseEntity<ArrayNode> response = exchange(url, HttpMethod.GET, httpEntity, ArrayNode.class, params);
 
-      ArrayNode incidents = response.getBody();
-      if (response.getStatusCode() != HttpStatus.OK || incidents == null) {
+      ArrayNode incidents = response.hasBody()
+        ? response.getBody()
+        : null;
+
+      if (incidents == null || response.getStatusCode() != HttpStatus.OK) {
         LOG.debug("Unable to get workflow incidents history from workflow engine!");
 
         incidents = mapper.createArrayNode();

--- a/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
@@ -32,6 +32,7 @@ public class WorkflowEngineService {
   private static final String WORKFLOW_ENGINE_ACTIVATE_URL_TEMPLATE = "%s%s/workflow-engine/workflows/activate";
   private static final String WORKFLOW_ENGINE_DEACTIVATE_URL_TEMPLATE = "%s%s/workflow-engine/workflows/deactivate";
 
+  private static final String PROCESS_DEFINITION_SORTED_URL_TEMPLATE = "%s%s/processDefinitionId=%s&sortBy=startTime&sortOrder=asc";
   private static final String PROCESS_DEFINITION_START_URL_TEMPLATE = "%s%s/process-definition/%s/start";
   private static final String PROCESS_DEFINITION_GET_URL_TEMPLATE = "%s%s/process-definition%s";
 
@@ -93,10 +94,14 @@ public class WorkflowEngineService {
   public void delete(String workflowId, String tenant, String token)
       throws WorkflowEngineServiceException {
 
-    try {
-      deactivate(workflowId, tenant, token);
-    } catch (WorkflowEngineServiceException e) {
-      throw new WorkflowEngineServiceException(String.format("Failed to delete Workflow '%s' due to deactivation failure: %s!", workflowId, e.getMessage()), e);
+    final ArrayNode node = fetchProcessInstanceHistory(workflowId, tenant, token);
+
+    if (!node.isEmpty()) {
+      try {
+        deactivate(workflowId, tenant, token);
+      } catch (WorkflowEngineServiceException e) {
+        throw new WorkflowEngineServiceException(String.format("Failed to delete Workflow '%s' due to deactivation failure: %s!", workflowId, e.getMessage()), e);
+      }
     }
 
     workflowRepo.deleteById(workflowId);
@@ -187,7 +192,7 @@ public class WorkflowEngineService {
 
     HttpEntity<Void> httpEntity = new HttpEntity<>(headers(tenant, token));
 
-    String arguments = String.format("?processDefinitionId=%s&sortBy=startTime&sortOrder=asc", processDefinitionId);
+    String arguments = String.format(PROCESS_DEFINITION_SORTED_URL_TEMPLATE, okapiUrl, restPath, processDefinitionId);
     String url = String.format(HISTORY_PROCESS_INSTANCE_URL_TEMPLATE, okapiUrl, restPath, arguments);
 
     try {

--- a/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
@@ -2,6 +2,7 @@ package org.folio.rest.workflow.service;
 
 import java.time.Instant;
 import java.util.Iterator;
+import java.util.Map;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.folio.rest.workflow.dto.WorkflowDto;
@@ -10,6 +11,7 @@ import org.folio.rest.workflow.exception.WorkflowEngineServiceException;
 import org.folio.rest.workflow.exception.WorkflowNotFoundException;
 import org.folio.rest.workflow.model.Workflow;
 import org.folio.rest.workflow.model.repo.WorkflowRepo;
+import org.mockito.ArgumentMatchers;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.restclient.RestTemplateBuilder;
 import org.springframework.http.HttpEntity;
@@ -32,12 +34,11 @@ public class WorkflowEngineService {
   private static final String WORKFLOW_ENGINE_ACTIVATE_URL_TEMPLATE = "%s%s/workflow-engine/workflows/activate";
   private static final String WORKFLOW_ENGINE_DEACTIVATE_URL_TEMPLATE = "%s%s/workflow-engine/workflows/deactivate";
 
-  private static final String PROCESS_DEFINITION_SORTED_URL_TEMPLATE = "%s%s/processDefinitionId=%s&sortBy=startTime&sortOrder=asc";
-  private static final String PROCESS_DEFINITION_START_URL_TEMPLATE = "%s%s/process-definition/%s/start";
-  private static final String PROCESS_DEFINITION_GET_URL_TEMPLATE = "%s%s/process-definition%s";
+  private static final String PROCESS_DEFINITION_START_URL_TEMPLATE = "%s%s/process-definition/{arg1}/start";
+  private static final String PROCESS_DEFINITION_GET_URL_TEMPLATE = "%s%s/process-definition?deploymentId={arg1}&versionTag={arg2}&maxResults=1";
 
-  private static final String HISTORY_PROCESS_INSTANCE_URL_TEMPLATE = "%s%s/history/process-instance%s";
-  private static final String HISTORY_INCIDENT_URL_TEMPLATE = "%s%s/history/incident%s";
+  private static final String HISTORY_PROCESS_INSTANCE_URL_TEMPLATE = "%s%s/history/process-instance?processDefinitionId={arg1}&sortBy=startTime&sortOrder=asc";
+  private static final String HISTORY_INCIDENT_URL_TEMPLATE = "%s%s/history/incident?processInstanceId={arg1}&sortBy=createTime&sortOrder=asc";
 
   @Value("${tenant.headerName:X-Okapi-Tenant}")
   private String tenantHeaderName;
@@ -132,9 +133,11 @@ public class WorkflowEngineService {
 
     HttpEntity<JsonNode> contextHttpEntity = new HttpEntity<>(context, headers(tenant, token));
 
-    String url = String.format(PROCESS_DEFINITION_START_URL_TEMPLATE, okapiUrl, restPath, definitionId);
+    String url = String.format(PROCESS_DEFINITION_START_URL_TEMPLATE, okapiUrl, restPath);
+    Map<String, Object> params = Map.of("arg1", definitionId);
+
     try {
-      ResponseEntity<JsonNode> response = exchange(url, HttpMethod.POST, contextHttpEntity, JsonNode.class);
+      ResponseEntity<JsonNode> response = exchange(url, HttpMethod.POST, contextHttpEntity, JsonNode.class, params);
 
       return response.getBody();
     } catch (Exception e) {
@@ -170,11 +173,11 @@ public class WorkflowEngineService {
 
     HttpEntity<Void> httpEntity = new HttpEntity<>(headers(tenant, token));
 
-    String arguments = String.format("?deploymentId=%s&versionTag=%s&maxResults=1", deploymentId, version);
-    String url = String.format(PROCESS_DEFINITION_GET_URL_TEMPLATE, okapiUrl, restPath, arguments);
+    String url = String.format(PROCESS_DEFINITION_GET_URL_TEMPLATE, okapiUrl, restPath);
+    Map<String, Object> params = Map.of("arg1", deploymentId, "arg2", version);
 
     try {
-      ResponseEntity<ArrayNode> response = exchange(url, HttpMethod.GET, httpEntity, ArrayNode.class);
+      ResponseEntity<ArrayNode> response = exchange(url, HttpMethod.GET, httpEntity, ArrayNode.class, params);
 
       ArrayNode definitions = response.getBody();
       if (response.getStatusCode() == HttpStatus.OK && definitions != null && !definitions.isEmpty()) {
@@ -192,11 +195,11 @@ public class WorkflowEngineService {
 
     HttpEntity<Void> httpEntity = new HttpEntity<>(headers(tenant, token));
 
-    String arguments = String.format(PROCESS_DEFINITION_SORTED_URL_TEMPLATE, okapiUrl, restPath, processDefinitionId);
-    String url = String.format(HISTORY_PROCESS_INSTANCE_URL_TEMPLATE, okapiUrl, restPath, arguments);
+    String url = String.format(HISTORY_PROCESS_INSTANCE_URL_TEMPLATE, okapiUrl, restPath);
+    Map<String, Object> params = Map.of("arg1", processDefinitionId);
 
     try {
-      ResponseEntity<ArrayNode> response = exchange(url, HttpMethod.GET, httpEntity, ArrayNode.class);
+      ResponseEntity<ArrayNode> response = exchange(url, HttpMethod.GET, httpEntity, ArrayNode.class, params);
 
       ArrayNode definitions = response.getBody();
       if (response.getStatusCode() == HttpStatus.OK && definitions != null) {
@@ -213,11 +216,11 @@ public class WorkflowEngineService {
 
     HttpEntity<Void> httpEntity = new HttpEntity<>(headers(tenant, token));
 
-    String arguments = String.format("?processInstanceId=%s&sortBy=createTime&sortOrder=asc", processInstanceId);
-    String url = String.format(HISTORY_INCIDENT_URL_TEMPLATE, okapiUrl, restPath, arguments);
+    String url = String.format(HISTORY_INCIDENT_URL_TEMPLATE, okapiUrl, restPath);
+    Map<String, Object> params = Map.of("arg1", processInstanceId);
 
     try {
-      ResponseEntity<ArrayNode> response = exchange(url, HttpMethod.GET, httpEntity, ArrayNode.class);
+      ResponseEntity<ArrayNode> response = exchange(url, HttpMethod.GET, httpEntity, ArrayNode.class, params);
 
       ArrayNode incidents = response.getBody();
       if (response.getStatusCode() != HttpStatus.OK || incidents == null) {
@@ -249,10 +252,11 @@ public class WorkflowEngineService {
 
     HttpEntity<WorkflowDto> entity = new HttpEntity<>(workflow, headers(tenant, token));
     String url = String.format(requestPath, okapiUrl, basePath);
+
     LOG.debug(String.format("Send Okapi workflow engine request %s %s", HttpMethod.POST, url));
 
     try {
-      ResponseEntity<Workflow> response = exchange(url, HttpMethod.POST, entity, Workflow.class);
+      ResponseEntity<Workflow> response = exchange(url, HttpMethod.POST, entity, Workflow.class, Map.of());
 
       if (response.getStatusCode() == HttpStatus.OK) {
         Workflow responseWorkflow = response.getBody();
@@ -292,9 +296,9 @@ public class WorkflowEngineService {
     return requestHeaders;
   }
 
-  private <T> ResponseEntity<T> exchange(String url, HttpMethod method, HttpEntity<?> request, Class<T> responseType) {
+  private <T> ResponseEntity<T> exchange(String url, HttpMethod method, HttpEntity<?> request, Class<T> responseType, Map<String, ?> params) {
     LOG.debug(String.format("Exchange for %s %s %s", responseType.getSimpleName(), method, url));
-    return this.restTemplate.exchange(url, method, request, responseType, (Object[]) new String[0]);
+    return this.restTemplate.exchange(url, method, request, responseType, (Object[]) new String[0], params);
   }
 
 }

--- a/service/src/test/java/org/folio/rest/workflow/controller/advice/WorkflowControllerAdviceTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/controller/advice/WorkflowControllerAdviceTest.java
@@ -1,5 +1,6 @@
 package org.folio.rest.workflow.controller.advice;
 
+import static org.folio.spring.test.mock.MockMvcConstant.INT_VALUE;
 import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -21,7 +22,6 @@ import org.folio.rest.workflow.exception.WorkflowImportJsonFileIsDirectory;
 import org.folio.rest.workflow.exception.WorkflowImportRequiredFileMissing;
 import org.folio.rest.workflow.exception.WorkflowNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -36,27 +36,43 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 class WorkflowControllerAdviceTest {
 
-  private static final EntityNotFoundException ENF_EXC = new EntityNotFoundException(VALUE);
+  private static final RuntimeException R_EXC = new RuntimeException(VALUE);
 
-  private static final WorkflowCreateAlreadyExistsException WCAE_EXC = new WorkflowCreateAlreadyExistsException(VALUE, VALUE);
+  private static final EntityNotFoundException ENF_EXC1 = new EntityNotFoundException(VALUE);
+  private static final EntityNotFoundException ENF_EXC2 = new EntityNotFoundException(VALUE, R_EXC);
 
-  private static final WorkflowNotFoundException WNF_EXC = new WorkflowNotFoundException(VALUE);
+  private static final WorkflowCreateAlreadyExistsException WCAE_EXC1 = new WorkflowCreateAlreadyExistsException(VALUE, VALUE);
+  private static final WorkflowCreateAlreadyExistsException WCAE_EXC2 = new WorkflowCreateAlreadyExistsException(VALUE, VALUE, R_EXC);
 
-  private static final WorkflowAlreadyActiveException WAA_EXC = new WorkflowAlreadyActiveException(VALUE);
+  private static final WorkflowNotFoundException WNF_EXC1 = new WorkflowNotFoundException(VALUE);
+  private static final WorkflowNotFoundException WNF_EXC2 = new WorkflowNotFoundException(VALUE, R_EXC);
 
-  private static final WorkflowDeploymentException WD_EXC = new WorkflowDeploymentException();
+  private static final WorkflowAlreadyActiveException WAA_EXC1 = new WorkflowAlreadyActiveException(VALUE);
+  private static final WorkflowAlreadyActiveException WAA_EXC2 = new WorkflowAlreadyActiveException(VALUE, R_EXC);
 
-  private static final WorkflowDeploymentNotFound WDNF_EXC = new WorkflowDeploymentNotFound(VALUE);
+  private static final WorkflowDeploymentException WD_EXC1 = new WorkflowDeploymentException();
 
-  private static final WorkflowEngineServiceException WES_EXC = new WorkflowEngineServiceException(VALUE);
+  private static final WorkflowDeploymentNotFound WDNF_EXC1 = new WorkflowDeploymentNotFound(VALUE);
+  private static final WorkflowDeploymentNotFound WDNF_EXC2 = new WorkflowDeploymentNotFound(VALUE, R_EXC);
+  private static final WorkflowDeploymentNotFound WDNF_EXC3 = new WorkflowDeploymentNotFound(INT_VALUE);
+  private static final WorkflowDeploymentNotFound WDNF_EXC4 = new WorkflowDeploymentNotFound(INT_VALUE, R_EXC);
 
-  private static final WorkflowImportAlreadyImported WIAI_EXC = new WorkflowImportAlreadyImported(VALUE);
+  private static final WorkflowEngineServiceException WES_EXC1 = new WorkflowEngineServiceException(VALUE);
+  private static final WorkflowEngineServiceException WES_EXC2 = new WorkflowEngineServiceException(VALUE, R_EXC);
+  private static final WorkflowEngineServiceException WES_EXC3 = new WorkflowEngineServiceException(INT_VALUE);
+  private static final WorkflowEngineServiceException WES_EXC4 = new WorkflowEngineServiceException(INT_VALUE, R_EXC);
 
-  private static final WorkflowImportInvalidOrMissingProperty WIIOMP_EXC = new WorkflowImportInvalidOrMissingProperty(VALUE, VALUE);
+  private static final WorkflowImportAlreadyImported WIAI_EXC1 = new WorkflowImportAlreadyImported(VALUE);
+  private static final WorkflowImportAlreadyImported WIAI_EXC2 = new WorkflowImportAlreadyImported(VALUE, R_EXC);
 
-  private static final WorkflowImportJsonFileIsDirectory WIJFID_EXC = new WorkflowImportJsonFileIsDirectory(VALUE);
+  private static final WorkflowImportInvalidOrMissingProperty WIIOMP_EXC1 = new WorkflowImportInvalidOrMissingProperty(VALUE, VALUE);
+  private static final WorkflowImportInvalidOrMissingProperty WIIOMP_EXC2 = new WorkflowImportInvalidOrMissingProperty(VALUE, VALUE, R_EXC);
 
-  private static final WorkflowImportRequiredFileMissing WIRFM_EXC = new WorkflowImportRequiredFileMissing(VALUE);
+  private static final WorkflowImportJsonFileIsDirectory WIJFID_EXC1 = new WorkflowImportJsonFileIsDirectory(VALUE);
+  private static final WorkflowImportJsonFileIsDirectory WIJFID_EXC2 = new WorkflowImportJsonFileIsDirectory(VALUE, R_EXC);
+
+  private static final WorkflowImportRequiredFileMissing WIRFM_EXC1 = new WorkflowImportRequiredFileMissing(VALUE);
+  private static final WorkflowImportRequiredFileMissing WIRFM_EXC2 = new WorkflowImportRequiredFileMissing(VALUE, R_EXC);
 
   private WorkflowControllerAdvice advice;
 
@@ -65,26 +81,25 @@ class WorkflowControllerAdviceTest {
     advice = new WorkflowControllerAdvice();
   }
 
-  @Test
-  void handleEntityNotFoundExceptionTest() {
+  @ParameterizedTest
+  @MethodSource("provideEntityNotFoundExceptions")
+  void handleEntityNotFoundExceptionTest(EntityNotFoundException exception, String simpleName) {
 
-    final String simpleName = EntityNotFoundException.class.getSimpleName();
-    final ResponseEntity<String> response = advice.handleEntityNotFoundException(ENF_EXC);
+    final ResponseEntity<String> response = advice.handleEntityNotFoundException(exception);
 
     assertNotNull(response);
     assertNotNull(response.getBody());
 
     assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
     assertEquals(MediaType.APPLICATION_JSON, response.getHeaders().getContentType());
-
     assertTrue(matchBody(response, simpleName));
   }
 
-  @Test
-  void handleWorkflowCreateAlreadyExistsExceptionTest() {
+  @ParameterizedTest
+  @MethodSource("provideWorkflowCreateAlreadyExistsExceptions")
+  void handleWorkflowCreateAlreadyExistsExceptionTest(WorkflowCreateAlreadyExistsException exception, String simpleName) {
 
-    final String simpleName = WorkflowCreateAlreadyExistsException.class.getSimpleName();
-    final ResponseEntity<String> response = advice.handleWorkflowCreateAlreadyExistsException(WCAE_EXC);
+    final ResponseEntity<String> response = advice.handleWorkflowCreateAlreadyExistsException(exception);
 
     assertNotNull(response);
     assertNotNull(response.getBody());
@@ -94,11 +109,11 @@ class WorkflowControllerAdviceTest {
     assertTrue(matchBody(response, simpleName));
   }
 
-  @Test
-  void handleWorkflowNotFoundExceptionTest() {
+  @ParameterizedTest
+  @MethodSource("provideWorkflowNotFoundExceptions")
+  void handleWorkflowNotFoundExceptionTest(WorkflowNotFoundException exception, String simpleName) {
 
-    final String simpleName = WorkflowNotFoundException.class.getSimpleName();
-    final ResponseEntity<String> response = advice.handleWorkflowNotFoundException(WNF_EXC);
+    final ResponseEntity<String> response = advice.handleWorkflowNotFoundException(exception);
 
     assertNotNull(response);
     assertNotNull(response.getBody());
@@ -108,11 +123,11 @@ class WorkflowControllerAdviceTest {
     assertTrue(matchBody(response, simpleName));
   }
 
-  @Test
-  void handleWorkflowAlreadyActiveExceptionTest() {
+  @ParameterizedTest
+  @MethodSource("provideWorkflowAlreadyActiveExceptions")
+  void handleWorkflowAlreadyActiveExceptionTest(WorkflowAlreadyActiveException exception, String simpleName) {
 
-    final String simpleName = WorkflowAlreadyActiveException.class.getSimpleName();
-    final ResponseEntity<String> response = advice.handleWorkflowAlreadyActiveException(WAA_EXC);
+    final ResponseEntity<String> response = advice.handleWorkflowAlreadyActiveException(exception);
 
     assertNotNull(response);
     assertNotNull(response.getBody());
@@ -122,11 +137,11 @@ class WorkflowControllerAdviceTest {
     assertTrue(matchBody(response, simpleName));
   }
 
-  @Test
-  void handleWorkflowDeploymentExceptionTest() {
+  @ParameterizedTest
+  @MethodSource("provideWorkflowDeploymentExceptions")
+  void handleWorkflowDeploymentExceptionTest(WorkflowDeploymentException exception, String simpleName) {
 
-    final String simpleName = WorkflowDeploymentException.class.getSimpleName();
-    final ResponseEntity<String> response = advice.handleWorkflowDeploymentException(WD_EXC);
+    final ResponseEntity<String> response = advice.handleWorkflowDeploymentException(exception);
 
     assertNotNull(response);
     assertNotNull(response.getBody());
@@ -136,11 +151,11 @@ class WorkflowControllerAdviceTest {
     assertTrue(matchBody(response, simpleName));
   }
 
-  @Test
-  void handleWorkflowDeploymentNotFoundTest() {
+  @ParameterizedTest
+  @MethodSource("provideWorkflowDeploymentNotFounds")
+  void handleWorkflowDeploymentNotFoundTest(WorkflowDeploymentNotFound exception, String simpleName) {
 
-    final String simpleName = WorkflowDeploymentNotFound.class.getSimpleName();
-    final ResponseEntity<String> response = advice.handleWorkflowDeploymentNotFound(WDNF_EXC);
+    final ResponseEntity<String> response = advice.handleWorkflowDeploymentNotFound(exception);
 
     assertNotNull(response);
     assertNotNull(response.getBody());
@@ -150,11 +165,11 @@ class WorkflowControllerAdviceTest {
     assertTrue(matchBody(response, simpleName));
   }
 
-  @Test
-  void handleWorkflowEngineServiceExceptionTest() {
+  @ParameterizedTest
+  @MethodSource("provideWorkflowEngineServiceExceptions")
+  void handleWorkflowEngineServiceExceptionTest(WorkflowEngineServiceException exception, String simpleName) {
 
-    final String simpleName = WorkflowEngineServiceException.class.getSimpleName();
-    final ResponseEntity<String> response = advice.handleWorkflowEngineServiceException(WES_EXC);
+    final ResponseEntity<String> response = advice.handleWorkflowEngineServiceException(exception);
 
     assertNotNull(response);
     assertNotNull(response.getBody());
@@ -195,6 +210,121 @@ class WorkflowControllerAdviceTest {
   }
 
   /**
+   * Helper function for parameterized test providing different types of EntityNotFoundException.
+   *
+   * @return
+   *   The arguments array stream with the stream columns as:
+   *     - Exception exception.
+   *     - String simpleName (exception name to match).
+   */
+  private static Stream<Arguments> provideEntityNotFoundExceptions() {
+
+    return Stream.of(
+      Arguments.of(ENF_EXC1,  EntityNotFoundException.class.getSimpleName()),
+      Arguments.of(ENF_EXC2, EntityNotFoundException.class.getSimpleName())
+    );
+  }
+
+  /**
+   * Helper function for parameterized test providing different types of WorkflowCreateAlreadyExistsException.
+   *
+   * @return
+   *   The arguments array stream with the stream columns as:
+   *     - Exception exception.
+   *     - String simpleName (exception name to match).
+   */
+  private static Stream<Arguments> provideWorkflowCreateAlreadyExistsExceptions() {
+
+    return Stream.of(
+      Arguments.of(WCAE_EXC1,  WorkflowCreateAlreadyExistsException.class.getSimpleName()),
+      Arguments.of(WCAE_EXC2, WorkflowCreateAlreadyExistsException.class.getSimpleName())
+    );
+  }
+
+  /**
+   * Helper function for parameterized test providing different types of WorkflowNotFoundException.
+   *
+   * @return
+   *   The arguments array stream with the stream columns as:
+   *     - Exception exception.
+   *     - String simpleName (exception name to match).
+   */
+  private static Stream<Arguments> provideWorkflowNotFoundExceptions() {
+
+    return Stream.of(
+      Arguments.of(WNF_EXC1,  WorkflowNotFoundException.class.getSimpleName()),
+      Arguments.of(WNF_EXC2, WorkflowNotFoundException.class.getSimpleName())
+    );
+  }
+
+  /**
+   * Helper function for parameterized test providing different types of WorkflowAlreadyActiveException.
+   *
+   * @return
+   *   The arguments array stream with the stream columns as:
+   *     - Exception exception.
+   *     - String simpleName (exception name to match).
+   */
+  private static Stream<Arguments> provideWorkflowAlreadyActiveExceptions() {
+
+    return Stream.of(
+      Arguments.of(WAA_EXC1,  WorkflowAlreadyActiveException.class.getSimpleName()),
+      Arguments.of(WAA_EXC2, WorkflowAlreadyActiveException.class.getSimpleName())
+    );
+  }
+
+  /**
+   * Helper function for parameterized test providing different types of WorkflowDeploymentException.
+   *
+   * @return
+   *   The arguments array stream with the stream columns as:
+   *     - Exception exception.
+   *     - String simpleName (exception name to match).
+   */
+  private static Stream<Arguments> provideWorkflowDeploymentExceptions() {
+
+    return Stream.of(
+      Arguments.of(WD_EXC1,  WorkflowDeploymentException.class.getSimpleName())
+    );
+  }
+
+  /**
+   * Helper function for parameterized test providing different types of WorkflowDeploymentNotFound.
+   *
+   * @return
+   *   The arguments array stream with the stream columns as:
+   *     - Exception exception.
+   *     - String simpleName (exception name to match).
+   */
+  private static Stream<Arguments> provideWorkflowDeploymentNotFounds() {
+
+    return Stream.of(
+      Arguments.of(WDNF_EXC1,  WorkflowDeploymentNotFound.class.getSimpleName()),
+      Arguments.of(WDNF_EXC2, WorkflowDeploymentNotFound.class.getSimpleName()),
+      Arguments.of(WDNF_EXC3, WorkflowDeploymentNotFound.class.getSimpleName()),
+      Arguments.of(WDNF_EXC4, WorkflowDeploymentNotFound.class.getSimpleName())
+    );
+  }
+
+  /**
+   * Helper function for parameterized test providing different types of WorkflowEngineServiceException.
+   *
+   * @return
+   *   The arguments array stream with the stream columns as:
+   *     - Exception exception.
+   *     - String simpleName (exception name to match).
+   */
+  private static Stream<Arguments> provideWorkflowEngineServiceExceptions() {
+
+    return Stream.of(
+      Arguments.of(WES_EXC1,  WorkflowEngineServiceException.class.getSimpleName()),
+      Arguments.of(WES_EXC2, WorkflowEngineServiceException.class.getSimpleName()),
+      Arguments.of(WES_EXC3, WorkflowEngineServiceException.class.getSimpleName()),
+      Arguments.of(WES_EXC4, WorkflowEngineServiceException.class.getSimpleName())
+    );
+  }
+
+  /**
    * Helper function for parameterized test providing different types of WorkflowImportException.
    *
    * @return
@@ -205,10 +335,14 @@ class WorkflowControllerAdviceTest {
   private static Stream<Arguments> provideWorkflowImportExceptions() {
 
     return Stream.of(
-      Arguments.of(WIAI_EXC,   WorkflowImportAlreadyImported.class.getSimpleName()),
-      Arguments.of(WIIOMP_EXC, WorkflowImportInvalidOrMissingProperty.class.getSimpleName()),
-      Arguments.of(WIJFID_EXC, WorkflowImportJsonFileIsDirectory.class.getSimpleName()),
-      Arguments.of(WIRFM_EXC,  WorkflowImportRequiredFileMissing.class.getSimpleName())
+      Arguments.of(WIAI_EXC1,   WorkflowImportAlreadyImported.class.getSimpleName()),
+      Arguments.of(WIAI_EXC2,   WorkflowImportAlreadyImported.class.getSimpleName()),
+      Arguments.of(WIIOMP_EXC1, WorkflowImportInvalidOrMissingProperty.class.getSimpleName()),
+      Arguments.of(WIIOMP_EXC2, WorkflowImportInvalidOrMissingProperty.class.getSimpleName()),
+      Arguments.of(WIJFID_EXC1, WorkflowImportJsonFileIsDirectory.class.getSimpleName()),
+      Arguments.of(WIJFID_EXC2, WorkflowImportJsonFileIsDirectory.class.getSimpleName()),
+      Arguments.of(WIRFM_EXC1,  WorkflowImportRequiredFileMissing.class.getSimpleName()),
+      Arguments.of(WIRFM_EXC2,  WorkflowImportRequiredFileMissing.class.getSimpleName())
     );
   }
 

--- a/service/src/test/java/org/folio/rest/workflow/controller/advice/WorkflowControllerAdviceTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/controller/advice/WorkflowControllerAdviceTest.java
@@ -11,6 +11,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import org.folio.rest.workflow.exception.WorkflowAlreadyActiveException;
 import org.folio.rest.workflow.exception.WorkflowDeploymentException;
+import org.folio.rest.workflow.exception.WorkflowDeploymentNotFound;
 import org.folio.rest.workflow.exception.WorkflowEngineServiceException;
 import org.folio.rest.workflow.exception.WorkflowImportAlreadyImported;
 import org.folio.rest.workflow.exception.WorkflowImportException;
@@ -41,6 +42,8 @@ class WorkflowControllerAdviceTest {
   private static final WorkflowAlreadyActiveException WAA_EXC = new WorkflowAlreadyActiveException(VALUE);
 
   private static final WorkflowDeploymentException WD_EXC = new WorkflowDeploymentException();
+
+  private static final WorkflowDeploymentNotFound WDNF_EXC = new WorkflowDeploymentNotFound(VALUE);
 
   private static final WorkflowEngineServiceException WES_EXC = new WorkflowEngineServiceException(VALUE);
 
@@ -112,6 +115,20 @@ class WorkflowControllerAdviceTest {
     assertNotNull(response.getBody());
 
     assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+    assertEquals(MediaType.APPLICATION_JSON, response.getHeaders().getContentType());
+    assertTrue(matchBody(response, simpleName));
+  }
+
+  @Test
+  void handleWorkflowDeploymentNotFoundTest() {
+
+    final String simpleName = WorkflowDeploymentNotFound.class.getSimpleName();
+    final ResponseEntity<String> response = advice.handleWorkflowDeploymentNotFound(WDNF_EXC);
+
+    assertNotNull(response);
+    assertNotNull(response.getBody());
+
+    assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
     assertEquals(MediaType.APPLICATION_JSON, response.getHeaders().getContentType());
     assertTrue(matchBody(response, simpleName));
   }

--- a/service/src/test/java/org/folio/rest/workflow/controller/advice/WorkflowControllerAdviceTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/controller/advice/WorkflowControllerAdviceTest.java
@@ -10,6 +10,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import org.folio.rest.workflow.exception.WorkflowAlreadyActiveException;
+import org.folio.rest.workflow.exception.WorkflowCreateAlreadyExistsException;
 import org.folio.rest.workflow.exception.WorkflowDeploymentException;
 import org.folio.rest.workflow.exception.WorkflowDeploymentNotFound;
 import org.folio.rest.workflow.exception.WorkflowEngineServiceException;
@@ -36,6 +37,8 @@ import org.springframework.test.context.ActiveProfiles;
 class WorkflowControllerAdviceTest {
 
   private static final EntityNotFoundException ENF_EXC = new EntityNotFoundException(VALUE);
+
+  private static final WorkflowCreateAlreadyExistsException WCAE_EXC = new WorkflowCreateAlreadyExistsException(VALUE, VALUE);
 
   private static final WorkflowNotFoundException WNF_EXC = new WorkflowNotFoundException(VALUE);
 
@@ -74,6 +77,20 @@ class WorkflowControllerAdviceTest {
     assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
     assertEquals(MediaType.APPLICATION_JSON, response.getHeaders().getContentType());
 
+    assertTrue(matchBody(response, simpleName));
+  }
+
+  @Test
+  void handleWorkflowCreateAlreadyExistsExceptionTest() {
+
+    final String simpleName = WorkflowCreateAlreadyExistsException.class.getSimpleName();
+    final ResponseEntity<String> response = advice.handleWorkflowCreateAlreadyExistsException(WCAE_EXC);
+
+    assertNotNull(response);
+    assertNotNull(response.getBody());
+
+    assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
+    assertEquals(MediaType.APPLICATION_JSON, response.getHeaders().getContentType());
     assertTrue(matchBody(response, simpleName));
   }
 

--- a/service/src/test/java/org/folio/rest/workflow/service/WorkflowEngineServiceTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/service/WorkflowEngineServiceTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
@@ -40,11 +41,15 @@ import org.springframework.web.client.RestTemplate;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.JsonNodeFactory;
 import tools.jackson.databind.node.ObjectNode;
 
 @ExtendWith(SpringExtension.class)
 @ExtendWith(MockitoExtension.class)
 class WorkflowEngineServiceTest {
+
+  private static final String PROCESS_DEFINITION_ID = "processDefinitionId=";
+  private static final String DEACTIVATE = "workflow-engine/workflows/deactivate";
 
   @Mock
   private WorkflowRepo workflowRepo;
@@ -132,12 +137,20 @@ class WorkflowEngineServiceTest {
 
   @Test
   void deleteWorksTest() throws WorkflowEngineServiceException {
-    WorkflowDto workflowDto = (WorkflowDto) workflow;
+
+    // The array node value is not expected to be processed beyond that the array is empty or not.
+    ArrayNode arrayNodeSingle = JsonNodeFactory.instance.arrayNode();
+    arrayNodeSingle.add("");
+
+    ResponseEntity<ArrayNode> responseArray = new ResponseEntity<>(arrayNodeSingle, HttpStatus.OK);
     ResponseEntity<Workflow> responseEntity = new ResponseEntity<>(HttpStatus.OK);
+
+    WorkflowDto workflowDto = (WorkflowDto) workflow;
     setField(responseEntity, "body", workflow);
 
     when(workflowRepo.getViewById(anyString(), ArgumentMatchers.<Class<WorkflowDto>>any())).thenReturn(workflowDto);
-    when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<Workflow>>any())).thenReturn(responseEntity);
+    when(restTemplate.exchange(contains(PROCESS_DEFINITION_ID), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any())).thenReturn(responseArray);
+    when(restTemplate.exchange(contains(DEACTIVATE), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<Workflow>>any())).thenReturn(responseEntity);
     when(workflowRepo.save(any())).thenReturn(workflow);
     doNothing().when(workflowRepo).deleteById(anyString());
 
@@ -148,13 +161,29 @@ class WorkflowEngineServiceTest {
   }
 
   @Test
+  void deleteNotActiveWorksTest() throws WorkflowEngineServiceException {
+
+    // The array node value is not expected to be processed beyond that the array is empty or not.
+    ArrayNode arrayNodeSingle = JsonNodeFactory.instance.arrayNode();
+
+    ResponseEntity<ArrayNode> responseArray = new ResponseEntity<>(arrayNodeSingle, HttpStatus.OK);
+
+    when(restTemplate.exchange(contains(PROCESS_DEFINITION_ID), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any())).thenReturn(responseArray);
+    doNothing().when(workflowRepo).deleteById(anyString());
+
+    workflowEngineService.delete(UUID, OKAPI_TENANT, OKAPI_TOKEN);
+
+    verify(workflowRepo).deleteById(anyString());
+  }
+
+  @Test
   void deleteThrowsExceptionUnableGetUpdatedTest() {
-    WorkflowDto workflowDto = (WorkflowDto) workflow;
+
     ResponseEntity<Workflow> responseEntity = new ResponseEntity<>(HttpStatus.ACCEPTED);
+
     setField(responseEntity, "body", workflow);
 
-    when(workflowRepo.getViewById(anyString(), ArgumentMatchers.<Class<WorkflowDto>>any())).thenReturn(workflowDto);
-    when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<Workflow>>any())).thenReturn(responseEntity);
+    when(restTemplate.exchange(contains(DEACTIVATE), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<Workflow>>any())).thenReturn(responseEntity);
 
     assertThrows(WorkflowEngineServiceException.class, () ->
       workflowEngineService.delete(UUID, OKAPI_TENANT, OKAPI_TOKEN)
@@ -166,12 +195,20 @@ class WorkflowEngineServiceTest {
 
   @Test
   void deleteThrowsExceptionFailedToSaveTest() {
-    WorkflowDto workflowDto = (WorkflowDto) workflow;
+
+    // The array node value is not expected to be processed beyond that the array is empty or not.
+    ArrayNode arrayNodeSingle = JsonNodeFactory.instance.arrayNode();
+    arrayNodeSingle.add("");
+
+    ResponseEntity<ArrayNode> responseArray = new ResponseEntity<>(arrayNodeSingle, HttpStatus.OK);
     ResponseEntity<Workflow> responseEntity = new ResponseEntity<>(HttpStatus.OK);
+
+    WorkflowDto workflowDto = (WorkflowDto) workflow;
     setField(responseEntity, "body", workflow);
 
     when(workflowRepo.getViewById(anyString(), ArgumentMatchers.<Class<WorkflowDto>>any())).thenReturn(workflowDto);
-    when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<Workflow>>any())).thenReturn(responseEntity);
+    when(restTemplate.exchange(contains(PROCESS_DEFINITION_ID), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any())).thenReturn(responseArray);
+    when(restTemplate.exchange(contains(DEACTIVATE), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<Workflow>>any())).thenReturn(responseEntity);
     when(workflowRepo.save(any())).thenThrow(new RuntimeException("Trigger Failure"));
 
     assertThrows(WorkflowEngineServiceException.class, () -> {
@@ -184,12 +221,12 @@ class WorkflowEngineServiceTest {
 
   @Test
   void deleteThrowsExceptionFailedToSendWithNullResponseBodyTest() {
-    WorkflowDto workflowDto = (WorkflowDto) workflow;
+
     ResponseEntity<Workflow> responseEntity = new ResponseEntity<>(HttpStatus.OK);
+
     setField(responseEntity, "body", null);
 
-    when(workflowRepo.getViewById(anyString(), ArgumentMatchers.<Class<WorkflowDto>>any())).thenReturn(workflowDto);
-    when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<Workflow>>any())).thenReturn(responseEntity);
+    when(restTemplate.exchange(contains(DEACTIVATE), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<Workflow>>any())).thenReturn(responseEntity);
 
     assertThrows(WorkflowEngineServiceException.class, () -> {
       workflowEngineService.delete(UUID, OKAPI_TENANT, OKAPI_TOKEN);
@@ -336,6 +373,40 @@ class WorkflowEngineServiceTest {
 
     JsonNode response = workflowEngineService.history(UUID, OKAPI_TENANT, OKAPI_TOKEN);
     assertEquals(historyArrayNode, response);
+  }
+
+  @Test
+  void historyWorksWithoutOkFetchingIncidentsHistoryTest() throws WorkflowEngineServiceException {
+
+    WorkflowOperationalDto workflowOperationalDto = (WorkflowOperationalDto) workflowOperational;
+
+    ResponseEntity<ArrayNode> deploymentEntity = new ResponseEntity<>(HttpStatus.OK);
+    ResponseEntity<ArrayNode> processEntity = new ResponseEntity<>(HttpStatus.OK);
+    ResponseEntity<ArrayNode> incidentsEntity = new ResponseEntity<>(HttpStatus.FOUND);
+
+    ObjectNode deploymentNode = mapper.createObjectNode();
+    deploymentNode.put("id", UUID);
+
+    ObjectNode processNode = mapper.createObjectNode();
+    processNode.put("id", UUID);
+
+    ArrayNode deploymentArrayNode = mapper.createArrayNode();
+    deploymentArrayNode.add(deploymentNode);
+    setField(deploymentEntity, "body", deploymentArrayNode);
+
+    ArrayNode processArrayNode = mapper.createArrayNode();
+    processArrayNode.add(processNode);
+    setField(processEntity, "body", processArrayNode);
+
+    ArrayNode incidentsArrayNode = mapper.createArrayNode();
+    setField(incidentsEntity, "body", incidentsArrayNode);
+
+    when(workflowRepo.getViewById(anyString(), ArgumentMatchers.<Class<WorkflowOperationalDto>>any())).thenReturn(workflowOperationalDto);
+    when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any()))
+      .thenReturn(processEntity, processEntity, incidentsEntity);
+
+    JsonNode response = workflowEngineService.history(UUID, OKAPI_TENANT, OKAPI_TOKEN);
+    assertEquals(processArrayNode, response);
   }
 
   @Test

--- a/service/src/test/java/org/folio/rest/workflow/service/WorkflowEngineServiceTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/service/WorkflowEngineServiceTest.java
@@ -7,19 +7,21 @@ import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.contains;
-import static org.mockito.Mockito.doAnswer;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
-import java.util.concurrent.atomic.AtomicInteger;
 import org.folio.rest.workflow.dto.WorkflowDto;
 import org.folio.rest.workflow.dto.WorkflowOperationalDto;
+import org.folio.rest.workflow.exception.WorkflowDeploymentNotFound;
 import org.folio.rest.workflow.exception.WorkflowEngineServiceException;
 import org.folio.rest.workflow.exception.WorkflowNotFoundException;
 import org.folio.rest.workflow.model.Workflow;
@@ -37,6 +39,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.json.JsonMapper;
@@ -48,8 +51,11 @@ import tools.jackson.databind.node.ObjectNode;
 @ExtendWith(MockitoExtension.class)
 class WorkflowEngineServiceTest {
 
-  private static final String PROCESS_DEFINITION_ID = "processDefinitionId=";
+  private static final RestClientException RC_EXC = new RestClientException("Trigger Failure");
+
   private static final String DEACTIVATE = "workflow-engine/workflows/deactivate";
+  private static final String HISTORY_INSTANCE = "history/process-instance";
+  private static final String PROCESS_DEFINITION = "process-definition";
 
   @Mock
   private WorkflowRepo workflowRepo;
@@ -89,14 +95,13 @@ class WorkflowEngineServiceTest {
 
   @Test
   void activateWorksTest() throws WorkflowEngineServiceException {
-
     WorkflowDto workflowDto = (WorkflowDto) workflow;
     ResponseEntity<Workflow> responseEntity = new ResponseEntity<>(HttpStatus.OK);
     setField(responseEntity, "body", workflow);
 
     when(workflowRepo.getViewById(anyString(), ArgumentMatchers.<Class<WorkflowDto>>any())).thenReturn(workflowDto);
 
-    when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<Workflow>>any(), any(Object[].class)))
+    when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), eq(Workflow.class), anyMap()))
       .thenReturn(responseEntity);
 
     when(workflowRepo.save(any())).thenReturn(workflow);
@@ -115,7 +120,7 @@ class WorkflowEngineServiceTest {
 
     when(workflowRepo.getViewById(anyString(), ArgumentMatchers.<Class<WorkflowDto>>any())).thenReturn(workflowDto);
 
-    when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<Workflow>>any(), any(Object[].class)))
+    when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), eq(Workflow.class), anyMap()))
       .thenReturn(responseEntity);
 
     when(workflowRepo.save(any())).thenReturn(workflow);
@@ -134,7 +139,7 @@ class WorkflowEngineServiceTest {
 
     when(workflowRepo.getViewById(anyString(), ArgumentMatchers.<Class<WorkflowDto>>any())).thenReturn(workflowDto);
 
-    when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<Workflow>>any(), any(Object[].class)))
+    when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), eq(Workflow.class), anyMap()))
       .thenReturn(responseEntity);
 
     when(workflowRepo.save(any())).thenReturn(workflow);
@@ -148,22 +153,25 @@ class WorkflowEngineServiceTest {
   @Test
   void deleteWorksTest() throws WorkflowEngineServiceException {
 
-    // The array node value is not expected to be processed beyond that the array is empty or not.
+    final ObjectNode objectNode = JsonNodeFactory.instance.objectNode();
+    objectNode.put("id", UUID);
+
     ArrayNode arrayNodeSingle = JsonNodeFactory.instance.arrayNode();
-    arrayNodeSingle.add("");
+    arrayNodeSingle.add(objectNode);
 
     ResponseEntity<ArrayNode> responseArray = new ResponseEntity<>(arrayNodeSingle, HttpStatus.OK);
     ResponseEntity<Workflow> responseEntity = new ResponseEntity<>(HttpStatus.OK);
-
-    WorkflowDto workflowDto = (WorkflowDto) workflow;
     setField(responseEntity, "body", workflow);
 
-    when(workflowRepo.getViewById(anyString(), ArgumentMatchers.<Class<WorkflowDto>>any())).thenReturn(workflowDto);
+    final WorkflowDto workflowDto = (WorkflowDto) workflow;
 
-    when(restTemplate.exchange(contains(PROCESS_DEFINITION_ID), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any(), any(Object[].class)))
+    when(workflowRepo.getViewById(anyString(), eq(WorkflowOperationalDto.class))).thenReturn(workflowOperational);
+    when(workflowRepo.getViewById(anyString(), eq(WorkflowDto.class))).thenReturn(workflowDto);
+
+    when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(ArrayNode.class), anyMap()))
       .thenReturn(responseArray);
 
-    when(restTemplate.exchange(contains(DEACTIVATE), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<Workflow>>any(), any(Object[].class)))
+    when(restTemplate.exchange(contains(DEACTIVATE), any(HttpMethod.class), any(HttpEntity.class), eq(Workflow.class), anyMap()))
       .thenReturn(responseEntity);
 
     when(workflowRepo.save(any())).thenReturn(workflow);
@@ -178,12 +186,13 @@ class WorkflowEngineServiceTest {
   @Test
   void deleteNotActiveWorksTest() throws WorkflowEngineServiceException {
 
-    // The array node value is not expected to be processed beyond that the array is empty or not.
     ArrayNode arrayNodeSingle = JsonNodeFactory.instance.arrayNode();
 
     ResponseEntity<ArrayNode> responseArray = new ResponseEntity<>(arrayNodeSingle, HttpStatus.OK);
 
-    when(restTemplate.exchange(contains(PROCESS_DEFINITION_ID), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any(), any(Object[].class)))
+    when(workflowRepo.getViewById(anyString(), eq(WorkflowOperationalDto.class))).thenReturn(workflowOperational);
+
+    when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(ArrayNode.class), anyMap()))
       .thenReturn(responseArray);
 
     doNothing().when(workflowRepo).deleteById(anyString());
@@ -196,11 +205,28 @@ class WorkflowEngineServiceTest {
   @Test
   void deleteThrowsExceptionUnableGetUpdatedTest() {
 
-    ResponseEntity<Workflow> responseEntity = new ResponseEntity<>(HttpStatus.ACCEPTED);
+    final ObjectNode objectNode = JsonNodeFactory.instance.objectNode();
+    objectNode.put("id", UUID);
 
-    setField(responseEntity, "body", workflow);
+    ArrayNode arrayNodeSingle = JsonNodeFactory.instance.arrayNode();
+    arrayNodeSingle.add(objectNode);
 
-    when(restTemplate.exchange(contains(DEACTIVATE), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<Workflow>>any())).thenReturn(responseEntity);
+    ResponseEntity<ArrayNode> responseArray = new ResponseEntity<>(arrayNodeSingle, HttpStatus.OK);
+
+    ResponseEntity<Workflow> workflowEntity = new ResponseEntity<>(HttpStatus.ACCEPTED);
+
+    setField(workflowEntity, "body", workflow);
+
+    final WorkflowDto workflowDto = (WorkflowDto) workflow;
+
+    when(workflowRepo.getViewById(anyString(), eq(WorkflowOperationalDto.class))).thenReturn(workflowOperational);
+    when(workflowRepo.getViewById(anyString(), eq(WorkflowDto.class))).thenReturn(workflowDto);
+
+    when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(ArrayNode.class), anyMap()))
+      .thenReturn(responseArray);
+
+    when(restTemplate.exchange(contains(DEACTIVATE), any(HttpMethod.class), any(HttpEntity.class), eq(Workflow.class), anyMap()))
+      .thenReturn(workflowEntity);
 
     assertThrows(WorkflowEngineServiceException.class, () ->
       workflowEngineService.delete(UUID, OKAPI_TENANT, OKAPI_TOKEN)
@@ -213,25 +239,28 @@ class WorkflowEngineServiceTest {
   @Test
   void deleteThrowsExceptionFailedToSaveTest() {
 
-    // The array node value is not expected to be processed beyond that the array is empty or not.
+    final ObjectNode objectNode = JsonNodeFactory.instance.objectNode();
+    objectNode.put("id", UUID);
+
     ArrayNode arrayNodeSingle = JsonNodeFactory.instance.arrayNode();
-    arrayNodeSingle.add("");
+    arrayNodeSingle.add(objectNode);
 
     ResponseEntity<ArrayNode> processEntity = new ResponseEntity<>(arrayNodeSingle, HttpStatus.OK);
     ResponseEntity<Workflow> workflowEntity = new ResponseEntity<>(HttpStatus.OK);
-
-    WorkflowDto workflowDto = (WorkflowDto) workflow;
     setField(workflowEntity, "body", workflow);
 
-    when(workflowRepo.getViewById(anyString(), ArgumentMatchers.<Class<WorkflowDto>>any())).thenReturn(workflowDto);
+    final WorkflowDto workflowDto = (WorkflowDto) workflow;
 
-    when(restTemplate.exchange(contains(PROCESS_DEFINITION_ID), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any(), any(Object[].class)))
+    when(workflowRepo.getViewById(anyString(), eq(WorkflowOperationalDto.class))).thenReturn(workflowOperational);
+    when(workflowRepo.getViewById(anyString(), eq(WorkflowDto.class))).thenReturn(workflowDto);
+
+    when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(ArrayNode.class), anyMap()))
       .thenReturn(processEntity);
 
-    when(restTemplate.exchange(contains(DEACTIVATE), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<Workflow>>any(), any(Object[].class)))
+    when(restTemplate.exchange(contains(DEACTIVATE), any(HttpMethod.class), any(HttpEntity.class), eq(Workflow.class), anyMap()))
       .thenReturn(workflowEntity);
 
-    when(workflowRepo.save(any())).thenThrow(new RuntimeException("Trigger Failure"));
+    when(workflowRepo.save(any())).thenThrow(RC_EXC);
 
     assertThrows(WorkflowEngineServiceException.class, () -> {
       workflowEngineService.delete(UUID, OKAPI_TENANT, OKAPI_TOKEN);
@@ -246,6 +275,7 @@ class WorkflowEngineServiceTest {
 
     ResponseEntity<ArrayNode> processEntity = new ResponseEntity<>(HttpStatus.OK);
     ResponseEntity<Workflow> workflowEntity = new ResponseEntity<>(HttpStatus.OK);
+    setField(workflowEntity, "body", null);
 
     ObjectNode processNode = mapper.createObjectNode();
     processNode.put("id", UUID);
@@ -254,12 +284,15 @@ class WorkflowEngineServiceTest {
     processArrayNode.add(processNode);
     setField(processEntity, "body", processArrayNode);
 
-    setField(workflowEntity, "body", null);
+    final WorkflowDto workflowDto = (WorkflowDto) workflow;
 
-    when(restTemplate.exchange(contains(PROCESS_DEFINITION_ID), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any(), any(Object[].class)))
+    when(workflowRepo.getViewById(anyString(), eq(WorkflowOperationalDto.class))).thenReturn(workflowOperational);
+    when(workflowRepo.getViewById(anyString(), eq(WorkflowDto.class))).thenReturn(workflowDto);
+
+    when(restTemplate.exchange(anyString(), eq(HttpMethod.GET), any(HttpEntity.class), eq(ArrayNode.class), anyMap()))
       .thenReturn(processEntity);
 
-    when(restTemplate.exchange(contains(DEACTIVATE), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<Workflow>>any(), any(Object[].class)))
+    when(restTemplate.exchange(contains(DEACTIVATE), any(HttpMethod.class), any(HttpEntity.class), eq(Workflow.class), anyMap()))
       .thenReturn(workflowEntity);
 
     assertThrows(WorkflowEngineServiceException.class, () -> {
@@ -287,67 +320,52 @@ class WorkflowEngineServiceTest {
   }
 
   @Test
-  void startWorksTest() throws WorkflowEngineServiceException {
-    WorkflowOperationalDto workflowOperationalDto = (WorkflowOperationalDto) workflowOperational;
-    ResponseEntity<ArrayNode> responseEntity = new ResponseEntity<>(HttpStatus.OK);
-    JsonNode context = mapper.createObjectNode();
-    ObjectNode objectNode = mapper.createObjectNode();
+  void startWorksTest() throws WorkflowDeploymentNotFound, WorkflowEngineServiceException, WorkflowNotFoundException {
+
+    final ObjectNode objectNode = JsonNodeFactory.instance.objectNode();
     objectNode.put("id", UUID);
 
-    ArrayNode arrayNode = mapper.createArrayNode();
+    final ArrayNode arrayNodeSingle = JsonNodeFactory.instance.arrayNode();
+    arrayNodeSingle.add(objectNode);
+
+    final ResponseEntity<JsonNode> workflowEntity = new ResponseEntity<>(HttpStatus.OK);
+    final ResponseEntity<ArrayNode> processEntity = new ResponseEntity<>(arrayNodeSingle, HttpStatus.OK);
+    final JsonNode context = JsonNodeFactory.instance.objectNode();
+
+    final ArrayNode arrayNode = JsonNodeFactory.instance.arrayNode();
     arrayNode.add(objectNode);
-    setField(responseEntity, "body", arrayNode);
+    setField(workflowEntity, "body", arrayNode);
 
-    when(workflowRepo.getViewById(anyString(), ArgumentMatchers.<Class<WorkflowOperationalDto>>any())).thenReturn(workflowOperationalDto);
+    when(workflowRepo.getViewById(anyString(), eq(WorkflowOperationalDto.class))).thenReturn(workflowOperational);
 
-    when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any(), any(Object[].class)))
-      .thenReturn(responseEntity);
+    when(restTemplate.exchange(contains(PROCESS_DEFINITION), eq(HttpMethod.GET), any(HttpEntity.class), eq(ArrayNode.class), anyMap()))
+      .thenReturn(processEntity);
 
-    JsonNode response = workflowEngineService.start(UUID, OKAPI_TENANT, OKAPI_TOKEN, context);
+    when(restTemplate.exchange(contains(PROCESS_DEFINITION), eq(HttpMethod.POST), any(HttpEntity.class), eq(JsonNode.class), anyMap()))
+      .thenReturn(workflowEntity);
+
+    final JsonNode response = workflowEngineService.start(UUID, OKAPI_TENANT, OKAPI_TOKEN, context);
     assertEquals(arrayNode, response);
   }
 
   @Test
   void startThrowsExceptionHttpNotOkTest() {
     WorkflowOperationalDto workflowOperationalDto = (WorkflowOperationalDto) workflowOperational;
-    ResponseEntity<ArrayNode> responseEntity = new ResponseEntity<>(HttpStatus.RESET_CONTENT);
+    ResponseEntity<ArrayNode> processEntity = new ResponseEntity<>(HttpStatus.RESET_CONTENT);
+
     JsonNode context = mapper.createObjectNode();
     ObjectNode objectNode = mapper.createObjectNode();
     objectNode.put("id", UUID);
 
-    ArrayNode arrayNode = mapper.createArrayNode();
-    arrayNode.add(objectNode);
-    setField(responseEntity, "body", arrayNode);
+    ArrayNode processNode = mapper.createArrayNode();
+    processNode.add(objectNode);
+    setField(processEntity, "body", processNode);
 
-    when(workflowRepo.getViewById(anyString(), ArgumentMatchers.<Class<WorkflowOperationalDto>>any())).thenReturn(workflowOperationalDto);
-    when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any())).thenReturn(responseEntity);
+    when(workflowRepo.getViewById(anyString(), eq(WorkflowOperationalDto.class)))
+      .thenReturn(workflowOperationalDto);
 
-    assertThrows(WorkflowEngineServiceException.class, () -> {
-      workflowEngineService.start(UUID, OKAPI_TENANT, OKAPI_TOKEN, context);
-    });
-  }
-
-  @Test
-  void startThrowsExceptionNullOrEmptyDefinitionsTest() {
-    WorkflowOperationalDto workflowOperationalDto = (WorkflowOperationalDto) workflowOperational;
-    ResponseEntity<ArrayNode> responseEntity = new ResponseEntity<>(HttpStatus.OK);
-    JsonNode context = mapper.createObjectNode();
-    ObjectNode objectNode = mapper.createObjectNode();
-    objectNode.put("id", UUID);
-
-    ArrayNode arrayNode = mapper.createArrayNode();
-    setField(responseEntity, "body", arrayNode);
-
-    when(workflowRepo.getViewById(anyString(), ArgumentMatchers.<Class<WorkflowOperationalDto>>any())).thenReturn(workflowOperationalDto);
-
-    when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any(), any(Object[].class)))
-      .thenReturn(responseEntity);
-
-    assertThrows(WorkflowEngineServiceException.class, () -> {
-      workflowEngineService.start(UUID, OKAPI_TENANT, OKAPI_TOKEN, context);
-    });
-
-    setField(responseEntity, "body", null);
+    when(restTemplate.exchange(contains(PROCESS_DEFINITION), eq(HttpMethod.GET), any(HttpEntity.class), eq(ArrayNode.class), anyMap()))
+      .thenReturn(processEntity);
 
     assertThrows(WorkflowEngineServiceException.class, () -> {
       workflowEngineService.start(UUID, OKAPI_TENANT, OKAPI_TOKEN, context);
@@ -357,25 +375,24 @@ class WorkflowEngineServiceTest {
   @Test
   void startThrowsExceptionOnBadExchangeTest() {
     WorkflowOperationalDto workflowOperationalDto = (WorkflowOperationalDto) workflowOperational;
-    ResponseEntity<ArrayNode> responseEntity = new ResponseEntity<>(HttpStatus.OK);
+    ResponseEntity<ArrayNode> processEntity = new ResponseEntity<>(HttpStatus.OK);
+
     JsonNode context = mapper.createObjectNode();
     ObjectNode objectNode = mapper.createObjectNode();
     objectNode.put("id", UUID);
 
-    ArrayNode arrayNode = mapper.createArrayNode();
-    arrayNode.add(objectNode);
-    setField(responseEntity, "body", arrayNode);
+    ArrayNode processNode = mapper.createArrayNode();
+    processNode.add(objectNode);
+    setField(processEntity, "body", processNode);
 
-    when(workflowRepo.getViewById(anyString(), ArgumentMatchers.<Class<WorkflowOperationalDto>>any())).thenReturn(workflowOperationalDto);
+    when(workflowRepo.getViewById(anyString(), eq(WorkflowOperationalDto.class)))
+      .thenReturn(workflowOperationalDto);
 
-    AtomicInteger exchangeCount = new AtomicInteger(0);
-    doAnswer(invocation -> {
-      if (exchangeCount.getAndIncrement() > 0) {
-        throw new RuntimeException("Failure on second exchange call.");
-      }
+    when(restTemplate.exchange(contains(PROCESS_DEFINITION), eq(HttpMethod.GET), any(HttpEntity.class), eq(ArrayNode.class), anyMap()))
+      .thenReturn(processEntity);
 
-      return responseEntity;
-    }).when(restTemplate).exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any(), any(Object[].class));
+    when(restTemplate.exchange(contains(PROCESS_DEFINITION), eq(HttpMethod.POST), any(HttpEntity.class), eq(JsonNode.class), anyMap()))
+      .thenThrow(RC_EXC);
 
     assertThrows(WorkflowEngineServiceException.class, () -> {
       workflowEngineService.start(UUID, OKAPI_TENANT, OKAPI_TOKEN, context);
@@ -383,7 +400,93 @@ class WorkflowEngineServiceTest {
   }
 
   @Test
-  void historyWorksTest() throws WorkflowEngineServiceException {
+  void startThrowsExceptionDeploymentIdMissingTest() {
+    WorkflowOperationalDto workflowOperationalDto = (WorkflowOperationalDto) workflowOperational;
+    workflowOperationalDto.setDeploymentId(null);
+
+    ResponseEntity<ArrayNode> responseEntity = new ResponseEntity<>(HttpStatus.RESET_CONTENT);
+    JsonNode context = mapper.createObjectNode();
+    ObjectNode objectNode = mapper.createObjectNode();
+
+    ArrayNode arrayNode = mapper.createArrayNode();
+    arrayNode.add(objectNode);
+    setField(responseEntity, "body", arrayNode);
+
+    when(workflowRepo.getViewById(anyString(), ArgumentMatchers.<Class<WorkflowOperationalDto>>any())).thenReturn(workflowOperationalDto);
+
+    final Exception exception = assertThrows(WorkflowEngineServiceException.class, () -> {
+      workflowEngineService.start(UUID, OKAPI_TENANT, OKAPI_TOKEN, context);
+    });
+
+    assertTrue(exception.getMessage().contains("Deployment ID is missing"));
+  }
+
+  @Test
+  void startThrowsExceptionWorkflowNullTest() {
+
+    final ObjectNode objectNode = JsonNodeFactory.instance.objectNode();
+    objectNode.put("id", UUID);
+
+    final JsonNode context = JsonNodeFactory.instance.objectNode();
+
+    when(workflowRepo.getViewById(anyString(), eq(WorkflowOperationalDto.class))).thenReturn(null);
+
+    assertThrows(WorkflowNotFoundException.class, () -> {
+      workflowEngineService.start(UUID, OKAPI_TENANT, OKAPI_TOKEN, context);
+    });
+  }
+
+  @Test
+  void startThrowsExceptionDefinitionNoIdTest() {
+
+    final ObjectNode objectNode = JsonNodeFactory.instance.objectNode();
+
+    final ArrayNode arrayNodeSingle = JsonNodeFactory.instance.arrayNode();
+    arrayNodeSingle.add(objectNode);
+
+    final ResponseEntity<ArrayNode> processEntity = new ResponseEntity<>(arrayNodeSingle, HttpStatus.OK);
+    final JsonNode context = JsonNodeFactory.instance.objectNode();
+
+    when(workflowRepo.getViewById(anyString(), eq(WorkflowOperationalDto.class))).thenReturn(workflowOperational);
+
+    when(restTemplate.exchange(contains(PROCESS_DEFINITION), eq(HttpMethod.GET), any(HttpEntity.class), eq(ArrayNode.class), anyMap()))
+      .thenReturn(processEntity);
+
+    final Exception exception = assertThrows(WorkflowEngineServiceException.class, () -> {
+      workflowEngineService.start(UUID, OKAPI_TENANT, OKAPI_TOKEN, context);
+    });
+
+    assertTrue(exception.getMessage().contains("has no definition ID"));
+  }
+
+  @Test
+  void startThrowsExceptionWorkflowNotFoundTest() {
+
+    final ObjectNode objectNode = JsonNodeFactory.instance.objectNode();
+    objectNode.put("id", UUID);
+
+    final ArrayNode arrayNodeSingle = JsonNodeFactory.instance.arrayNode();
+    arrayNodeSingle.add(objectNode);
+
+    final ResponseEntity<JsonNode> workflowEntity = new ResponseEntity<>(HttpStatus.NOT_FOUND);
+    final ResponseEntity<ArrayNode> processEntity = new ResponseEntity<>(arrayNodeSingle, HttpStatus.OK);
+    final JsonNode context = JsonNodeFactory.instance.objectNode();
+
+    when(workflowRepo.getViewById(anyString(), eq(WorkflowOperationalDto.class))).thenReturn(workflowOperational);
+
+    when(restTemplate.exchange(contains(PROCESS_DEFINITION), eq(HttpMethod.GET), any(HttpEntity.class), eq(ArrayNode.class), anyMap()))
+      .thenReturn(processEntity);
+
+    when(restTemplate.exchange(contains(PROCESS_DEFINITION), eq(HttpMethod.POST), any(HttpEntity.class), eq(JsonNode.class), anyMap()))
+      .thenReturn(workflowEntity);
+
+    assertThrows(WorkflowNotFoundException.class, () -> {
+      workflowEngineService.start(UUID, OKAPI_TENANT, OKAPI_TOKEN, context);
+    });
+  }
+
+  @Test
+  void historyWorksTest() throws WorkflowDeploymentNotFound, WorkflowEngineServiceException {
     WorkflowOperationalDto workflowOperationalDto = (WorkflowOperationalDto) workflowOperational;
     ResponseEntity<ArrayNode> responseEntity = new ResponseEntity<>(HttpStatus.OK);
     ResponseEntity<ArrayNode> historyResponseEntity = new ResponseEntity<>(HttpStatus.OK);
@@ -402,19 +505,17 @@ class WorkflowEngineServiceTest {
     historyArrayNode.add(historyNode);
     setField(historyResponseEntity, "body", historyArrayNode);
 
-    when(workflowRepo.getViewById(anyString(), ArgumentMatchers.<Class<WorkflowOperationalDto>>any())).thenReturn(workflowOperationalDto);
+    when(workflowRepo.getViewById(anyString(), eq(WorkflowOperationalDto.class))).thenReturn(workflowOperationalDto);
 
-    AtomicInteger exchangeCount = new AtomicInteger(0);
-    doAnswer(invocation -> {
-      return (exchangeCount.getAndIncrement() > 0) ? historyResponseEntity : responseEntity;
-    }).when(restTemplate).exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any(), any(Object[].class));
+    when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), eq(ArrayNode.class), anyMap()))
+      .thenReturn(responseEntity, historyResponseEntity);
 
     JsonNode response = workflowEngineService.history(UUID, OKAPI_TENANT, OKAPI_TOKEN);
     assertEquals(historyArrayNode, response);
   }
 
   @Test
-  void historyWorksWithoutOkFetchingIncidentsHistoryTest() throws WorkflowEngineServiceException {
+  void historyWorksWithoutOkFetchingIncidentsHistoryTest() throws WorkflowDeploymentNotFound, WorkflowEngineServiceException {
 
     WorkflowOperationalDto workflowOperationalDto = (WorkflowOperationalDto) workflowOperational;
 
@@ -439,8 +540,9 @@ class WorkflowEngineServiceTest {
     ArrayNode incidentsArrayNode = mapper.createArrayNode();
     setField(incidentsEntity, "body", incidentsArrayNode);
 
-    when(workflowRepo.getViewById(anyString(), ArgumentMatchers.<Class<WorkflowOperationalDto>>any())).thenReturn(workflowOperationalDto);
-    when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any(), any(Object[].class)))
+    when(workflowRepo.getViewById(anyString(), eq(WorkflowOperationalDto.class))).thenReturn(workflowOperationalDto);
+
+    when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), eq(ArrayNode.class), anyMap()))
       .thenReturn(processEntity, processEntity, incidentsEntity);
 
     JsonNode response = workflowEngineService.history(UUID, OKAPI_TENANT, OKAPI_TOKEN);
@@ -461,12 +563,10 @@ class WorkflowEngineServiceTest {
 
     setField(historyResponseEntity, "body", null);
 
-    when(workflowRepo.getViewById(anyString(), ArgumentMatchers.<Class<WorkflowOperationalDto>>any())).thenReturn(workflowOperationalDto);
+    when(workflowRepo.getViewById(anyString(), eq(WorkflowOperationalDto.class))).thenReturn(workflowOperationalDto);
 
-    AtomicInteger exchangeCount = new AtomicInteger(0);
-    doAnswer(invocation -> {
-      return (exchangeCount.getAndIncrement() > 0) ? historyResponseEntity : responseEntity;
-    }).when(restTemplate).exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any(), any(Object[].class));
+    when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), eq(ArrayNode.class), anyMap()))
+      .thenReturn(responseEntity, historyResponseEntity);
 
     assertThrows(WorkflowEngineServiceException.class, () -> {
       workflowEngineService.history(UUID, OKAPI_TENANT, OKAPI_TOKEN);
@@ -476,23 +576,25 @@ class WorkflowEngineServiceTest {
   @Test
   void historyThrowsExceptionWithNullIncidentsForProcessTest() {
     WorkflowOperationalDto workflowOperationalDto = (WorkflowOperationalDto) workflowOperational;
-    ResponseEntity<ArrayNode> responseEntity = new ResponseEntity<>(HttpStatus.OK);
-    ResponseEntity<ArrayNode> historyResponseEntity = new ResponseEntity<>(HttpStatus.OK);
+    ResponseEntity<ArrayNode> processEntity = new ResponseEntity<>(HttpStatus.OK);
+    ResponseEntity<ArrayNode> historyEntity = new ResponseEntity<>(HttpStatus.OK);
+
     ObjectNode objectNode = mapper.createObjectNode();
     objectNode.put("id", UUID);
 
-    ArrayNode arrayNode = mapper.createArrayNode();
-    arrayNode.add(objectNode);
-    setField(responseEntity, "body", arrayNode);
+    ArrayNode processNode = mapper.createArrayNode();
+    processNode.add(objectNode);
+    setField(processEntity, "body", processNode);
 
-    setField(historyResponseEntity, "body", null);
+    setField(historyEntity, "body", null);
 
-    when(workflowRepo.getViewById(anyString(), ArgumentMatchers.<Class<WorkflowOperationalDto>>any())).thenReturn(workflowOperationalDto);
+    when(workflowRepo.getViewById(anyString(), eq(WorkflowOperationalDto.class))).thenReturn(workflowOperationalDto);
 
-    AtomicInteger exchangeCount = new AtomicInteger(0);
-    doAnswer(invocation -> {
-      return (exchangeCount.getAndIncrement() > 0) ? historyResponseEntity : responseEntity;
-    }).when(restTemplate).exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any(), any(Object[].class));
+    when(restTemplate.exchange(contains(PROCESS_DEFINITION), eq(HttpMethod.GET), any(HttpEntity.class), eq(ArrayNode.class), anyMap()))
+    .thenReturn(processEntity);
+
+  when(restTemplate.exchange(contains(HISTORY_INSTANCE), eq(HttpMethod.GET), any(HttpEntity.class), eq(ArrayNode.class), anyMap()))
+    .thenReturn(historyEntity);
 
     assertThrows(WorkflowEngineServiceException.class, () -> {
       workflowEngineService.history(UUID, OKAPI_TENANT, OKAPI_TOKEN);
@@ -502,8 +604,9 @@ class WorkflowEngineServiceTest {
   @Test
   void historyWorksThrowsExceptionForFetchingIncidentsHistoryTest() {
     WorkflowOperationalDto workflowOperationalDto = (WorkflowOperationalDto) workflowOperational;
-    ResponseEntity<ArrayNode> responseEntity = new ResponseEntity<>(HttpStatus.OK);
-    ResponseEntity<ArrayNode> historyResponseEntity = new ResponseEntity<>(HttpStatus.OK);
+    ResponseEntity<ArrayNode> processEntity = new ResponseEntity<>(HttpStatus.OK);
+    ResponseEntity<ArrayNode> historyEntity = new ResponseEntity<>(HttpStatus.NOT_FOUND);
+
     ObjectNode objectNode = mapper.createObjectNode();
     objectNode.put("id", UUID);
 
@@ -511,24 +614,21 @@ class WorkflowEngineServiceTest {
     historyNode.put("id", UUID);
     historyNode.put("history", VALUE);
 
-    ArrayNode arrayNode = mapper.createArrayNode();
-    arrayNode.add(objectNode);
-    setField(responseEntity, "body", arrayNode);
+    ArrayNode processNode = mapper.createArrayNode();
+    processNode.add(objectNode);
+    setField(processEntity, "body", processNode);
 
     ArrayNode historyArrayNode = mapper.createArrayNode();
     historyArrayNode.add(historyNode);
-    setField(historyResponseEntity, "body", historyArrayNode);
+    setField(historyEntity, "body", historyArrayNode);
 
-    when(workflowRepo.getViewById(anyString(), ArgumentMatchers.<Class<WorkflowOperationalDto>>any())).thenReturn(workflowOperationalDto);
+    when(workflowRepo.getViewById(anyString(), eq(WorkflowOperationalDto.class))).thenReturn(workflowOperationalDto);
 
-    AtomicInteger exchangeCount = new AtomicInteger(0);
-    doAnswer(invocation -> {
-      if (exchangeCount.getAndIncrement() > 1) {
-        throw new RuntimeException("Failure on third exchange call.");
-      }
+    when(restTemplate.exchange(contains(PROCESS_DEFINITION), eq(HttpMethod.GET), any(HttpEntity.class), eq(ArrayNode.class), anyMap()))
+      .thenReturn(processEntity);
 
-      return (exchangeCount.get() > 0) ? historyResponseEntity : responseEntity;
-    }).when(restTemplate).exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any(), any(Object[].class));
+    when(restTemplate.exchange(contains(HISTORY_INSTANCE), eq(HttpMethod.GET), any(HttpEntity.class), eq(ArrayNode.class), anyMap()))
+      .thenReturn(historyEntity);
 
     assertThrows(WorkflowEngineServiceException.class, () -> {
       workflowEngineService.history(UUID, OKAPI_TENANT, OKAPI_TOKEN);
@@ -538,9 +638,10 @@ class WorkflowEngineServiceTest {
   @Test
   void historyWorksThrowsExceptionForNotOkHttpOnIncidentsHistoryTest() {
     WorkflowOperationalDto workflowOperationalDto = (WorkflowOperationalDto) workflowOperational;
-    ResponseEntity<ArrayNode> responseEntity = new ResponseEntity<>(HttpStatus.OK);
-    ResponseEntity<ArrayNode> historyResponseEntity = new ResponseEntity<>(HttpStatus.BAD_REQUEST);
-    ResponseEntity<ArrayNode> thirdResponseEntity = new ResponseEntity<>(HttpStatus.RESET_CONTENT);
+    ResponseEntity<ArrayNode> processEntity = new ResponseEntity<>(HttpStatus.OK);
+    ResponseEntity<ArrayNode> historyEntity = new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+    ResponseEntity<ArrayNode> thirdEntity = new ResponseEntity<>(HttpStatus.RESET_CONTENT);
+
     ObjectNode objectNode = mapper.createObjectNode();
     objectNode.put("id", UUID);
 
@@ -548,24 +649,21 @@ class WorkflowEngineServiceTest {
     historyNode.put("id", UUID);
     historyNode.put("history", VALUE);
 
-    ArrayNode arrayNode = mapper.createArrayNode();
-    arrayNode.add(objectNode);
-    setField(responseEntity, "body", arrayNode);
+    ArrayNode processNode = mapper.createArrayNode();
+    processNode.add(objectNode);
+    setField(processEntity, "body", processNode);
 
     ArrayNode historyArrayNode = mapper.createArrayNode();
     historyArrayNode.add(historyNode);
-    setField(historyResponseEntity, "body", historyArrayNode);
+    setField(historyEntity, "body", historyArrayNode);
 
-    when(workflowRepo.getViewById(anyString(), ArgumentMatchers.<Class<WorkflowOperationalDto>>any())).thenReturn(workflowOperationalDto);
+    when(workflowRepo.getViewById(anyString(), eq(WorkflowOperationalDto.class))).thenReturn(workflowOperationalDto);
 
-    AtomicInteger exchangeCount = new AtomicInteger(0);
-    doAnswer(invocation -> {
-      if (exchangeCount.getAndIncrement() > 1) {
-        return thirdResponseEntity;
-      }
+    when(restTemplate.exchange(contains(PROCESS_DEFINITION), eq(HttpMethod.GET), any(HttpEntity.class), eq(ArrayNode.class), anyMap()))
+      .thenReturn(processEntity);
 
-      return (exchangeCount.get() > 0) ? historyResponseEntity : responseEntity;
-    }).when(restTemplate).exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any(), any(Object[].class));
+    when(restTemplate.exchange(contains(HISTORY_INSTANCE), eq(HttpMethod.GET), any(HttpEntity.class), eq(ArrayNode.class), anyMap()))
+      .thenReturn(historyEntity, thirdEntity);
 
     assertThrows(WorkflowEngineServiceException.class, () -> {
       workflowEngineService.history(UUID, OKAPI_TENANT, OKAPI_TOKEN);
@@ -575,9 +673,8 @@ class WorkflowEngineServiceTest {
   @Test
   void historyWorksThrowsExceptionForNullIncidentsOnIncidentsHistoryTest() {
     WorkflowOperationalDto workflowOperationalDto = (WorkflowOperationalDto) workflowOperational;
-    ResponseEntity<ArrayNode> responseEntity = new ResponseEntity<>(HttpStatus.OK);
-    ResponseEntity<ArrayNode> historyResponseEntity = new ResponseEntity<>(HttpStatus.OK);
-    ResponseEntity<ArrayNode> thirdResponseEntity = new ResponseEntity<>(HttpStatus.OK);
+    ResponseEntity<ArrayNode> processEntity = new ResponseEntity<>(HttpStatus.OK);
+    ResponseEntity<ArrayNode> historyEntity = new ResponseEntity<>(HttpStatus.OK);
     ObjectNode objectNode = mapper.createObjectNode();
     objectNode.put("id", UUID);
 
@@ -585,22 +682,19 @@ class WorkflowEngineServiceTest {
     historyNode.put("id", UUID);
     historyNode.put("history", VALUE);
 
-    ArrayNode arrayNode = mapper.createArrayNode();
-    arrayNode.add(objectNode);
-    setField(responseEntity, "body", arrayNode);
+    ArrayNode processNode = mapper.createArrayNode();
+    processNode.add(objectNode);
+    setField(processEntity, "body", processNode);
 
-    setField(historyResponseEntity, "body", null);
+    setField(historyEntity, "body", null);
 
-    when(workflowRepo.getViewById(anyString(), ArgumentMatchers.<Class<WorkflowOperationalDto>>any())).thenReturn(workflowOperationalDto);
+    when(workflowRepo.getViewById(anyString(), eq(WorkflowOperationalDto.class))).thenReturn(workflowOperationalDto);
 
-    AtomicInteger exchangeCount = new AtomicInteger(0);
-    doAnswer(invocation -> {
-      if (exchangeCount.getAndIncrement() > 1) {
-        return thirdResponseEntity;
-      }
+    when(restTemplate.exchange(contains(PROCESS_DEFINITION), eq(HttpMethod.GET), any(HttpEntity.class), eq(ArrayNode.class), anyMap()))
+      .thenReturn(processEntity);
 
-      return (exchangeCount.get() > 0) ? historyResponseEntity : responseEntity;
-    }).when(restTemplate).exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any(), any(Object[].class));
+    when(restTemplate.exchange(contains(HISTORY_INSTANCE), eq(HttpMethod.GET), any(HttpEntity.class), eq(ArrayNode.class), anyMap()))
+      .thenReturn(historyEntity);
 
     assertThrows(WorkflowEngineServiceException.class, () -> {
       workflowEngineService.history(UUID, OKAPI_TENANT, OKAPI_TOKEN);

--- a/service/src/test/java/org/folio/rest/workflow/service/WorkflowEngineServiceTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/service/WorkflowEngineServiceTest.java
@@ -89,12 +89,16 @@ class WorkflowEngineServiceTest {
 
   @Test
   void activateWorksTest() throws WorkflowEngineServiceException {
+
     WorkflowDto workflowDto = (WorkflowDto) workflow;
     ResponseEntity<Workflow> responseEntity = new ResponseEntity<>(HttpStatus.OK);
     setField(responseEntity, "body", workflow);
 
     when(workflowRepo.getViewById(anyString(), ArgumentMatchers.<Class<WorkflowDto>>any())).thenReturn(workflowDto);
-    when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<Workflow>>any())).thenReturn(responseEntity);
+
+    when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<Workflow>>any(), any(Object[].class)))
+      .thenReturn(responseEntity);
+
     when(workflowRepo.save(any())).thenReturn(workflow);
 
     workflowEngineService.activate(UUID, OKAPI_TENANT, OKAPI_TOKEN);
@@ -110,7 +114,10 @@ class WorkflowEngineServiceTest {
     setField(responseEntity, "body", workflow);
 
     when(workflowRepo.getViewById(anyString(), ArgumentMatchers.<Class<WorkflowDto>>any())).thenReturn(workflowDto);
-    when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<Workflow>>any())).thenReturn(responseEntity);
+
+    when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<Workflow>>any(), any(Object[].class)))
+      .thenReturn(responseEntity);
+
     when(workflowRepo.save(any())).thenReturn(workflow);
 
     workflowEngineService.activate(UUID, null, null);
@@ -126,7 +133,10 @@ class WorkflowEngineServiceTest {
     setField(responseEntity, "body", workflow);
 
     when(workflowRepo.getViewById(anyString(), ArgumentMatchers.<Class<WorkflowDto>>any())).thenReturn(workflowDto);
-    when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<Workflow>>any())).thenReturn(responseEntity);
+
+    when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<Workflow>>any(), any(Object[].class)))
+      .thenReturn(responseEntity);
+
     when(workflowRepo.save(any())).thenReturn(workflow);
 
     workflowEngineService.deactivate(UUID, OKAPI_TENANT, OKAPI_TOKEN);
@@ -149,8 +159,13 @@ class WorkflowEngineServiceTest {
     setField(responseEntity, "body", workflow);
 
     when(workflowRepo.getViewById(anyString(), ArgumentMatchers.<Class<WorkflowDto>>any())).thenReturn(workflowDto);
-    when(restTemplate.exchange(contains(PROCESS_DEFINITION_ID), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any())).thenReturn(responseArray);
-    when(restTemplate.exchange(contains(DEACTIVATE), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<Workflow>>any())).thenReturn(responseEntity);
+
+    when(restTemplate.exchange(contains(PROCESS_DEFINITION_ID), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any(), any(Object[].class)))
+      .thenReturn(responseArray);
+
+    when(restTemplate.exchange(contains(DEACTIVATE), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<Workflow>>any(), any(Object[].class)))
+      .thenReturn(responseEntity);
+
     when(workflowRepo.save(any())).thenReturn(workflow);
     doNothing().when(workflowRepo).deleteById(anyString());
 
@@ -168,7 +183,9 @@ class WorkflowEngineServiceTest {
 
     ResponseEntity<ArrayNode> responseArray = new ResponseEntity<>(arrayNodeSingle, HttpStatus.OK);
 
-    when(restTemplate.exchange(contains(PROCESS_DEFINITION_ID), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any())).thenReturn(responseArray);
+    when(restTemplate.exchange(contains(PROCESS_DEFINITION_ID), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any(), any(Object[].class)))
+      .thenReturn(responseArray);
+
     doNothing().when(workflowRepo).deleteById(anyString());
 
     workflowEngineService.delete(UUID, OKAPI_TENANT, OKAPI_TOKEN);
@@ -200,15 +217,20 @@ class WorkflowEngineServiceTest {
     ArrayNode arrayNodeSingle = JsonNodeFactory.instance.arrayNode();
     arrayNodeSingle.add("");
 
-    ResponseEntity<ArrayNode> responseArray = new ResponseEntity<>(arrayNodeSingle, HttpStatus.OK);
-    ResponseEntity<Workflow> responseEntity = new ResponseEntity<>(HttpStatus.OK);
+    ResponseEntity<ArrayNode> processEntity = new ResponseEntity<>(arrayNodeSingle, HttpStatus.OK);
+    ResponseEntity<Workflow> workflowEntity = new ResponseEntity<>(HttpStatus.OK);
 
     WorkflowDto workflowDto = (WorkflowDto) workflow;
-    setField(responseEntity, "body", workflow);
+    setField(workflowEntity, "body", workflow);
 
     when(workflowRepo.getViewById(anyString(), ArgumentMatchers.<Class<WorkflowDto>>any())).thenReturn(workflowDto);
-    when(restTemplate.exchange(contains(PROCESS_DEFINITION_ID), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any())).thenReturn(responseArray);
-    when(restTemplate.exchange(contains(DEACTIVATE), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<Workflow>>any())).thenReturn(responseEntity);
+
+    when(restTemplate.exchange(contains(PROCESS_DEFINITION_ID), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any(), any(Object[].class)))
+      .thenReturn(processEntity);
+
+    when(restTemplate.exchange(contains(DEACTIVATE), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<Workflow>>any(), any(Object[].class)))
+      .thenReturn(workflowEntity);
+
     when(workflowRepo.save(any())).thenThrow(new RuntimeException("Trigger Failure"));
 
     assertThrows(WorkflowEngineServiceException.class, () -> {
@@ -222,11 +244,23 @@ class WorkflowEngineServiceTest {
   @Test
   void deleteThrowsExceptionFailedToSendWithNullResponseBodyTest() {
 
-    ResponseEntity<Workflow> responseEntity = new ResponseEntity<>(HttpStatus.OK);
+    ResponseEntity<ArrayNode> processEntity = new ResponseEntity<>(HttpStatus.OK);
+    ResponseEntity<Workflow> workflowEntity = new ResponseEntity<>(HttpStatus.OK);
 
-    setField(responseEntity, "body", null);
+    ObjectNode processNode = mapper.createObjectNode();
+    processNode.put("id", UUID);
 
-    when(restTemplate.exchange(contains(DEACTIVATE), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<Workflow>>any())).thenReturn(responseEntity);
+    ArrayNode processArrayNode = mapper.createArrayNode();
+    processArrayNode.add(processNode);
+    setField(processEntity, "body", processArrayNode);
+
+    setField(workflowEntity, "body", null);
+
+    when(restTemplate.exchange(contains(PROCESS_DEFINITION_ID), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any(), any(Object[].class)))
+      .thenReturn(processEntity);
+
+    when(restTemplate.exchange(contains(DEACTIVATE), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<Workflow>>any(), any(Object[].class)))
+      .thenReturn(workflowEntity);
 
     assertThrows(WorkflowEngineServiceException.class, () -> {
       workflowEngineService.delete(UUID, OKAPI_TENANT, OKAPI_TOKEN);
@@ -265,7 +299,9 @@ class WorkflowEngineServiceTest {
     setField(responseEntity, "body", arrayNode);
 
     when(workflowRepo.getViewById(anyString(), ArgumentMatchers.<Class<WorkflowOperationalDto>>any())).thenReturn(workflowOperationalDto);
-    when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any())).thenReturn(responseEntity);
+
+    when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any(), any(Object[].class)))
+      .thenReturn(responseEntity);
 
     JsonNode response = workflowEngineService.start(UUID, OKAPI_TENANT, OKAPI_TOKEN, context);
     assertEquals(arrayNode, response);
@@ -303,7 +339,9 @@ class WorkflowEngineServiceTest {
     setField(responseEntity, "body", arrayNode);
 
     when(workflowRepo.getViewById(anyString(), ArgumentMatchers.<Class<WorkflowOperationalDto>>any())).thenReturn(workflowOperationalDto);
-    when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any())).thenReturn(responseEntity);
+
+    when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any(), any(Object[].class)))
+      .thenReturn(responseEntity);
 
     assertThrows(WorkflowEngineServiceException.class, () -> {
       workflowEngineService.start(UUID, OKAPI_TENANT, OKAPI_TOKEN, context);
@@ -337,7 +375,7 @@ class WorkflowEngineServiceTest {
       }
 
       return responseEntity;
-    }).when(restTemplate).exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any());
+    }).when(restTemplate).exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any(), any(Object[].class));
 
     assertThrows(WorkflowEngineServiceException.class, () -> {
       workflowEngineService.start(UUID, OKAPI_TENANT, OKAPI_TOKEN, context);
@@ -369,7 +407,7 @@ class WorkflowEngineServiceTest {
     AtomicInteger exchangeCount = new AtomicInteger(0);
     doAnswer(invocation -> {
       return (exchangeCount.getAndIncrement() > 0) ? historyResponseEntity : responseEntity;
-    }).when(restTemplate).exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any());
+    }).when(restTemplate).exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any(), any(Object[].class));
 
     JsonNode response = workflowEngineService.history(UUID, OKAPI_TENANT, OKAPI_TOKEN);
     assertEquals(historyArrayNode, response);
@@ -402,7 +440,7 @@ class WorkflowEngineServiceTest {
     setField(incidentsEntity, "body", incidentsArrayNode);
 
     when(workflowRepo.getViewById(anyString(), ArgumentMatchers.<Class<WorkflowOperationalDto>>any())).thenReturn(workflowOperationalDto);
-    when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any()))
+    when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any(), any(Object[].class)))
       .thenReturn(processEntity, processEntity, incidentsEntity);
 
     JsonNode response = workflowEngineService.history(UUID, OKAPI_TENANT, OKAPI_TOKEN);
@@ -428,7 +466,7 @@ class WorkflowEngineServiceTest {
     AtomicInteger exchangeCount = new AtomicInteger(0);
     doAnswer(invocation -> {
       return (exchangeCount.getAndIncrement() > 0) ? historyResponseEntity : responseEntity;
-    }).when(restTemplate).exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any());
+    }).when(restTemplate).exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any(), any(Object[].class));
 
     assertThrows(WorkflowEngineServiceException.class, () -> {
       workflowEngineService.history(UUID, OKAPI_TENANT, OKAPI_TOKEN);
@@ -454,7 +492,7 @@ class WorkflowEngineServiceTest {
     AtomicInteger exchangeCount = new AtomicInteger(0);
     doAnswer(invocation -> {
       return (exchangeCount.getAndIncrement() > 0) ? historyResponseEntity : responseEntity;
-    }).when(restTemplate).exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any());
+    }).when(restTemplate).exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any(), any(Object[].class));
 
     assertThrows(WorkflowEngineServiceException.class, () -> {
       workflowEngineService.history(UUID, OKAPI_TENANT, OKAPI_TOKEN);
@@ -490,7 +528,7 @@ class WorkflowEngineServiceTest {
       }
 
       return (exchangeCount.get() > 0) ? historyResponseEntity : responseEntity;
-    }).when(restTemplate).exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any());
+    }).when(restTemplate).exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any(), any(Object[].class));
 
     assertThrows(WorkflowEngineServiceException.class, () -> {
       workflowEngineService.history(UUID, OKAPI_TENANT, OKAPI_TOKEN);
@@ -527,7 +565,7 @@ class WorkflowEngineServiceTest {
       }
 
       return (exchangeCount.get() > 0) ? historyResponseEntity : responseEntity;
-    }).when(restTemplate).exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any());
+    }).when(restTemplate).exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any(), any(Object[].class));
 
     assertThrows(WorkflowEngineServiceException.class, () -> {
       workflowEngineService.history(UUID, OKAPI_TENANT, OKAPI_TOKEN);
@@ -562,7 +600,7 @@ class WorkflowEngineServiceTest {
       }
 
       return (exchangeCount.get() > 0) ? historyResponseEntity : responseEntity;
-    }).when(restTemplate).exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any());
+    }).when(restTemplate).exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), ArgumentMatchers.<Class<ArrayNode>>any(), any(Object[].class));
 
     assertThrows(WorkflowEngineServiceException.class, () -> {
       workflowEngineService.history(UUID, OKAPI_TENANT, OKAPI_TOKEN);

--- a/service/src/test/java/org/folio/rest/workflow/service/WorkflowEngineServiceTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/service/WorkflowEngineServiceTest.java
@@ -54,6 +54,7 @@ class WorkflowEngineServiceTest {
   private static final RestClientException RC_EXC = new RestClientException("Trigger Failure");
 
   private static final String DEACTIVATE = "workflow-engine/workflows/deactivate";
+  private static final String HISTORY_INCIDENT = "history/incident";
   private static final String HISTORY_INSTANCE = "history/process-instance";
   private static final String PROCESS_DEFINITION = "process-definition";
 
@@ -486,10 +487,45 @@ class WorkflowEngineServiceTest {
   }
 
   @Test
+  void startThrowsExceptionWorkflowNotFoundViaViewTest() {
+
+    final JsonNode context = JsonNodeFactory.instance.objectNode();
+
+    when(workflowRepo.getViewById(anyString(), eq(WorkflowOperationalDto.class))).thenReturn(null);
+
+    assertThrows(WorkflowNotFoundException.class, () -> {
+      workflowEngineService.start(UUID, OKAPI_TENANT, OKAPI_TOKEN, context);
+    });
+  }
+
+  @Test
+  void startThrowsExceptionWorkflowDeploymentNotFoundViaViewTest() {
+
+    final ObjectNode objectNode = JsonNodeFactory.instance.objectNode();
+    objectNode.put("id", UUID);
+
+    final ArrayNode arrayNodeSingle = JsonNodeFactory.instance.arrayNode();
+
+    final ResponseEntity<ArrayNode> processEntity = new ResponseEntity<>(arrayNodeSingle, HttpStatus.OK);
+    final JsonNode context = JsonNodeFactory.instance.objectNode();
+
+    when(workflowRepo.getViewById(anyString(), eq(WorkflowOperationalDto.class))).thenReturn(workflowOperational);
+
+    when(restTemplate.exchange(contains(PROCESS_DEFINITION), eq(HttpMethod.GET), any(HttpEntity.class), eq(ArrayNode.class), anyMap()))
+      .thenReturn(processEntity);
+
+    assertThrows(WorkflowDeploymentNotFound.class, () -> {
+      workflowEngineService.start(UUID, OKAPI_TENANT, OKAPI_TOKEN, context);
+    });
+  }
+
+  @Test
   void historyWorksTest() throws WorkflowDeploymentNotFound, WorkflowEngineServiceException {
     WorkflowOperationalDto workflowOperationalDto = (WorkflowOperationalDto) workflowOperational;
-    ResponseEntity<ArrayNode> responseEntity = new ResponseEntity<>(HttpStatus.OK);
-    ResponseEntity<ArrayNode> historyResponseEntity = new ResponseEntity<>(HttpStatus.OK);
+    ResponseEntity<ArrayNode> processEntity = new ResponseEntity<>(HttpStatus.OK);
+    ResponseEntity<ArrayNode> historyEntity = new ResponseEntity<>(HttpStatus.OK);
+    ResponseEntity<ArrayNode> incidentEntity = new ResponseEntity<>(HttpStatus.OK);
+
     ObjectNode objectNode = mapper.createObjectNode();
     objectNode.put("id", UUID);
 
@@ -497,18 +533,27 @@ class WorkflowEngineServiceTest {
     historyNode.put("id", UUID);
     historyNode.put("history", VALUE);
 
-    ArrayNode arrayNode = mapper.createArrayNode();
-    arrayNode.add(objectNode);
-    setField(responseEntity, "body", arrayNode);
+    ObjectNode incidentNode = mapper.createObjectNode();
+    incidentNode.put("id", UUID);
+
+    ArrayNode processNode = mapper.createArrayNode();
+    processNode.add(objectNode);
+    setField(processEntity, "body", processNode);
 
     ArrayNode historyArrayNode = mapper.createArrayNode();
     historyArrayNode.add(historyNode);
-    setField(historyResponseEntity, "body", historyArrayNode);
+    setField(historyEntity, "body", historyArrayNode);
 
     when(workflowRepo.getViewById(anyString(), eq(WorkflowOperationalDto.class))).thenReturn(workflowOperationalDto);
 
-    when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), eq(ArrayNode.class), anyMap()))
-      .thenReturn(responseEntity, historyResponseEntity);
+    when(restTemplate.exchange(contains(PROCESS_DEFINITION), eq(HttpMethod.GET), any(HttpEntity.class), eq(ArrayNode.class), anyMap()))
+      .thenReturn(processEntity);
+
+    when(restTemplate.exchange(contains(HISTORY_INSTANCE), eq(HttpMethod.GET), any(HttpEntity.class), eq(ArrayNode.class), anyMap()))
+      .thenReturn(historyEntity);
+
+    when(restTemplate.exchange(contains(HISTORY_INCIDENT), eq(HttpMethod.GET), any(HttpEntity.class), eq(ArrayNode.class), anyMap()))
+      .thenReturn(incidentEntity);
 
     JsonNode response = workflowEngineService.history(UUID, OKAPI_TENANT, OKAPI_TOKEN);
     assertEquals(historyArrayNode, response);
@@ -552,21 +597,25 @@ class WorkflowEngineServiceTest {
   @Test
   void historyThrowsExceptionWithNotOkHttpStatusForProcessTest() {
     WorkflowOperationalDto workflowOperationalDto = (WorkflowOperationalDto) workflowOperational;
-    ResponseEntity<ArrayNode> responseEntity = new ResponseEntity<>(HttpStatus.OK);
-    ResponseEntity<ArrayNode> historyResponseEntity = new ResponseEntity<>(HttpStatus.RESET_CONTENT);
+    ResponseEntity<ArrayNode> processEntity = new ResponseEntity<>(HttpStatus.OK);
+    ResponseEntity<ArrayNode> historyEntity = new ResponseEntity<>(HttpStatus.RESET_CONTENT);
+
     ObjectNode objectNode = mapper.createObjectNode();
     objectNode.put("id", UUID);
 
-    ArrayNode arrayNode = mapper.createArrayNode();
-    arrayNode.add(objectNode);
-    setField(responseEntity, "body", arrayNode);
+    ArrayNode processNode = mapper.createArrayNode();
+    processNode.add(objectNode);
+    setField(processEntity, "body", processNode);
 
-    setField(historyResponseEntity, "body", null);
+    setField(historyEntity, "body", null);
 
     when(workflowRepo.getViewById(anyString(), eq(WorkflowOperationalDto.class))).thenReturn(workflowOperationalDto);
 
-    when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), eq(ArrayNode.class), anyMap()))
-      .thenReturn(responseEntity, historyResponseEntity);
+    when(restTemplate.exchange(contains(PROCESS_DEFINITION), eq(HttpMethod.GET), any(HttpEntity.class), eq(ArrayNode.class), anyMap()))
+      .thenReturn(processEntity);
+
+    when(restTemplate.exchange(contains(HISTORY_INSTANCE), eq(HttpMethod.GET), any(HttpEntity.class), eq(ArrayNode.class), anyMap()))
+      .thenReturn(historyEntity);
 
     assertThrows(WorkflowEngineServiceException.class, () -> {
       workflowEngineService.history(UUID, OKAPI_TENANT, OKAPI_TOKEN);
@@ -591,10 +640,10 @@ class WorkflowEngineServiceTest {
     when(workflowRepo.getViewById(anyString(), eq(WorkflowOperationalDto.class))).thenReturn(workflowOperationalDto);
 
     when(restTemplate.exchange(contains(PROCESS_DEFINITION), eq(HttpMethod.GET), any(HttpEntity.class), eq(ArrayNode.class), anyMap()))
-    .thenReturn(processEntity);
+      .thenReturn(processEntity);
 
-  when(restTemplate.exchange(contains(HISTORY_INSTANCE), eq(HttpMethod.GET), any(HttpEntity.class), eq(ArrayNode.class), anyMap()))
-    .thenReturn(historyEntity);
+    when(restTemplate.exchange(contains(HISTORY_INSTANCE), eq(HttpMethod.GET), any(HttpEntity.class), eq(ArrayNode.class), anyMap()))
+      .thenReturn(historyEntity);
 
     assertThrows(WorkflowEngineServiceException.class, () -> {
       workflowEngineService.history(UUID, OKAPI_TENANT, OKAPI_TOKEN);


### PR DESCRIPTION
[MODWRKFLOW-72](https://folio-org.atlassian.net/browse/MODWRKFLOW-72)

Call the history from the engine and if there is no history, then the workflow is not activated.

Add new exception `WorkflowDeploymentNotFound` to more properly communicate 404s.

Provide new function called `fetchDeploymentDefinitions()` for getting all activated workflows without throwing an exception.
This allows the delete method to get the response without treating a 404 as a problem.
Update the existing `fetchDeploymentDefinition()` to call the new function but still throw the 404.
The `fetchDeploymentDefinition()` now throws the new `WorkflowDeploymentNotFound` exception.
The `workflowId` is now passed to `fetchDeploymentDefinition()` to report the **Workflow ID** in the 404.

Handle the NULL case for when the **Deployment ID** is not found.

Add function comments to both the new method and the updated method.

There is a lot of work that needs to be done for the unit tests to get them into better shape.
This attempts to only address the necessary or practical changes only.

The `Exception` is being caught when a specific exception, like `RestClientException` should instead be caught.
This behavior is a problem because exceptions other than `RestClientException` that are thrown within are then caught again and then rethrown as a different type.