### PR TITLE
MODWRKFLOW-70: Implement sendEmptyBody support.

### DIFF
--- a/components/src/main/java/org/folio/rest/workflow/dto/Request.java
+++ b/components/src/main/java/org/folio/rest/workflow/dto/Request.java
@@ -26,12 +26,17 @@ public class Request {
 
   private String responseKey;
 
+  @NotNull
+  private Boolean sendEmptyBody;
+
   public Request() {
     super();
-    contentType = MediaType.APPLICATION_JSON_VALUE;
+
     accept = MediaType.APPLICATION_JSON_VALUE;
-    bodyTemplate = "{}";
+    contentType = MediaType.APPLICATION_JSON_VALUE;
+    bodyTemplate = null;
     iterable = false;
+    sendEmptyBody = true;
   }
 
   /**
@@ -91,6 +96,15 @@ public class Request {
   }
 
   /**
+   * Get the sendEmptyBody value.
+   *
+   * @return The sendEmptyBody value.
+   */
+  public Boolean getSendEmptyBody() {
+    return sendEmptyBody;
+  }
+
+  /**
    * @param url the url to set
    */
   public void setUrl(String url) {
@@ -144,6 +158,15 @@ public class Request {
    */
   public void setResponseKey(String responseKey) {
     this.responseKey = responseKey;
+  }
+
+  /**
+   * Set the sendEmptyBody value.
+   *
+   * @param sendEmptyBody the sendEmptyBody to set
+   */
+  public void setSendEmptyBody(Boolean sendEmptyBody) {
+    this.sendEmptyBody = sendEmptyBody;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/EmbeddedRequest.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/EmbeddedRequest.java
@@ -19,7 +19,6 @@ public class EmbeddedRequest implements HasEmbeddedRequestCommon, HasUrl {
   @Column(nullable = true)
   private String accept;
 
-  // Must be designated as nullable even if this is not supposed to be NULL.
   @Column(columnDefinition = "TEXT", nullable = true)
   private String bodyTemplate;
 
@@ -40,6 +39,9 @@ public class EmbeddedRequest implements HasEmbeddedRequestCommon, HasUrl {
 
   private String responseKey;
 
+  @Column(nullable = false)
+  private Boolean sendEmptyBody;
+
   // Must be designated as nullable even if this is not supposed to be NULL.
   @NotNull
   @Column(nullable = true)
@@ -49,10 +51,11 @@ public class EmbeddedRequest implements HasEmbeddedRequestCommon, HasUrl {
     super();
 
     accept = MediaType.APPLICATION_JSON_VALUE;
-    bodyTemplate = "{}";
+    bodyTemplate = null;
     contentType = MediaType.APPLICATION_JSON_VALUE;
     iterable = false;
     method = HttpMethod.GET;
+    sendEmptyBody = true;
     url = "";
   }
 
@@ -62,8 +65,12 @@ public class EmbeddedRequest implements HasEmbeddedRequestCommon, HasUrl {
       accept = MediaType.APPLICATION_JSON_VALUE;
     }
 
-    if (bodyTemplate == null) {
-      bodyTemplate = "{}";
+    if (sendEmptyBody == null) {
+      sendEmptyBody = true;
+    }
+
+    if (bodyTemplate == null || bodyTemplate.isEmpty()) {
+      bodyTemplate = Boolean.TRUE.equals(sendEmptyBody) ? "{}" : null;
     }
 
     if (contentType == null) {
@@ -102,6 +109,11 @@ public class EmbeddedRequest implements HasEmbeddedRequestCommon, HasUrl {
   @Override
   public String getIterableKey() {
     return iterableKey;
+  }
+
+  @Override
+  public Boolean getSendEmptyBody() {
+    return sendEmptyBody;
   }
 
   @Override
@@ -157,6 +169,11 @@ public class EmbeddedRequest implements HasEmbeddedRequestCommon, HasUrl {
   @Override
   public void setUrl(String url) {
     this.url = url;
+  }
+
+  @Override
+  public void setSendEmptyBody(Boolean sendEmptyBody) {
+    this.sendEmptyBody = sendEmptyBody;
   }
 
 }

--- a/components/src/main/java/org/folio/rest/workflow/model/has/common/HasEmbeddedRequestCommon.java
+++ b/components/src/main/java/org/folio/rest/workflow/model/has/common/HasEmbeddedRequestCommon.java
@@ -13,7 +13,8 @@ public interface HasEmbeddedRequestCommon {
   public boolean getIterable();
   public String getIterableKey();
   public HttpMethod getMethod();
-  public String getResponseKey() ;
+  public String getResponseKey();
+  public Boolean getSendEmptyBody();
 
   public void setAccept(String accept);
   public void setBodyTemplate(String bodyTemplate);
@@ -22,5 +23,6 @@ public interface HasEmbeddedRequestCommon {
   public void setIterableKey(String iterableKey);
   public void setMethod(HttpMethod method);
   public void setResponseKey(String responseKey);
+  public void setSendEmptyBody(Boolean sendEmptyBody);
 
 }

--- a/components/src/test/java/org/folio/rest/workflow/dto/RequestTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/dto/RequestTest.java
@@ -11,6 +11,15 @@ import org.springframework.http.HttpMethod;
 
 class RequestTest {
 
+  private static final String ACCEPT        = "accept";
+  private static final String BODYTEMPLATE  = "bodyTemplate";
+  private static final String CONTENTTYPE   = "contentType";
+  private static final String ITERABLE      = "iterable";
+  private static final String METHOD        = "method";
+  private static final String RESPONSEKEY   = "responseKey";
+  private static final String SENDEMPTYBODY = "sendEmptyBody";
+  private static final String URL           = "url";
+
   private Request request;
 
   @BeforeEach
@@ -20,109 +29,128 @@ class RequestTest {
 
   @Test
   void getUrlWorksTest() {
-    setField(request, "url", VALUE);
+    setField(request, URL, VALUE);
 
     assertEquals(VALUE, request.getUrl());
   }
 
   @Test
   void setUrlWorksTest() {
-    setField(request, "url", null);
+    setField(request, URL, null);
 
     request.setUrl(VALUE);
-    assertEquals(VALUE, getField(request, "url"));
+    assertEquals(VALUE, getField(request, URL));
   }
 
   @Test
   void getMethodWorksTest() {
-    setField(request, "method", HttpMethod.DELETE);
+    setField(request, METHOD, HttpMethod.DELETE);
 
     assertEquals(HttpMethod.DELETE, request.getMethod());
   }
 
   @Test
   void setMethodWorksTest() {
-    setField(request, "method", null);
+    setField(request, METHOD, null);
 
     request.setMethod(HttpMethod.DELETE);
-    assertEquals(HttpMethod.DELETE, getField(request, "method"));
+    assertEquals(HttpMethod.DELETE, getField(request, METHOD));
   }
 
   @Test
   void getContentTypeWorksTest() {
-    setField(request, "contentType", VALUE);
+    setField(request, CONTENTTYPE, VALUE);
 
     assertEquals(VALUE, request.getContentType());
   }
 
   @Test
   void setContentTypeWorksTest() {
-    setField(request, "contentType", null);
+    setField(request, CONTENTTYPE, null);
 
     request.setContentType(VALUE);
-    assertEquals(VALUE, getField(request, "contentType"));
+    assertEquals(VALUE, getField(request, CONTENTTYPE));
   }
 
   @Test
   void getAcceptWorksTest() {
-    setField(request, "accept", VALUE);
+    setField(request, ACCEPT, VALUE);
 
     assertEquals(VALUE, request.getAccept());
   }
 
   @Test
   void setAcceptWorksTest() {
-    setField(request, "accept", null);
+    setField(request, ACCEPT, null);
 
     request.setAccept(VALUE);
-    assertEquals(VALUE, getField(request, "accept"));
+    assertEquals(VALUE, getField(request, ACCEPT));
   }
 
   @Test
   void getBodyTemplateWorksTest() {
-    setField(request, "bodyTemplate", VALUE);
+    setField(request, BODYTEMPLATE, VALUE);
 
     assertEquals(VALUE, request.getBodyTemplate());
   }
 
   @Test
   void setBodyTemplateWorksTest() {
-    setField(request, "bodyTemplate", null);
+    setField(request, BODYTEMPLATE, null);
 
     request.setBodyTemplate(VALUE);
-    assertEquals(VALUE, getField(request, "bodyTemplate"));
+    assertEquals(VALUE, getField(request, BODYTEMPLATE));
   }
 
   @Test
   void getIterableWorksTest() {
-    setField(request, "iterable", true);
+    setField(request, ITERABLE, true);
 
     assertEquals(true, request.isIterable());
   }
 
   @Test
   void setIterableWorksTest() {
-    setField(request, "iterable", false);
+    setField(request, ITERABLE, false);
 
     request.setIterable(true);
-    assertEquals(true, getField(request, "iterable"));
+    assertEquals(true, getField(request, ITERABLE));
   }
 
   @Test
   void getResponseKeyWorksTest() {
-    setField(request, "responseKey", VALUE);
+    setField(request, RESPONSEKEY, VALUE);
 
     assertEquals(VALUE, request.getResponseKey());
   }
 
   @Test
   void setResponseKeyWorksTest() {
-    setField(request, "responseKey", null);
+    setField(request, RESPONSEKEY, null);
 
     request.setResponseKey(VALUE);
-    assertEquals(VALUE, getField(request, "responseKey"));
+    assertEquals(VALUE, getField(request, RESPONSEKEY));
   }
 
-  private static class Impl extends Request { };
+  @Test
+  void getSendEmptyBodyWorksTest() {
+    final boolean value = false;
+
+    setField(request, SENDEMPTYBODY, value);
+
+    assertEquals(value, request.getSendEmptyBody());
+  }
+
+  @Test
+  void setSendEmptyBodyWorksTest() {
+    final boolean value = true;
+
+    setField(request, SENDEMPTYBODY, null);
+
+    request.setSendEmptyBody(value);
+    assertEquals(value, getField(request, SENDEMPTYBODY));
+  }
+
+  private static class Impl extends Request { }
 
 }

--- a/components/src/test/java/org/folio/rest/workflow/model/EmbeddedRequestTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/EmbeddedRequestTest.java
@@ -24,14 +24,15 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 class EmbeddedRequestTest {
 
-  private static final String ACCEPT       = "accept";
-  private static final String BODYTEMPLATE = "bodyTemplate";
-  private static final String CONTENTTYPE  = "contentType";
-  private static final String ITERABLE     = "iterable";
-  private static final String ITERABLEKEY  = "iterableKey";
-  private static final String METHOD       = "method";
-  private static final String RESPONSEKEY  = "responseKey";
-  private static final String URL          = "url";
+  private static final String ACCEPT        = "accept";
+  private static final String BODYTEMPLATE  = "bodyTemplate";
+  private static final String CONTENTTYPE   = "contentType";
+  private static final String ITERABLE      = "iterable";
+  private static final String ITERABLEKEY   = "iterableKey";
+  private static final String METHOD        = "method";
+  private static final String RESPONSEKEY   = "responseKey";
+  private static final String SENDEMPTYBODY = "sendEmptyBody";
+  private static final String URL           = "url";
 
   private EmbeddedRequest embeddedRequest;
 
@@ -160,6 +161,25 @@ class EmbeddedRequestTest {
     assertEquals(VALUE, getField(embeddedRequest, RESPONSEKEY));
   }
 
+  @Test
+  void getSendEmptyBodyWorksTest() {
+    final boolean value = false;
+
+    setField(embeddedRequest, SENDEMPTYBODY, value);
+
+    assertEquals(value, embeddedRequest.getSendEmptyBody());
+  }
+
+  @Test
+  void setSendEmptyBodyWorksTest() {
+    final boolean value = true;
+
+    setField(embeddedRequest, SENDEMPTYBODY, null);
+
+    embeddedRequest.setSendEmptyBody(value);
+    assertEquals(value, getField(embeddedRequest, SENDEMPTYBODY));
+  }
+
   @ParameterizedTest
   @MethodSource("providePrePersistFor")
   void prePersistWorksTest(Map<String, Object> initial, Map<String, Object> expected) {
@@ -186,28 +206,32 @@ class EmbeddedRequestTest {
 
     return List.of(
       Arguments.of(
-        helperFieldMap(NULL_STR, NULL_STR,    NULL_STR, null, NULL_STR),
-        helperFieldMap(APP_JSON, JSON_OBJECT, APP_JSON, GET,  "")
+        helperFieldMap(NULL_STR, NULL_STR,    NULL_STR, null, null,  NULL_STR),
+        helperFieldMap(APP_JSON, JSON_OBJECT, APP_JSON, GET,  true,  "")
       ),
       Arguments.of(
-        helperFieldMap(VALUE,    NULL_STR,    NULL_STR, null, NULL_STR),
-        helperFieldMap(VALUE,    JSON_OBJECT, APP_JSON, GET,  "")
+        helperFieldMap(VALUE,    NULL_STR,    NULL_STR, null, null,  NULL_STR),
+        helperFieldMap(VALUE,    JSON_OBJECT, APP_JSON, GET,  true,  "")
       ),
       Arguments.of(
-        helperFieldMap(NULL_STR, VALUE,       NULL_STR, null, NULL_STR),
-        helperFieldMap(APP_JSON, VALUE,       APP_JSON, GET,  "")
+        helperFieldMap(NULL_STR, VALUE,       NULL_STR, null, null,  NULL_STR),
+        helperFieldMap(APP_JSON, VALUE,       APP_JSON, GET,  true,  "")
       ),
       Arguments.of(
-        helperFieldMap(NULL_STR, NULL_STR,    VALUE,    null, NULL_STR),
-        helperFieldMap(APP_JSON, JSON_OBJECT, VALUE,    GET,  "")
+        helperFieldMap(NULL_STR, NULL_STR,    VALUE,    null, null,  NULL_STR),
+        helperFieldMap(APP_JSON, JSON_OBJECT, VALUE,    GET,  true,  "")
       ),
       Arguments.of(
-        helperFieldMap(NULL_STR, NULL_STR,    NULL_STR, POST, NULL_STR),
-        helperFieldMap(APP_JSON, JSON_OBJECT, APP_JSON, POST, "")
+        helperFieldMap(NULL_STR, NULL_STR,    NULL_STR, POST, null,  NULL_STR),
+        helperFieldMap(APP_JSON, JSON_OBJECT, APP_JSON, POST, true,  "")
       ),
       Arguments.of(
-        helperFieldMap(NULL_STR, NULL_STR,    NULL_STR, null, VALUE),
-        helperFieldMap(APP_JSON, JSON_OBJECT, APP_JSON, GET,  VALUE)
+        helperFieldMap(NULL_STR, NULL_STR,    NULL_STR, POST, false, NULL_STR),
+        helperFieldMap(APP_JSON, NULL_STR,    APP_JSON, POST, false, "")
+      ),
+      Arguments.of(
+        helperFieldMap(NULL_STR, NULL_STR,    NULL_STR, null, null,  VALUE),
+        helperFieldMap(APP_JSON, JSON_OBJECT, APP_JSON, GET,  true,  VALUE)
       )
     ).stream();
   }
@@ -215,21 +239,23 @@ class EmbeddedRequestTest {
   /**
    * Helper for reducing in line code repetition for assignments.
    *
-   * @param accept The accept value.
-   * @param bodyTemplate The bodyTemplate value.
-   * @param contentType The contentType value.
-   * @param method The method value.
-   * @param url The url value.
+   * @param accept        The accept value.
+   * @param bodyTemplate  The bodyTemplate value.
+   * @param contentType   The contentType value.
+   * @param method        The method value.
+   * @param sendEmptyBody The sendEmptyBody value.
+   * @param url           The url value.
    *
    * @return The built arguments map.
    */
-  private static Map<String, Object> helperFieldMap(String accept, String bodyTemplate, String contentType, HttpMethod method, String url) {
+  private static Map<String, Object> helperFieldMap(String accept, String bodyTemplate, String contentType, HttpMethod method, Boolean sendEmptyBody, String url) {
     final Map<String, Object> map = new HashMap<>();
 
     map.put(ACCEPT, accept);
     map.put(BODYTEMPLATE, bodyTemplate);
     map.put(CONTENTTYPE, contentType);
     map.put(METHOD, method);
+    map.put(SENDEMPTYBODY, sendEmptyBody);
     map.put(URL, url);
 
     return map;

--- a/components/src/test/java/org/folio/rest/workflow/model/EndEventTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/EndEventTest.java
@@ -82,6 +82,6 @@ class EndEventTest {
     assertEquals(VALUE, getField(endEvent, DESERIALIZEAS));
   }
 
-  private static class Impl extends EndEvent { };
+  private static class Impl extends EndEvent { }
 
 }

--- a/components/src/test/java/org/folio/rest/workflow/model/RequestTaskTest.java
+++ b/components/src/test/java/org/folio/rest/workflow/model/RequestTaskTest.java
@@ -238,6 +238,20 @@ class RequestTaskTest {
     });
   }
 
+  @ParameterizedTest
+  @MethodSource("provideSendEmptyBodyFor")
+  void prePersistSendEmptyBodyWorksTest(final Boolean sendEmptyBody, final String bodyTemplate, final String expected) {
+
+    final EmbeddedRequest er = new EmbeddedRequest();
+
+    setField(er, "sendEmptyBody", sendEmptyBody);
+    setField(er, "bodyTemplate", bodyTemplate);
+
+    er.prePersist();
+
+    assertEquals(expected, getField(er, "bodyTemplate"));
+  }
+
   /**
    * Helper function for parameterized tests for the prePersist function.
    *
@@ -278,6 +292,27 @@ class RequestTaskTest {
         helperFieldMap(headerOutputVariables),
         helperPersistMap(true)
       )
+    ).stream();
+  }
+
+  /**
+   * Helper function for parameterized tests for the prePersist function.
+   *
+   * @return
+   *   The arguments array stream with the stream columns as:
+   *     - Arguments sendEmptyBody The initial sendEmptyBody value.
+   *     - Arguments bodyTemplate The initial bodyTemplate value.
+   *     - Arguments expect The expected bodyTemplate value.
+   */
+  private static Stream<Arguments> provideSendEmptyBodyFor() {
+
+    return List.of(
+      Arguments.of(true,  null,  "{}"),
+      Arguments.of(true,  "",    "{}"),
+      Arguments.of(false, null,  null),
+      Arguments.of(false, "",    null),
+      Arguments.of(true,  VALUE, VALUE),
+      Arguments.of(false, VALUE, VALUE)
     ).stream();
   }
 

--- a/service/src/main/java/org/folio/rest/workflow/controller/EventController.java
+++ b/service/src/main/java/org/folio/rest/workflow/controller/EventController.java
@@ -108,9 +108,7 @@ public class EventController {
       .stream()
       .filter(name -> !name.equals("file"))
       .filter(name -> !name.equals("path"))
-      .forEach(name -> {
-        body.put(name, request.getParameter(name));
-      });
+      .forEach(name -> body.put(name, request.getParameter(name)));
 
     try (InputStream is = multipartFile.getInputStream()) {
       Files.copy(is, filePath, StandardCopyOption.REPLACE_EXISTING);

--- a/service/src/test/java/org/folio/rest/workflow/dto/TriggerDtoTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/dto/TriggerDtoTest.java
@@ -94,6 +94,6 @@ class TriggerDtoTest {
     assertEquals(VALUE, getField(triggerDto, "pathPattern"));
   }
 
-  private static class Impl extends Trigger implements TriggerDto { };
+  private static class Impl extends Trigger implements TriggerDto { }
 
 }


### PR DESCRIPTION
Resolves [MODWRKFLOW-70](https://folio-org.atlassian.net/browse/MODWRKFLOW-70) .

Provide `sendEmptyBody` in such a way that existing behavior is preserved when `sendEmptyBody` is not defined.

When `sendEmptyBody` is TRUE, then the default value for the `bodyTemplate` must be `{}`.
When `sendEmptyBody` is FALSE, then the default value for the `bodyTemplate` must be NULL.

Any non-null, non-empty, value in `bodyTemplate` should not be affected. The `sendEmptyBody` may be NULL to allow for this.

The default behavior is set to TRUE to preserve the existing behavior.

The `prePersists()` handles this logic so that the normal class instantiation can operate more practically. Setting the `bodyTemplate` to non-NULL in the initializer could cause problems (doing so in the `prePersists()` is safe).

The `sendEmptyBody` is allowed to be NULL during `prePersist()`, but must not be NULL in the database.

This also requires changes to `mod-camunda`.