### PR TITLE
MODWRKFLOW-73: Fix transactional based problems.

### DIFF
--- a/service/src/main/java/org/folio/rest/workflow/service/DeleteService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/DeleteService.java
@@ -23,7 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
  * Each entity, etc.., must be found and explicitly deleted.
  */
 @Service
-@Transactional
+@Transactional(rollbackFor = Exception.class)
 public class DeleteService {
 
   private static final Logger LOG = LoggerFactory.getLogger(DeleteService.class);

--- a/service/src/main/java/org/folio/rest/workflow/service/DeleteService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/DeleteService.java
@@ -145,6 +145,10 @@ public class DeleteService {
       .setParameter("id", id)
       .executeUpdate();
 
+    if (total > 0) {
+      entityManager.clear();
+    }
+
     LOG.debug("Deleted '{}' entities for entityName '{}' with id '{}'.", total, entityName, id);
   }
 

--- a/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
@@ -96,7 +96,7 @@ public class WorkflowEngineService {
    *
    * @throws WorkflowEngineServiceException When the request fails in some way preventing the return of an HttpEntity.
    */
-  @Transactional
+  @Transactional(rollbackFor = Exception.class)
   public void delete(String workflowId, String tenant, String token)
       throws WorkflowEngineServiceException {
 

--- a/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
+++ b/service/src/main/java/org/folio/rest/workflow/service/WorkflowEngineService.java
@@ -21,6 +21,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import tools.jackson.databind.JsonNode;
@@ -95,6 +96,7 @@ public class WorkflowEngineService {
    *
    * @throws WorkflowEngineServiceException When the request fails in some way preventing the return of an HttpEntity.
    */
+  @Transactional
   public void delete(String workflowId, String tenant, String token)
       throws WorkflowEngineServiceException {
 

--- a/service/src/test/java/org/folio/rest/workflow/service/DeleteServiceTest.java
+++ b/service/src/test/java/org/folio/rest/workflow/service/DeleteServiceTest.java
@@ -143,6 +143,24 @@ class DeleteServiceTest {
   }
 
   @Test
+  void deleteNodesForSimpleWithNoDeletionsTest() {
+
+    nodes.add(startEvent);
+
+    when(entityManager.createQuery(anyString())).thenReturn(typedQuery);
+
+    when(typedQuery.setParameter(anyString(), anyString())).thenAnswer(invocation -> {
+      return typedQuery;
+    });
+
+    when(typedQuery.executeUpdate()).thenReturn(0);
+
+    deleteService.deleteNodes(workflowOperationalNode);
+
+    verify(typedQuery).executeUpdate();
+  }
+
+  @Test
   void deleteNodesForNodeWithoutChildrenTest() {
 
     final List<Object[]> results = new ArrayList<>();


### PR DESCRIPTION
[MODWRKFLOW-73](https://folio-org.atlassian.net/browse/MODWRKFLOW-73)

Back porting this to the **Spring Boot 3** revealed some problems that were not immediately obvious. The basic testing showed no problems with the current code. However, extensive testing based on observations in **Spring Boot 3** has revealed problems under **Spring Boot 4**.

The `DeleteService` has transactional, but the `workflowRepo.deleteById()` does not fall into scope with this. Add `@Transactional` to the `WorkflowEngineService.delete()` function.

Ensure that the entity cache is cleared after every delete operation.

Explicitly specify transactional rollback behavior.

I was not aware that checked expressions are not handled on rollback.
This seems counter-intuitive.

The `java:S8989` thankfully reported this for me.
Explicitly have it rollback on any exception, period.
This ensures that the transaction operates as one would expect it would by default.

I would note that **SonarQube** does not report this for the class level annotation.
I added this to the class level annotation, regardless.
